### PR TITLE
clang_git.bb: Add dep on clang-native to clang

### DIFF
--- a/recipes-devtools/clang/clang_git.bb
+++ b/recipes-devtools/clang/clang_git.bb
@@ -87,6 +87,7 @@ EXTRA_OEMAKE += "REQUIRES_RTTI=1 VERBOSE=1"
 DEPENDS = "zlib libffi libxml2 binutils"
 DEPENDS_remove_class-nativesdk = "nativesdk-binutils"
 DEPENDS_append_class-nativesdk = " clang-native "
+DEPENDS_append_class-target = " clang-native "
 
 do_configure_prepend() {
 	# Remove RPATHs


### PR DESCRIPTION
Otherwise llvm-tblgen cannot be found if clang happens
to be built before clang-native.

Signed-off-by: Dmitry Rozhkov <dmitry.rozhkov@linux.intel.com>