### PR TITLE
clang: set target DEPENDS for gcc TOOLCHAIN

### DIFF
--- a/recipes-devtools/clang/clang_git.bb
+++ b/recipes-devtools/clang/clang_git.bb
@@ -88,7 +88,7 @@ EXTRA_OEMAKE += "REQUIRES_RTTI=1 VERBOSE=1"
 DEPENDS = "zlib libffi libxml2 binutils"
 DEPENDS_remove_class-nativesdk = "nativesdk-binutils"
 DEPENDS_append_class-nativesdk = " clang-native virtual/${TARGET_PREFIX}binutils-crosssdk virtual/${TARGET_PREFIX}gcc-crosssdk virtual/${TARGET_PREFIX}g++-crosssdk"
-DEPENDS_append_class-target = " clang-cross-${TARGET_ARCH} "
+DEPENDS_append_class-target = " clang-cross-${TARGET_ARCH} ${@bb.utils.contains('TOOLCHAIN', 'gcc', 'virtual/${TARGET_PREFIX}gcc virtual/${TARGET_PREFIX}g++', '', d)}"
 
 do_configure_prepend() {
 	# Remove RPATHs


### PR DESCRIPTION
With the layer defaults (TOOLCHAIN ??= gcc) clang for target fails
to build due to missing compilers in the native (recipe specific)
sysroot.

Set the necessary additional DEPENDS if TOOLCHAIN = gcc to get the
compilers installed.

Signed-off-by: Mikko Ylinen <mikko.ylinen@linux.intel.com>