### PR TITLE
llvm config fixes

### DIFF
--- a/recipes-devtools/clang/clang.inc
+++ b/recipes-devtools/clang/clang.inc
@@ -7,8 +7,10 @@ LLVM_GIT_PROTOCOL ?= "git"
 #
 # Uncomment below to enable master version of clang/llvm
 #
-BASEPV = "4.0.0"
-PV = "${BASEPV}"
+MAJOR_VER="4"
+MINOR_VER="0"
+PATCH_VER="0"
+PV = "${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}"
 BRANCH = "release_40"
 SRCREV_llvm = "4423e351176a92975739dd4ea43c2ff5877236ae"
 SRCREV_clang = "559aa046fe3260d8640791f2249d7b0d458b5700"

--- a/recipes-devtools/clang/clang/0004-llvm-allow-env-override-of-exe-path.patch
+++ b/recipes-devtools/clang/clang/0004-llvm-allow-env-override-of-exe-path.patch
@@ -1,0 +1,36 @@
+From 60eb14f995e0359aef4ef144338d932cbf9c4531 Mon Sep 17 00:00:00 2001
+From: Martin Kelly <mkelly@xevo.com>
+Date: Wed, 15 Mar 2017 10:50:25 -0700
+Subject: [PATCH] allow env override of exe path
+
+When using a native llvm-config from inside a sysroot, we need llvm-config to
+return the libraries, include directories, etc. from inside the sysroot rather
+than from the native sysroot. Thus provide an env override for calling
+llvm-config from a target sysroot.
+
+Signed-off-by: Martin Kelly <mkelly@xevo.com>
+---
+ tools/llvm-config/llvm-config.cpp | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/tools/llvm-config/llvm-config.cpp b/tools/llvm-config/llvm-config.cpp
+index 25344e4..26724c1 100644
+--- a/tools/llvm-config/llvm-config.cpp
++++ b/tools/llvm-config/llvm-config.cpp
+@@ -225,6 +225,13 @@ Typical components:\n\
+ 
+ /// \brief Compute the path to the main executable.
+ std::string GetExecutablePath(const char *Argv0) {
++  // Hack for Yocto: we need to override the root path when we are using
++  // llvm-config from within a target sysroot.
++  const char *Sysroot = std::getenv("YOCTO_ALTERNATE_EXE_PATH");
++  if (Sysroot != nullptr) {
++    return Sysroot;
++  }
++
+   // This just needs to be some symbol in the binary; C++ doesn't
+   // allow taking the address of ::main however.
+   void *P = (void *)(intptr_t)GetExecutablePath;
+-- 
+2.1.4
+

--- a/recipes-devtools/clang/clang_git.bb
+++ b/recipes-devtools/clang/clang_git.bb
@@ -22,6 +22,7 @@ SRC_URI += "\
            file://0001-llvm-Remove-CMAKE_CROSSCOMPILING-so-it-can-cross-com.patch \
            file://0002-llvm-Do-not-assume-linux-glibc.patch \
            file://0003-llvm-TargetLibraryInfo-Undefine-libc-functions-if-th.patch \
+           file://0004-llvm-allow-env-override-of-exe-path.patch \
           "
 
 # Clang patches
@@ -95,12 +96,6 @@ DEPENDS = "zlib libffi libxml2 binutils"
 DEPENDS_remove_class-nativesdk = "nativesdk-binutils nativesdk-compiler-rt nativesdk-libcxx nativesdk-llvm-unwind"
 DEPENDS_append_class-nativesdk = " clang-native virtual/${TARGET_PREFIX}binutils-crosssdk virtual/${TARGET_PREFIX}gcc-crosssdk virtual/${TARGET_PREFIX}g++-crosssdk"
 DEPENDS_append_class-target = " clang-cross-${TARGET_ARCH} ${@bb.utils.contains('TOOLCHAIN', 'gcc', 'virtual/${TARGET_PREFIX}gcc virtual/${TARGET_PREFIX}g++', '', d)}"
-
-do_configure_prepend() {
-	# Fix paths in llvm-config
-	sed -i "s|sys::path::parent_path(CurrentPath))\.str()|sys::path::parent_path(sys::path::parent_path(CurrentPath))).str()|g" ${S}/tools/llvm-config/llvm-config.cpp
-	sed -ri "s#/(bin|include|lib)(/?\")#/\1/${LLVM_DIR}\2#g" ${S}/tools/llvm-config/llvm-config.cpp
-}
 
 do_compile_prepend_class-native () {
 	oe_runmake LLVM-tablegen-host

--- a/recipes-devtools/clang/clang_git.bb
+++ b/recipes-devtools/clang/clang_git.bb
@@ -75,8 +75,8 @@ EXTRA_OECMAKE="-DLLVM_ENABLE_RTTI=True \
                -DLLVM_ENABLE_FFI=False \
                -DCMAKE_SYSTEM_NAME=Linux \
                -DCMAKE_BUILD_TYPE=Release \
-	       -DLLVM_BUILD_EXTERNAL_COMPILER_RT=True \
-	      "
+               -DLLVM_BUILD_EXTERNAL_COMPILER_RT=True \
+"
 
 EXTRA_OECMAKE_append_class-native = "\
                -DLLVM_TARGETS_TO_BUILD='AArch64;ARM;Mips;PowerPC;X86' \

--- a/recipes-devtools/clang/clang_git.bb
+++ b/recipes-devtools/clang/clang_git.bb
@@ -83,7 +83,8 @@ EXTRA_OECMAKE_append_class-nativesdk = "\
 "
 EXTRA_OECMAKE_append_class-target = "\
                -DBUILD_SHARED_LIBS=OFF \
-               -DLLVM_ENABLE_PIC=OFF \
+               -DLLVM_BUILD_LLVM_DYLIB=ON \
+               -DLLVM_ENABLE_PIC=ON \
                -DLLVM_TABLEGEN=${STAGING_BINDIR_NATIVE}/llvm-tblgen \
                -DCLANG_TABLEGEN=${STAGING_BINDIR_NATIVE}/clang-tblgen \
                -DLLVM_TARGETS_TO_BUILD=${@get_clang_target_arch(bb, d)} \
@@ -121,12 +122,18 @@ do_install_append_class-nativesdk () {
 
 PACKAGE_DEBUG_SPLIT_STYLE_class-nativesdk = "debug-without-src"
 
+PACKAGES =+ "${PN}-libllvm"
+
 BBCLASSEXTEND = "native nativesdk"
 
 FILES_${PN} += "\
   ${libdir}/BugpointPasses.so \
   ${libdir}/LLVMHello.so \
   ${datadir}/scan-* \
+"
+
+FILES_${PN}-libllvm += "\
+  ${libdir}/libLLVM-${MAJOR_VER}.${MINOR_VER}.so \
 "
 
 FILES_${PN}-dev += "\

--- a/recipes-devtools/clang/clang_git.bb
+++ b/recipes-devtools/clang/clang_git.bb
@@ -59,12 +59,6 @@ def get_clang_target_arch(bb, d):
         return clang_arches[target_arch]
     return ""
 
-#TUNE_CCARGS_remove = "-mthumb-interwork"
-#TUNE_CCARGS_remove = "-march=armv7-a"
-#TUNE_CCARGS_remove = "-marm"
-#TUNE_CCARGS_append_class-target = " -D__extern_always_inline=inline -I${PKG_CONFIG_SYSROOT_DIR}${includedir}/libxml2 "
-#LDFLAGS_append_class-target = " -L${PKG_CONFIG_SYSROOT_DIR}${libdir}/libxml2 "
-
 PACKAGECONFIG ??= "compiler-rt libcplusplus"
 PACKAGECONFIG_class-native = ""
 
@@ -95,10 +89,6 @@ EXTRA_OECMAKE_append_class-target = "\
                -DLLVM_TARGET_ARCH=${@get_clang_target_arch(bb, d)} \
                -DLLVM_DEFAULT_TARGET_TRIPLE=${TARGET_SYS} \
 "
-#               -DCMAKE_CXX_FLAGS='-target armv7a -ccc-gcc-name ${HOST_PREFIX}g++ ${HOST_CC_ARCH}${TOOLCHAIN_OPTIONS} -v -I ${PKG_CONFIG_SYSROOT_DIR}${includedir}/c++/5.1.0 -I ${PKG_CONFIG_SYSROOT_DIR}${includedir}/c++/5.1.0/arm-rdk-linux-gnueabi' \
-#               -DCMAKE_C_FLAGS='-target armv7a -ccc-gcc-name ${HOST_PREFIX}gcc ${HOST_CC_ARCH}${TOOLCHAIN_OPTIONS} -v -I ${PKG_CONFIG_SYSROOT_DIR}${includedir}/c++/5.1.0 -I ${PKG_CONFIG_SYSROOT_DIR}${includedir}/c++/5.1.0/arm-rdk-linux-gnueabi' \
-#
-#
 EXTRA_OEMAKE += "REQUIRES_RTTI=1 VERBOSE=1"
 
 DEPENDS = "zlib libffi libxml2 binutils"
@@ -107,11 +97,6 @@ DEPENDS_append_class-nativesdk = " clang-native virtual/${TARGET_PREFIX}binutils
 DEPENDS_append_class-target = " clang-cross-${TARGET_ARCH} ${@bb.utils.contains('TOOLCHAIN', 'gcc', 'virtual/${TARGET_PREFIX}gcc virtual/${TARGET_PREFIX}g++', '', d)}"
 
 do_configure_prepend() {
-	# Remove RPATHs
-#	sed -i 's:$(RPATH) -Wl,$(\(ToolDir\|LibDir\|ExmplDir\))::g' ${S}/Makefile.rules
-	# Drop "svn" suffix from version string
-#	sed -i 's/${PV}svn/${PV}/g' ${S}/configure
-
 	# Fix paths in llvm-config
 	sed -i "s|sys::path::parent_path(CurrentPath))\.str()|sys::path::parent_path(sys::path::parent_path(CurrentPath))).str()|g" ${S}/tools/llvm-config/llvm-config.cpp
 	sed -ri "s#/(bin|include|lib)(/?\")#/\1/${LLVM_DIR}\2#g" ${S}/tools/llvm-config/llvm-config.cpp

--- a/recipes-devtools/clang/compiler-rt_git.bb
+++ b/recipes-devtools/clang/compiler-rt_git.bb
@@ -48,23 +48,23 @@ EXTRA_OECMAKE_append_class-nativesdk = "\
 EXTRA_OECMAKE_append_libc-musl = " -DCOMPILER_RT_BUILD_SANITIZERS=OFF -DCOMPILER_RT_BUILD_XRAY=OFF "
 
 do_install_append () {
-	install -d ${D}${libdir}/clang/${BASEPV}/lib/linux
+	install -d ${D}${libdir}/clang/${PV}/lib/linux
 	if [ -d ${D}${libdir}/linux ]; then
 		for f in `find ${D}${libdir}/linux -maxdepth 1 -type f`
 		do
-			mv $f ${D}${libdir}/clang/${BASEPV}/lib/linux
+			mv $f ${D}${libdir}/clang/${PV}/lib/linux
 		done
 		rmdir ${D}${libdir}/linux
 	fi
 	for f in `find ${D}${exec_prefix} -maxdepth 1 -name '*.txt' -type f`
 	do
-		mv $f ${D}${libdir}/clang/${BASEPV}
+		mv $f ${D}${libdir}/clang/${PV}
 	done
 }
 
 FILES_SOLIBSDEV = ""
-FILES_${PN} += "${libdir}/clang/${BASEPV}/lib/linux/lib*${SOLIBSDEV} ${libdir}/clang/${BASEPV}/*.txt"
-FILES_${PN}-staticdev += "${libdir}/clang/${BASEPV}/lib/linux/*.a"
+FILES_${PN} += "${libdir}/clang/${PV}/lib/linux/lib*${SOLIBSDEV} ${libdir}/clang/${PV}/*.txt"
+FILES_${PN}-staticdev += "${libdir}/clang/${PV}/lib/linux/*.a"
 INSANE_SKIP_${PN} = "dev-so"
 
 #PROVIDES_append_class-target = "\
@@ -76,7 +76,7 @@ INSANE_SKIP_${PN} = "dev-so"
 #        "
 #
 
-FILES_${PN}-dev += "${libdir}/clang/${BASEPV}/lib/linux/*.syms"
+FILES_${PN}-dev += "${libdir}/clang/${PV}/lib/linux/*.syms"
 
 BBCLASSEXTEND = "native nativesdk"
 

--- a/recipes-devtools/clang/llvm-common/llvm-config
+++ b/recipes-devtools/clang/llvm-common/llvm-config
@@ -1,10 +1,35 @@
-#!/bin/sh
-# Wrapper script for real llvm-config. Simply calls
+#!/bin/bash
+#
+# Wrapper script for llvm-config. Supplies the right environment variables
+# for the target and delegates to the native llvm-config for anything else. This
+# is needed because arguments like --ldflags, --cxxflags, etc. are set by the
+# native compile rather than the target compile.
+#
 
-if [ $WANT_LLVM_RELEASE ]; then
-	exec `dirname $0`/${TARGET_PREFIX}llvm-config$WANT_LLVM_RELEASE ${@}
-else
-  echo "The variable WANT_LLVM_RELEASE is not defined and exported"
-	echo "by your build recipe. Go figure."
-  exit 1
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+NEXT_LLVM_CONFIG="$(which -a llvm-config | sed -n 2p)"
+export YOCTO_ALTERNATE_EXE_PATH="$(readlink -f "$SCRIPT_DIR/../llvm-config")"
+
+if [[ $# == 0 ]]; then
+  exec "$NEXT_LLVM_CONFIG"
 fi
+
+for arg in "$@"; do
+  case "$arg" in
+    --cppflags)
+      echo $TARGET_CPPFLAGS
+      ;;
+    --cflags)
+      echo $TARGET_CFLAGS
+      ;;
+    --cxxflags)
+      echo $TARGET_CXXFLAGS
+      ;;
+    --ldflags)
+      echo $TARGET_LDFLAGS
+      ;;
+    *)
+      echo "$("$NEXT_LLVM_CONFIG" "$arg")"
+      ;;
+  esac
+done


### PR DESCRIPTION
Hi,

This patch series fixes a number of issues I hit when trying to use the
meta-clang llvm-config to cross-compile a project that uses CMake, calling
into llvm-config, to determine compile flags. With the series applied, the
cross compile successfully builds and runs. Please let me know if you have
any concerns or if there is something I missed, and I will fix it up.