### PR TITLE
Remove binutils from DEPENDS

### DIFF
--- a/recipes-devtools/clang/clang_git.bb
+++ b/recipes-devtools/clang/clang_git.bb
@@ -105,10 +105,12 @@ EXTRA_OECMAKE_append_class-target = "\
 "
 EXTRA_OEMAKE += "REQUIRES_RTTI=1 VERBOSE=1"
 
-DEPENDS = "zlib libffi libxml2 binutils"
+DEPENDS = "zlib libffi libxml2"
 DEPENDS_remove_class-nativesdk = "nativesdk-binutils nativesdk-compiler-rt nativesdk-libcxx nativesdk-llvm-unwind"
 DEPENDS_append_class-nativesdk = " clang-native virtual/${TARGET_PREFIX}binutils-crosssdk virtual/${TARGET_PREFIX}gcc-crosssdk virtual/${TARGET_PREFIX}g++-crosssdk"
 DEPENDS_append_class-target = " clang-cross-${TARGET_ARCH} ${@bb.utils.contains('TOOLCHAIN', 'gcc', 'virtual/${TARGET_PREFIX}gcc virtual/${TARGET_PREFIX}g++', '', d)}"
+
+RRECOMMENDS_${PN} = "binutils"
 
 do_compile_prepend_class-native () {
 	oe_runmake LLVM-tablegen-host


### PR DESCRIPTION
`binutils` is not needed during compile time. Add it instead to `RRECOMMENDS_clang`.
