### PR TITLE
clang: Add missing FILE

### DIFF
--- a/recipes-devtools/clang/clang_git.bb
+++ b/recipes-devtools/clang/clang_git.bb
@@ -127,6 +127,7 @@ FILES_${PN} += "\
   ${libdir}/BugpointPasses.so \
   ${libdir}/LLVMHello.so \
   ${datadir}/scan-* \
+  ${datadir}/opt-viewer/ \
 "
 
 FILES_${PN}-libllvm += "\


### PR DESCRIPTION
Fixes:

ERROR: clang-5.0.0+gitAUTOINC+f65227fd46_2ce35b601d-r0 do_package: QA Issue: clang: Files/directories were installed but not shipped in any package:
  /usr/share/opt-viewer
  /usr/share/opt-viewer/optrecord.py
  /usr/share/opt-viewer/opt-viewer.py
  /usr/share/opt-viewer/opt-stats.py
  /usr/share/opt-viewer/optpmap.py
  /usr/share/opt-viewer/opt-diff.py
  /usr/share/opt-viewer/style.css
Please set FILES such that these items are packaged. Alternatively if they are unneeded, avoid installing them or delete them within do_install.

Signed-off-by: Ricardo Ribalda Delgado <ricardo.ribalda@gmail.com>