### PR TITLE
Add settings to build with libcxx as default C++ standard library

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,22 @@ you can select clang per package too by writing bbappends for them containing
 TOOLCHAIN = "clang"
 ```
 
+# Default C++ Standard Library Switch
+
+Note that by default libstdc++ will remain the default C++ standard library, however if you wish
+libc++ to be the default one then set
+
+```python
+TARGET_CXXFLAGS_append_toolchain-clang ?= " -stdlib=libc++ "
+```
+
+in local.conf.
+You can select libc++ per package too by writing bbappends for them containing
+
+```python
+TARGET_CXXFLAGS_append_toolchain-clang = " -stdlib=libc++ "
+```
+
 # Building
 
 Below we build for qemuarm machine as an example
@@ -61,7 +77,13 @@ simply add it to conf/nonclangable.inc e.g.
 TOOLCHAIN_pn-<recipe> = "gcc"
 ```
 
-and OE will start using gcc to cross compile that recipe,
+and OE will start using gcc to cross compile that recipe.
+
+And if a component does not build with libc++, you can add it to conf/nonclangable.inc e.g.
+
+```shell
+TARGET_CXXFLAGS_remove_pn-<recipe>_toolchain-clang = " -stdlib=libc++ "
+```
 
 # Dependencies
 

--- a/recipes-devtools/clang/compiler-rt_git.bb
+++ b/recipes-devtools/clang/compiler-rt_git.bb
@@ -27,6 +27,7 @@ SRCREV_FORMAT = "compiler-rt"
 
 BASEDEPENDS_remove_toolchain-clang_class-target = "compiler-rt"
 BASEDEPENDS_remove_toolchain-clang_class-target = "libcxx"
+TARGET_CXXFLAGS_remove_toolchain-clang = " -stdlib=libc++ "
 
 DEPENDS += "ninja-native"
 

--- a/recipes-devtools/clang/libcxx_git.bb
+++ b/recipes-devtools/clang/libcxx_git.bb
@@ -58,7 +58,7 @@ EXTRA_OECMAKE_append_libc-musl = " -DLIBCXX_HAS_MUSL_LIBC=ON "
 COMPILE_TARGETS ?= "unwind cxxabi"
 COMPILE_TARGETS_mipsarch = "cxxabi"
 
-INSTALL_TARGETS ?= "projects/libunwind/install install-cxxabi"
+INSTALL_TARGETS ?= "install-unwind install-cxxabi"
 INSTALL_TARGETS_mipsarch = "install-cxxabi"
 
 do_compile() {

--- a/recipes-devtools/clang/libcxx_git.bb
+++ b/recipes-devtools/clang/libcxx_git.bb
@@ -14,6 +14,7 @@ PV .= "+git${SRCPV}"
 
 DEPENDS += "ninja-native"
 BASEDEPENDS_remove_toolchain-clang_class-target = "libcxx"
+TARGET_CXXFLAGS_remove_toolchain-clang = " -stdlib=libc++ "
 
 PROVIDES = "libunwind"
 PROVIDES_remove_mipsarch = "libunwind"


### PR DESCRIPTION
As suggested by Khem in https://github.com/kraj/meta-clang/issues/49.