### PR TITLE
[morty] clang: enable support for BPF target

### DIFF
--- a/recipes-devtools/clang/clang_git.bb
+++ b/recipes-devtools/clang/clang_git.bb
@@ -67,10 +67,10 @@ EXTRA_OECMAKE="-DLLVM_ENABLE_RTTI=True \
 	      "
 
 EXTRA_OECMAKE_append_class-native = "\
-               -DLLVM_TARGETS_TO_BUILD='AArch64;ARM;Mips;PowerPC;X86' \
+               -DLLVM_TARGETS_TO_BUILD='AArch64;ARM;BPF;Mips;PowerPC;X86' \
 "
 EXTRA_OECMAKE_append_class-nativesdk = "\
-               -DLLVM_TARGETS_TO_BUILD='AArch64;ARM;Mips;PowerPC;X86' \
+               -DLLVM_TARGETS_TO_BUILD='AArch64;ARM;BPF;Mips;PowerPC;X86' \
                -DLLVM_TABLEGEN=${STAGING_BINDIR_NATIVE}/llvm-tblgen \
                -DCLANG_TABLEGEN=${STAGING_BINDIR_NATIVE}/clang-tblgen \
 "


### PR DESCRIPTION
Only Morty is different -- Pyro and Rocko can use the same commit from master.