### PR TITLE
clang: Fix sigsegv of llvm-config on the target

### DIFF
--- a/recipes-devtools/clang/clang_git.bb
+++ b/recipes-devtools/clang/clang_git.bb
@@ -159,3 +159,6 @@ FILES_${PN}-dev += "\
 
 INSANE_SKIP_${PN} += "already-stripped"
 INSANE_SKIP_${PN}-dev += "dev-elf"
+
+#Avoid SSTATE_SCAN_COMMAND running sed over llvm-config.
+SSTATE_SCAN_FILES_remove = "*-config"


### PR DESCRIPTION
llvm-config is, by default, broken by the SSTATE_SCAN_CMD. This patch
removes llvm-config from SSTATE_SCAN_FILES.

Signed-off-by: Ricardo Ribalda Delgado <ricardo.ribalda@gmail.com>