### PR TITLE
compiler-rt: Fix unintended dependencies concatenation

### DIFF
--- a/recipes-devtools/clang/compiler-rt_git.bb
+++ b/recipes-devtools/clang/compiler-rt_git.bb
@@ -20,7 +20,7 @@ BASEDEPENDS_remove_toolchain-clang_class-target = "libcxx"
 TARGET_CXXFLAGS_remove_toolchain-clang = " -stdlib=libc++ "
 TUNE_CCARGS_remove = "-no-integrated-as"
 DEPENDS += "ninja-native"
-DEPENDS_append_class-nativesdk = "clang-native"
+DEPENDS_append_class-nativesdk = " clang-native"
 
 THUMB_TUNE_CCARGS = ""
 #TUNE_CCARGS += "-nostdlib"


### PR DESCRIPTION
The error message was:
>>  Nothing PROVIDES 'ninja-nativeclang-native' (but virtual:nativesdk:/media/storage/romanek-adam/build-2018-12-17-clang/workspace/meta-clang/recipes-devtools/clang/compiler-rt_git.bb DEPENDS on or otherwise requires it)