### PR TITLE
clang: Fix binaries built for x86_64 native target (bad interpreter)

### DIFF
--- a/recipes-devtools/clang/common.inc
+++ b/recipes-devtools/clang/common.inc
@@ -28,7 +28,6 @@ GCCPIE ??= ""
 
 # Clang patches
 CLANGPATCHES = "\
-    file://0001-clang-driver-Use-lib-for-ldso-on-OE.patch;patchdir=clang \
     file://0002-clang-Driver-tools.cpp-Add-lssp_nonshared-on-musl.patch;patchdir=clang \
     file://0003-clang-musl-ppc-does-not-support-128-bit-long-double.patch;patchdir=clang \
     file://0004-clang-Prepend-trailing-to-sysroot.patch;patchdir=clang \


### PR DESCRIPTION
Assuming the native platform is x86_64 the binaries built by Clang from
clang-native package were properly compiled and linked but could not be
run, e.g.:

> bash: test: No such file or directory

The reason for that was the interpreter set by Clang in the .interp
section of the ELF binary. It was set to /lib/ld-linux-x86-64.so.2
whereas it should be set to /lib64/ld-linux-x86-64.so.2.

This change removes a patch which messes this up.