### PR TITLE
Switch to canonical git mirror

### DIFF
--- a/recipes-devtools/clang/clang.inc
+++ b/recipes-devtools/clang/clang.inc
@@ -1,17 +1,17 @@
 LLVM_RELEASE = ""
 LLVM_DIR = "llvm${LLVM_RELEASE}"
 
-LLVM_GIT ?= "git://github.com/llvm-project"
+LLVM_GIT ?= "git://github.com/llvm"
 LLVM_GIT_PROTOCOL ?= "https"
 
 MAJOR_VER = "7"
 MINOR_VER = "0"
 PATCH_VER = "1"
 
-SRCREV ?= "b8e7044dd2e6e7af9e58cef99b840bd88cfd2dec"
+SRCREV ?= "d0d8eb2e5415b8be29343e3c17a18e49e67b5551"
 
 PV = "${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}"
-BRANCH = "release_${MAJOR_VER}${MINOR_VER}"
+BRANCH = "release/${MAJOR_VER}.x"
 
 LLVMMD5SUM = "c520ed40e11887bb1d24d86f7f5b1f05"
 CLANGMD5SUM = "444af0e124949f07f791f12c928e5994"

--- a/recipes-devtools/clang/common.inc
+++ b/recipes-devtools/clang/common.inc
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://llvm/LICENSE.TXT;md5=${LLVMMD5SUM} \
 "
 LICENSE = "NCSA"
 
-BASEURI ??= "${LLVM_GIT}/llvm-project-20170507;protocol=${LLVM_GIT_PROTOCOL};branch=${BRANCH}"
+BASEURI ??= "${LLVM_GIT}/llvm-project;protocol=${LLVM_GIT_PROTOCOL};branch=${BRANCH}"
 SRC_URI = "\
     ${BASEURI} \
     ${LLVMPATCHES} \

--- a/recipes-devtools/clang/llvm-project-source.bb
+++ b/recipes-devtools/clang/llvm-project-source.bb
@@ -1,8 +1,8 @@
 # Copyright (C) 2018 Khem Raj <raj.khem@gmail.com>
 # Released under the MIT license (see COPYING.MIT for the terms)
 
-SUMMARY = "Flat monorepo imported from http://llvm.org/git/ (17 repos)"
-HOMEPAGE = "https://github.com/llvm-project/llvm-project-20170507"
+SUMMARY = "This is the canonical git mirror of the LLVM subversion repository."
+HOMEPAGE = "https://github.com/llvm/llvm-project"
 
 require llvm-project-source.inc
 require clang.inc


### PR DESCRIPTION
LLVM has set up an official git monorepo. Switch to that, and use its branch naming scheme.