### PR TITLE
Update clang to latest 8.x

### DIFF
--- a/recipes-devtools/clang/clang.inc
+++ b/recipes-devtools/clang/clang.inc
@@ -8,7 +8,7 @@ MAJOR_VER = "8"
 MINOR_VER = "0"
 PATCH_VER = "0"
 
-SRCREV ?= "e264daec97935db606c312b10e43f4e35ac39b58"
+SRCREV ?= "30d3a54b74cf304a82d4f4ab2ef39efdc017ed78"
 
 PV = "${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}"
 BRANCH = "release/${MAJOR_VER}.x"

--- a/recipes-devtools/clang/clang/0016-clang-Append-libunwind-to-compiler-rt-for-linking.patch
+++ b/recipes-devtools/clang/clang/0016-clang-Append-libunwind-to-compiler-rt-for-linking.patch
@@ -1,0 +1,23 @@
+From 4b5386fe67b03923b7ce25c066e6f6220a32eb44 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Fri, 25 Jan 2019 14:39:04 -0800
+Subject: [PATCH] clang: Append libunwind to compiler-rt for linking
+
+Some packages which use libgcc tend to use low level unwind functions
+too, and they are missing in compiler-rt but provided by llvm libunwind
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ clang/lib/Driver/ToolChains/CommonArgs.cpp | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+--- a/clang/lib/Driver/ToolChains/CommonArgs.cpp
++++ b/clang/lib/Driver/ToolChains/CommonArgs.cpp
+@@ -1191,6 +1191,7 @@ void tools::AddRunTimeLibs(const ToolCha
+   switch (RLT) {
+   case ToolChain::RLT_CompilerRT:
+     CmdArgs.push_back(TC.getCompilerRTArgString(Args, "builtins"));
++    CmdArgs.push_back(Args.MakeArgString(D.SysRoot + "/usr/lib" "/libunwind.a"));
+     break;
+   case ToolChain::RLT_Libgcc:
+     // Make sure libgcc is not used under MSVC environment by default

--- a/recipes-devtools/clang/common.inc
+++ b/recipes-devtools/clang/common.inc
@@ -24,6 +24,7 @@ SRC_URI = "\
     file://0013-compiler-rt-support-a-new-embedded-linux-target.patch \
     file://0014-compiler-rt-Simplify-cross-compilation.-Don-t-use-na.patch \
     file://0015-compiler-rt-Disable-tsan-on-OE-glibc.patch \
+    file://0016-clang-Append-libunwind-to-compiler-rt-for-linking.patch \
 "
 
 # Fallback to no-PIE if not set

--- a/recipes-devtools/clang/compiler-rt_git.bb
+++ b/recipes-devtools/clang/compiler-rt_git.bb
@@ -18,6 +18,7 @@ LIC_FILES_CHKSUM = "file://compiler-rt/LICENSE.TXT;md5=f981c4637a4cd67915ac527b3
 BASEDEPENDS_remove_toolchain-clang_class-target = "compiler-rt libcxx"
 CXX_remove_toolchain-clang = "-stdlib=libc++"
 TARGET_CXXFLAGS_remove_toolchain-clang = "-stdlib=libc++"
+TUNE_CCARGS_remove_toolchain-clang = "--rtlib=compiler-rt"
 TUNE_CCARGS_remove = "-no-integrated-as"
 DEPENDS += "ninja-native"
 DEPENDS_append_class-nativesdk = " clang-native"

--- a/recipes-devtools/clang/libcxx_git.bb
+++ b/recipes-devtools/clang/libcxx_git.bb
@@ -15,6 +15,7 @@ DEPENDS += "ninja-native"
 BASEDEPENDS_remove_toolchain-clang = "libcxx"
 CXX_remove_toolchain-clang = "-stdlib=libc++"
 TARGET_CXXFLAGS_remove_toolchain-clang = "-stdlib=libc++"
+TUNE_CCARGS_remove_toolchain-clang = "--rtlib=compiler-rt"
 
 PACKAGECONFIG ??= "unwind"
 PACKAGECONFIG_powerpc = ""


### PR DESCRIPTION
Bolt in fixes for building with compiler-rt + libcxx instead of libgcc + libstdc++