### PR TITLE
Fix duplicates symbols when building with lld

### DIFF
--- a/recipes-connectivity/samba/files/fix_duplicate_pdb_search_init.patch
+++ b/recipes-connectivity/samba/files/fix_duplicate_pdb_search_init.patch
@@ -1,0 +1,10 @@
+--- a/source3/wscript_build	2019-03-14 09:03:29.498617250 +0100
++++ b/source3/wscript_build	2019-03-14 09:06:19.824949694 +0100
+@@ -124,7 +124,6 @@
+                      '!get_attr_list']
+ private_pdb_match.append('!pdb_nds_*')
+ private_pdb_match.append('!pdb_ldapsam_init*')
+-private_pdb_match.append('!pdb_*_init')
+ private_pdb_match = private_pdb_match + ldapsam_pdb_match
+ 
+ bld.SAMBA3_LIBRARY('samba-passdb',

--- a/recipes-connectivity/samba/samba_4.8.%.bbappend
+++ b/recipes-connectivity/samba/samba_4.8.%.bbappend
@@ -1,0 +1,3 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+SRC_URI_append += " file://fix_duplicate_pdb_search_init.patch "

--- a/recipes-connectivity/samba/samba_4.8.%.bbappend
+++ b/recipes-connectivity/samba/samba_4.8.%.bbappend
@@ -1,3 +1,3 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
-SRC_URI_append += " file://fix_duplicate_pdb_search_init.patch "
+SRC_URI_append = " file://fix_duplicate_pdb_search_init.patch "

--- a/recipes-graphics/wayland/files/fix_duplicate_main.patch
+++ b/recipes-graphics/wayland/files/fix_duplicate_main.patch
@@ -1,0 +1,54 @@
+--- wayland-1.16.0/Makefile.am	2019-03-14 10:29:31.103099516 +0100
++++ wayland-1.16.0/Makefile.am	2019-03-14 10:33:07.987977505 +0100
+@@ -210,12 +210,15 @@
+ 	exec-fd-leak-checker			\
+ 	fixed-benchmark
+ 
+-noinst_LTLIBRARIES += libtest-runner.la
++noinst_LTLIBRARIES +=				\
++	libtest-runner.la			\
++	libtest-helpers.la
++
++libtest_helpers_la_SOURCES = tests/test-helpers.c
+ 
+ libtest_runner_la_SOURCES =			\
+ 	tests/test-runner.c			\
+ 	tests/test-runner.h			\
+-	tests/test-helpers.c			\
+ 	tests/test-compositor.h			\
+ 	tests/test-compositor.c
+ libtest_runner_la_LIBADD =			\
+@@ -223,9 +226,9 @@
+ 	libwayland-util.la			\
+ 	libwayland-client.la			\
+ 	libwayland-server.la			\
++	libtest-helpers.la			\
+ 	-lrt -ldl $(FFI_LIBS)
+ 
+-
+ array_test_SOURCES = tests/array-test.c
+ array_test_LDADD = libtest-runner.la
+ client_test_SOURCES = tests/client-test.c
+@@ -270,7 +273,6 @@
+ headers_test_SOURCES = tests/headers-test.c \
+ 		       tests/headers-protocol-test.c \
+ 		       tests/headers-protocol-core-test.c
+-headers_test_LDADD = libtest-runner.la
+ nodist_headers_test_SOURCES =			\
+ 	protocol/wayland-server-protocol-core.h	\
+ 	protocol/wayland-client-protocol-core.h
+@@ -280,13 +282,12 @@
+ endif
+ 
+ fixed_benchmark_SOURCES = tests/fixed-benchmark.c
+-fixed_benchmark_LDADD = libtest-runner.la
+ 
+ os_wrappers_test_SOURCES = tests/os-wrappers-test.c
+ os_wrappers_test_LDADD = libtest-runner.la
+ 
+ exec_fd_leak_checker_SOURCES = tests/exec-fd-leak-checker.c
+-exec_fd_leak_checker_LDADD = libtest-runner.la
++exec_fd_leak_checker_LDADD = libtest-helpers.la
+ 
+ EXTRA_DIST += tests/scanner-test.sh			\
+ 	protocol/tests.xml				\

--- a/recipes-graphics/wayland/wayland_1.16.%.bbappend
+++ b/recipes-graphics/wayland/wayland_1.16.%.bbappend
@@ -1,3 +1,3 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
-SRC_URI_append += " file://fix_duplicate_main.patch "
+SRC_URI_append = " file://fix_duplicate_main.patch "

--- a/recipes-graphics/wayland/wayland_1.16.%.bbappend
+++ b/recipes-graphics/wayland/wayland_1.16.%.bbappend
@@ -1,0 +1,3 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+SRC_URI_append += " file://fix_duplicate_main.patch "


### PR DESCRIPTION
Samba: https://svnweb.freebsd.org/ports/branches/2018Q4/net/samba47/files/patch-source3__wscript_build?view=markup&pathrev=481551
Wayland: https://gitlab.freedesktop.org/wayland/wayland/commit/c70fd8a812d74b5ef6fcba1287b409f4f8821e91