### PR TITLE
clang: support old toolchains

### DIFF
--- a/recipes-devtools/clang/clang_git.bb
+++ b/recipes-devtools/clang/clang_git.bb
@@ -89,6 +89,7 @@ EXTRA_OECMAKE += "-DLLVM_ENABLE_ASSERTIONS=OFF \
                   -DLLVM_ENABLE_PROJECTS='clang;lld' \
                   -DLLVM_BINUTILS_INCDIR=${STAGING_INCDIR} \
                   -G Ninja ${S}/llvm \
+                  -DLLVM_TEMPORARILY_ALLOW_OLD_TOOLCHAIN=ON \
 "
 
 EXTRA_OECMAKE_append_class-native = "\


### PR DESCRIPTION
Allows building llvm/clang on Centos7 (gcc4.8) which still is one of the
suported distros in YP.

Signed-off-by: Anuj Mittal <anuj.mittal@intel.com>