### PR TITLE
lldb: ignore format-security warnings

### DIFF
--- a/recipes-devtools/clang/lldb_git.bb
+++ b/recipes-devtools/clang/lldb_git.bb
@@ -45,6 +45,8 @@ EXTRA_OECMAKE="\
 
 EXTRA_OEMAKE = "VERBOSE=1"
 
+CXXFLAGS_append_toolchain-gcc = " -Wno-error=format-security"
+
 do_compile() {
        ninja ${PARALLEL_MAKE} lldb
 }


### PR DESCRIPTION
lldb doesn't build when -Wformat-security -Werror=format-security is
added/enabled and results in errors with gcc9:

| BUILD/build/tmp/work-shared/llvm-project-source-8.0.1-r0/git/lldb/source/Core/Module.cpp: In member function 'size_t lldb_private::Module::FindTypes_Impl(const lldb_private::ConstString&, const lldb_private::CompilerDeclContext*, bool, size_t, llvm::DenseSet<lldb_private::SymbolFile*>&, lldb_private::TypeMap&)':
| BUILD/build/tmp/work-shared/llvm-project-source-8.0.1-r0/git/lldb/source/Core/Module.cpp:951:52: error: format not a string literal and no format arguments [-Werror=format-security]
|   951 |   Timer scoped_timer(func_cat, LLVM_PRETTY_FUNCTION);
|       |                                                    ^
| BUILD/build/tmp/work-shared/llvm-project-source-8.0.1-r0/git/lldb/source/Core/Module.cpp: In member function 'virtual lldb_private::SymbolVendor* lldb_private::Module::GetSymbolVendor(bool, lldb_private::Stream*)':
| BUILD/build/tmp/work-shared/llvm-project-source-8.0.1-r0/git/lldb/source/Core/Module.cpp:1052:58: error: format not a string literal and no format arguments [-Werror=format-security]
|  1052 |         Timer scoped_timer(func_cat, LLVM_PRETTY_FUNCTION);
|       |

Signed-off-by: Anuj Mittal <anuj.mittal@intel.com>