### PR TITLE
clang: Move libclang into its own dedicated package.

### DIFF
--- a/recipes-devtools/clang/clang_git.bb
+++ b/recipes-devtools/clang/clang_git.bb
@@ -179,7 +179,7 @@ do_install_append_class-nativesdk () {
 
 PACKAGE_DEBUG_SPLIT_STYLE_class-nativesdk = "debug-without-src"
 
-PACKAGES =+ "${PN}-libllvm"
+PACKAGES =+ "${PN}-libllvm libclang"
 
 BBCLASSEXTEND = "native nativesdk"
 
@@ -196,6 +196,10 @@ FILES_${PN}-libllvm += "\
   ${libdir}/libLLVM-${MAJOR_VER}.${MINOR_VER}.so \
   ${libdir}/libLLVM-${MAJOR_VER}.so \
   ${libdir}/libLLVM-${MAJOR_VER}.${MINOR_VER}svn.so \
+"
+
+FILES_libclang = "\
+  ${libdir}/libclang.so.${MAJOR_VER} \
 "
 
 FILES_${PN}-dev += "\


### PR DESCRIPTION
This library has a few potential consimers (ex, qttools) which don't
need whole clang install. Distributions like debian already package
lbiclang separately as libclang1. This makes even more sense for
embedded systems. Do the same for OE/Yocto.

Signed-off-by: Piotr Tworek <tworaz@tworaz.net>