### PR TITLE
use native-clang compiler when building nativesdk-clang

### DIFF
--- a/recipes-devtools/clang/clang_git.bb
+++ b/recipes-devtools/clang/clang_git.bb
@@ -10,6 +10,8 @@ require common-source.inc
 
 INHIBIT_DEFAULT_DEPS = "1"
 
+BUILD_CC_class-nativesdk = "clang"
+BUILD_CXX_class-nativesdk = "clang++"
 BUILD_AR_class-nativesdk = "llvm-ar"
 BUILD_RANLIB_class-nativesdk = "llvm-ranlib"
 BUILD_NM_class-nativesdk = "llvm-nm"


### PR DESCRIPTION
Some cmake based steps when building clang uses BUILD_CC, BUILD_CXX variables,
which points to gcc even if `TOOLCHAIN_class-nativesdk = "clang"`.

This patch sets it to clang if `TOOLCHAIN_class-nativesdk = "clang"` is set.

Signed-off-by: Daniel Dittmann <daniel.dittmann@rohde-schwarz.com>