### PR TITLE
nonclangable: Remove aspell from the list

### DIFF
--- a/conf/nonclangable.conf
+++ b/conf/nonclangable.conf
@@ -1,4 +1,3 @@
-TOOLCHAIN_pn-aspell = "gcc"
 TOOLCHAIN_pn-u-boot = "gcc"
 TOOLCHAIN_pn-cpufrequtils = "gcc"
 # crash embeds version of gdb which is not buildable with clang


### PR DESCRIPTION
The package was recently updated to version 0.60.7 which builds fine
with both clang 8.x and 9.x.

Signed-off-by: Piotr Tworek <tworaz@tworaz.net>