### PR TITLE
clang: Inherit python3native.

### DIFF
--- a/recipes-devtools/clang/clang_git.bb
+++ b/recipes-devtools/clang/clang_git.bb
@@ -17,7 +17,7 @@ BUILD_RANLIB_class-nativesdk = "llvm-ranlib"
 BUILD_NM_class-nativesdk = "llvm-nm"
 LDFLAGS_append_class-nativesdk = " -fuse-ld=gold"
 
-inherit cmake cmake-native
+inherit cmake cmake-native python3native
 
 OECMAKE_FIND_ROOT_PATH_MODE_PROGRAM = "BOTH"
 


### PR DESCRIPTION
Without this for some reason lldb configure process manages to mix host
system provided python3 interpreter with libpython provided in
recipe-sysroot-native. As result the build fails with the following
error message:

| -- Found PythonInterp: /usr/bin/python3.6 (found version "3.6.5")
...
| -- Found PythonLibs: /mnt/storage/build-purple/tmp-musl/work/x86_64-linux/clang-native/9.0.0-r0/recipe-sysroot-native/usr/lib/libpython3.7m.so (found version "3.7.4")
| CMake Error at /mnt/storage/build-purple/tmp-musl/work-shared/llvm-project-source-9.0.0-r0/git/lldb/cmake/modules/LLDBConfig.cmake:204 (message):
|   Found incompatible Python interpreter (3.6.5) and Python libraries (3.7.4)
| Call Stack (most recent call first):
|   /mnt/storage/build-purple/tmp-musl/work-shared/llvm-project-source-9.0.0-r0/git/lldb/CMakeLists.txt:20 (include)

Signed-off-by: Piotr Tworek <tworaz@tworaz.net>