### PR TITLE
Pass Python3 Exectuable to CMake

### DIFF
--- a/recipes-devtools/clang/clang_git.bb
+++ b/recipes-devtools/clang/clang_git.bb
@@ -93,6 +93,7 @@ EXTRA_OECMAKE += "-DLLVM_ENABLE_ASSERTIONS=OFF \
                   -DLLVM_BINUTILS_INCDIR=${STAGING_INCDIR} \
                   -G Ninja ${S}/llvm \
                   -DLLVM_TEMPORARILY_ALLOW_OLD_TOOLCHAIN=ON \
+		  -DPYTHON_EXECUTABLE=${PYTHON} \
 "
 
 EXTRA_OECMAKE_append_class-native = "\


### PR DESCRIPTION
Even when inheriting Python3native, CMake is picking up the system python executable for some reason, and can cause builds to fail. This fixes that by explicitly providing the path to the executable for CMake to use.

Resolves #145