### PR TITLE
libcxx: Add libunwind to PROVIDES not only RPROVIDES.

### DIFF
--- a/recipes-devtools/clang/libcxx_git.bb
+++ b/recipes-devtools/clang/libcxx_git.bb
@@ -80,7 +80,7 @@ do_install() {
 
 ALLOW_EMPTY_${PN} = "1"
 
-#PROVIDES = "virtual/${TARGET_PREFIX}compilerlibs"
+PROVIDES = "${@bb.utils.contains('PACKAGECONFIG', 'unwind', 'libunwind', '', d)}"
 RPROVIDES_${PN} += "${@bb.utils.contains('PACKAGECONFIG', 'unwind', 'libunwind', '', d)}"
 RPROVIDES_${PN}-dev += "${@bb.utils.contains('PACKAGECONFIG', 'unwind', 'libunwind-dev', '', d)}"
 RPROVIDES_${PN}-doc += "${@bb.utils.contains('PACKAGECONFIG', 'unwind', 'libunwind-doc', '', d)}"


### PR DESCRIPTION
Without this bitbake will still pull standard libunwind package when
building recipes depending on libunwind. If such recipe also happens
to pull libcxx the build will fail when assembling the sysroot because
both libcxx and libunwind provide libunwind.so.

This problem has been observed when building libstd-rs from meta-rust
layer agains musl libc.

Signed-off-by: Piotr Tworek <tworaz@tworaz.net>