### PR TITLE
layer: drop sumo support

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -7,7 +7,7 @@ BBFILES += "${LAYERDIR}/recipes*/*/*.bb ${LAYERDIR}/recipes*/*/*.bbappend"
 BBFILE_COLLECTIONS += "clang-layer"
 BBFILE_PATTERN_clang-layer := "^${LAYERDIR}/"
 BBFILE_PRIORITY_clang-layer = "7"
-LAYERSERIES_COMPAT_clang-layer = "sumo thud warrior"
+LAYERSERIES_COMPAT_clang-layer = "thud warrior"
 
 BBFILES_DYNAMIC += " \
     openembedded-layer:${LAYERDIR}/dynamic-layers/openembedded-layer/*/*/*.bb \


### PR DESCRIPTION
can't build with sumo because of the dependency on libedit which require native.
libedit doesn't provide BBCLASSEXTEND on sumo.