### PR TITLE
libcxx: Do not hardcode llvm ar/ranlib/nm

### DIFF
--- a/recipes-devtools/clang/libcxx_git.bb
+++ b/recipes-devtools/clang/libcxx_git.bb
@@ -45,9 +45,9 @@ EXTRA_OECMAKE += "\
                   -DLIBCXXABI_LIBCXX_INCLUDES=${S}/libcxx/include \
                   -DLIBCXX_CXX_ABI_INCLUDE_PATHS=${S}/libcxxabi/include \
                   -DLIBCXX_CXX_ABI_LIBRARY_PATH=${B}/lib \
-                  -DCMAKE_AR=${STAGING_BINDIR_TOOLCHAIN}/${TARGET_PREFIX}llvm-ar \
-                  -DCMAKE_NM=${STAGING_BINDIR_TOOLCHAIN}/${TARGET_PREFIX}llvm-nm \
-                  -DCMAKE_RANLIB=${STAGING_BINDIR_TOOLCHAIN}/${TARGET_PREFIX}llvm-ranlib \
+                  -DCMAKE_AR=${STAGING_BINDIR_TOOLCHAIN}/${AR} \
+                  -DCMAKE_NM=${STAGING_BINDIR_TOOLCHAIN}/${NM} \
+                  -DCMAKE_RANLIB=${STAGING_BINDIR_TOOLCHAIN}/${RANLIB} \
                   -DLLVM_ENABLE_PROJECTS='libcxx;libcxxabi${LIBUNWIND}' \
                   -G Ninja \
                   ${S}/llvm \


### PR DESCRIPTION
This helps in building with gcc

Signed-off-by: Khem Raj <raj.khem@gmail.com>