### PR TITLE
kernel-selftest.bbappend: Remove llvm-native from dependency

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-kernel/kernel-selftest/kernel-selftest.bbappend
+++ b/dynamic-layers/openembedded-layer/recipes-kernel/kernel-selftest/kernel-selftest.bbappend
@@ -1,1 +1,2 @@
 DEPENDS_append = " clang-native"
+DEPENDS_remove = "llvm-native"


### PR DESCRIPTION
clang-native is sufficient to provide needed tools for kernel-selftest
including the ones from llvm-native

Signed-off-by: Khem Raj <raj.khem@gmail.com>