### PR TITLE
clang: Upgrade to latest 9.x

### DIFF
--- a/classes/clang.bbclass
+++ b/classes/clang.bbclass
@@ -9,6 +9,7 @@ AR_toolchain-clang = "${HOST_PREFIX}llvm-ar"
 NM_toolchain-clang = "${HOST_PREFIX}llvm-nm"
 
 COMPILER_RT ??= "--rtlib=compiler-rt ${UNWINDLIB}"
+COMPILER_RT_powerpc = "--rtlib=libgcc ${UNWINDLIB}"
 
 UNWINDLIB ??= "--unwindlib=libunwind"
 UNWINDLIB_riscv64 = "--unwindlib=libgcc"

--- a/classes/clang.bbclass
+++ b/classes/clang.bbclass
@@ -32,6 +32,7 @@ TUNE_CCARGS_remove_toolchain-clang_powerpc = "-mhard-float"
 TUNE_CCARGS_remove_toolchain-clang_powerpc = "-mno-spe"
 
 TUNE_CCARGS_append_toolchain-clang = " -Wno-error=unused-command-line-argument -Qunused-arguments"
+TUNE_CCARGS_append_toolchain-clang_libc-musl_powerpc64 = " -mlong-double-64"
 
 LDFLAGS_append_toolchain-clang_class-nativesdk_x86-64 = " -Wl,-dynamic-linker,${base_libdir}/ld-linux-x86-64.so.2"
 LDFLAGS_append_toolchain-clang_class-nativesdk_x86 = " -Wl,-dynamic-linker,${base_libdir}/ld-linux.so.2"

--- a/recipes-core/musl/musl_%.bbappend
+++ b/recipes-core/musl/musl_%.bbappend
@@ -1,4 +1,5 @@
 DEPENDS_append_toolchain-clang = " clang-cross-${TARGET_ARCH}"
 TOOLCHAIN_x86-x32 = "gcc"
 TOOLCHAIN_riscv64 = "gcc"
+TOOLCHAIN_powerpc64 = "gcc"
 inherit lto

--- a/recipes-devtools/clang/clang.inc
+++ b/recipes-devtools/clang/clang.inc
@@ -8,7 +8,7 @@ MAJOR_VER = "9"
 MINOR_VER = "0"
 PATCH_VER = "0"
 
-SRCREV ?= "b2b72eca6623ebb9d70052a8546508c34fccb42c"
+SRCREV ?= "1cf7a88045ced9f19f5e6dc0add51723d39eef7f"
 
 PV = "${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}"
 BRANCH = "release/${MAJOR_VER}.x"

--- a/recipes-devtools/clang/common.inc
+++ b/recipes-devtools/clang/common.inc
@@ -16,7 +16,7 @@ SRC_URI = "\
     file://0006-llvm-TargetLibraryInfo-Undefine-libc-functions-if-th.patch \
     file://0007-llvm-allow-env-override-of-exe-path.patch \
     file://0008-llvm-Enhance-path-prefix-mapping.patch \
-    ${@'file://0009-clang-Enable-SSP-and-PIE-by-default.patch' if '${GCCPIE}' else ''} \
+    file://0009-clang-Enable-SSP-and-PIE-by-default.patch \
     file://0010-clang-driver-Use-lib-for-ldso-on-OE.patch \
     file://0011-clang-Driver-tools.cpp-Add-lssp_nonshared-on-musl.patch \
     file://0012-clang-musl-ppc-does-not-support-128-bit-long-double.patch \

--- a/recipes-devtools/clang/compiler-rt_git.bb
+++ b/recipes-devtools/clang/compiler-rt_git.bb
@@ -43,7 +43,8 @@ EXTRA_OECMAKE_append_class-nativesdk = "\
 
 EXTRA_OECMAKE_append_libc-musl = " -DCOMPILER_RT_BUILD_SANITIZERS=OFF "
 CXXFLAGS_append_libc-musl = " -D_LIBCPP_HAS_MUSL_LIBC=ON "
-EXTRA_OECMAKE_append_mipsarch = "-DCOMPILER_RT_BUILD_SANITIZERS=OFF "
+EXTRA_OECMAKE_append_mipsarch = " -DCOMPILER_RT_BUILD_SANITIZERS=OFF "
+EXTRA_OECMAKE_append_powerpc = " -DCOMPILER_RT_DEFAULT_TARGET_ARCH=powerpc "
 
 do_compile() {
 	ninja ${PARALLEL_MAKE} compiler-rt
@@ -55,29 +56,29 @@ do_install() {
 
 
 do_install_append () {
-	if [ -d ${D}${libdir}/linux ]; then
-		for f in `find ${D}${libdir}/linux -maxdepth 1 -type f`
+	if [ -d ${D}${exec_prefix}/lib/linux ]; then
+		for f in `find ${D}${exec_prefix}/lib/linux -maxdepth 1 -type f`
 		do
-			install -D -m 0644 $f ${D}${libdir}/clang/${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}/lib/linux/`basename $f`
+			install -D -m 0644 $f ${D}${exec_prefix}/lib/clang/${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}/lib/linux/`basename $f`
 			rm $f
 		done
-		rmdir ${D}${libdir}/linux
+		rmdir ${D}${exec_prefix}/lib/linux
 	fi
 	for f in `find ${D}${exec_prefix} -maxdepth 1 -name '*.txt' -type f`
 	do
-		install -D -m 0644  $f ${D}${libdir}/clang/${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}/`basename $f`
+		install -D -m 0644  $f ${D}${exec_prefix}/lib/clang/${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}/`basename $f`
 		rm $f
 	done
-        rm -rf ${D}${libdir}/clang/${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}/lib/linux/clang_rt.crt*.o
+        rm -rf ${D}${exec_prefix}/lib/clang/${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}/lib/linux/clang_rt.crt*.o
 }
 
 FILES_SOLIBSDEV = ""
-FILES_${PN} += "${libdir}/clang/${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}/lib/linux/lib*${SOLIBSDEV} \
-                ${libdir}/clang/${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}/*.txt \
-                ${libdir}/clang/${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}/share/*.txt"
-FILES_${PN}-staticdev += "${libdir}/clang/${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}/lib/linux/*.a"
-FILES_${PN}-dev += "${datadir} ${libdir}/clang/${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}/lib/linux/*.syms \
-                    ${libdir}/clang/${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}/lib/linux/clang_rt.crt*.o \
+FILES_${PN} += "${exec_prefix}/lib/clang/${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}/lib/linux/lib*${SOLIBSDEV} \
+                ${exec_prefix}/lib/clang/${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}/*.txt \
+                ${exec_prefix}/lib/clang/${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}/share/*.txt"
+FILES_${PN}-staticdev += "${exec_prefix}/lib/clang/${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}/lib/linux/*.a"
+FILES_${PN}-dev += "${datadir} ${exec_prefix}/lib/clang/${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}/lib/linux/*.syms \
+                    ${exec_prefix}/lib/clang/${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}/lib/linux/clang_rt.crt*.o \
                    "
 INSANE_SKIP_${PN} = "dev-so"
 

--- a/recipes-devtools/clang/libcxx_git.bb
+++ b/recipes-devtools/clang/libcxx_git.bb
@@ -66,6 +66,11 @@ EXTRA_OECMAKE_append_riscv32 = " -DLIBCXXABI_ENABLE_EXCEPTIONS=ON \
                                  -DLIBOMP_LIBFLAGS='-latomic' \
                                  -DCMAKE_SHARED_LINKER_FLAGS='-lgcc_s -latomic' \
                                  "
+EXTRA_OECMAKE_append_powerpc = " -DLIBCXXABI_ENABLE_EXCEPTIONS=ON \
+                                 -DLIBCXX_ENABLE_EXCEPTIONS=ON \
+                                 -DLIBOMP_LIBFLAGS='-latomic' \
+                                 -DCMAKE_SHARED_LINKER_FLAGS='-lgcc_s -latomic' \
+                                 "
 do_compile() {
     if ${@bb.utils.contains('PACKAGECONFIG', 'unwind', 'true', 'false', d)}; then
         ninja -v ${PARALLEL_MAKE} unwind


### PR DESCRIPTION
Default to ssp and pie irrespective of GCCPIE
this lets us build one clang for all

Signed-off-by: Khem Raj <raj.khem@gmail.com>