### PR TITLE
clang.bbclass: Do not set LIBCPLUSPLUS and COMPILER_RT when compiler …

### DIFF
--- a/conf/nonclangable.conf
+++ b/conf/nonclangable.conf
@@ -137,7 +137,8 @@ CFLAGS_append_pn-mdadm_toolchain-clang = " -Wno-error=unknown-warning-option"
 
 #../libffi-3.2.1/src/arm/sysv.S:363:2: error: invalid instruction, did you mean: fldmiax?
 # fldmiadgt ip, {d0-d7}
-#CFLAGS_append_pn-libffi_toolchain-clang = " -no-integrated-as"
+CFLAGS_append_pn-libffi_arm_toolchain-clang = " -no-integrated-as"
+CFLAGS_append_pn-libffi_armeb_toolchain-clang = " -no-integrated-as"
 # ../db-5.3.28/src/mutex/mut_tas.c:150:34: error: unknown directive
 #<inline asm>:9:2: note: instantiated into assembly here
 # .force_thumb
@@ -211,8 +212,8 @@ TUNE_CCARGS_remove_pn-omxplayer_toolchain-clang = "-no-integrated-as"
 
 #| /usr/src/debug/ruby/2.5.1-r0/build/../ruby-2.5.1/process.c:7073: undefined reference to `__mulodi4'
 #| clang-7: error: linker command failed with exit code 1 (use -v to see invocation)
-LDFLAGS_append_pn-ruby_toolchain-clang = " -rtlib=compiler-rt"
-LDFLAGS_append_pn-m4_toolchain-clang = " -rtlib=compiler-rt"
+LDFLAGS_append_pn-ruby_toolchain-clang = "${@bb.utils.contains('COMPILER_RT', '--rtlib=compiler-rt', ' -rtlib=compiler-rt', '', d)}"
+LDFLAGS_append_pn-m4_toolchain-clang = "${@bb.utils.contains('COMPILER_RT', '--rtlib=compiler-rt', ' -rtlib=compiler-rt', '', d)}"
 LDFLAGS_remove_pn-m4_powerpc = "-rtlib=compiler-rt"
 
 LDFLAGS_append_pn-gnutls_toolchain-clang_riscv64 = " -latomic"


### PR DESCRIPTION
…!= clang

* Add compiler-rt and libcxx only when these libs are used via cmdline

* libffi still need to disable internal asm on arm <= v6

* Add compiler-rt to linker only when compiler-rt is used in compiler
  cmdline

* Set BASE_DEFAULT_DEPS instead of munging BASEEDEPENDS directly

Signed-off-by: Khem Raj <raj.khem@gmail.com>