### PR TITLE
fixes for multilib and python detection

### DIFF
--- a/recipes-devtools/clang/clang/0001-Pass-PYTHON_EXECUTABLE-when-cross-compiling-for-nati.patch
+++ b/recipes-devtools/clang/clang/0001-Pass-PYTHON_EXECUTABLE-when-cross-compiling-for-nati.patch
@@ -1,0 +1,25 @@
+From 112a89e845333ae98e9802c5ac5a4761032e08de Mon Sep 17 00:00:00 2001
+From: Anuj Mittal <anuj.mittal@intel.com>
+Date: Wed, 18 Sep 2019 12:56:58 +0800
+Subject: [PATCH] Pass PYTHON_EXECUTABLE when cross compiling for native build
+
+Signed-off-by: Anuj Mittal <anuj.mittal@intel.com>
+---
+ llvm/cmake/modules/CrossCompile.cmake | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/llvm/cmake/modules/CrossCompile.cmake b/llvm/cmake/modules/CrossCompile.cmake
+index d6b4161..7fae108 100644
+--- a/llvm/cmake/modules/CrossCompile.cmake
++++ b/llvm/cmake/modules/CrossCompile.cmake
+@@ -62,6 +62,7 @@ function(llvm_create_cross_target_internal target_name toolchain buildtype)
+         -DLLVM_ENABLE_PROJECTS="${llvm_enable_projects_arg}"
+         -DLLVM_EXTERNAL_PROJECTS="${llvm_external_projects_arg}"
+         -DLLVM_TEMPORARILY_ALLOW_OLD_TOOLCHAIN="${LLVM_TEMPORARILY_ALLOW_OLD_TOOLCHAIN}"
++        -DPYTHON_EXECUTABLE="${PYTHON_EXECUTABLE}"
+         ${build_type_flags} ${linker_flag} ${external_clang_dir}
+     WORKING_DIRECTORY ${LLVM_${target_name}_BUILD}
+     DEPENDS CREATE_LLVM_${target_name}
+-- 
+2.7.4
+

--- a/recipes-devtools/clang/clang_git.bb
+++ b/recipes-devtools/clang/clang_git.bb
@@ -146,6 +146,7 @@ EXTRA_OECMAKE_append_class-target = "\
                   -DLLVM_DEFAULT_TARGET_TRIPLE=${TARGET_SYS}${HF} \
                   -DPYTHON_LIBRARY=${STAGING_LIBDIR}/lib${PYTHON_DIR}${PYTHON_ABI}.so \
                   -DPYTHON_INCLUDE_DIR=${STAGING_INCDIR}/${PYTHON_DIR}${PYTHON_ABI} \
+                  -DLLVM_LIBDIR_SUFFIX=${@d.getVar('baselib').replace('lib', '')} \
 "
 
 DEPENDS = "binutils zlib libffi libedit libedit-native libxml2 libxml2-native ninja-native swig-native"

--- a/recipes-devtools/clang/clang_git.bb
+++ b/recipes-devtools/clang/clang_git.bb
@@ -147,6 +147,7 @@ EXTRA_OECMAKE_append_class-target = "\
                   -DPYTHON_LIBRARY=${STAGING_LIBDIR}/lib${PYTHON_DIR}${PYTHON_ABI}.so \
                   -DPYTHON_INCLUDE_DIR=${STAGING_INCDIR}/${PYTHON_DIR}${PYTHON_ABI} \
                   -DLLVM_LIBDIR_SUFFIX=${@d.getVar('baselib').replace('lib', '')} \
+                  -DPYTHON_EXECUTABLE='${PYTHON}' \
 "
 
 DEPENDS = "binutils zlib libffi libedit libedit-native libxml2 libxml2-native ninja-native swig-native"

--- a/recipes-devtools/clang/common.inc
+++ b/recipes-devtools/clang/common.inc
@@ -30,6 +30,7 @@ SRC_URI = "\
     file://0020-clang-default-to-lp64d-ABI-and-rv64gc-ISA.patch \
     file://0022-Driver-Prioritize-SYSROOT-usr-include-over-RESOURCE_.patch \
     file://0023-RISCV-Add-support-for-floating-point-registers-in-in.patch \
+    file://0001-Pass-PYTHON_EXECUTABLE-when-cross-compiling-for-nati.patch \
 "
 
 # Fallback to no-PIE if not set

--- a/recipes-devtools/clang/compiler-rt_git.bb
+++ b/recipes-devtools/clang/compiler-rt_git.bb
@@ -72,6 +72,10 @@ do_install_append () {
         rm -rf ${D}${exec_prefix}/lib/clang/${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}/lib/linux/clang_rt.crt*.o
 }
 
+sysroot_stage_all_append_class-target() {
+        sysroot_stage_dir ${D}${exec_prefix}/lib ${SYSROOT_DESTDIR}${exec_prefix}/lib
+}
+
 FILES_SOLIBSDEV = ""
 FILES_${PN} += "${exec_prefix}/lib/clang/${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}/lib/linux/lib*${SOLIBSDEV} \
                 ${exec_prefix}/lib/clang/${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}/*.txt \
@@ -80,7 +84,7 @@ FILES_${PN}-staticdev += "${exec_prefix}/lib/clang/${MAJOR_VER}.${MINOR_VER}.${P
 FILES_${PN}-dev += "${datadir} ${exec_prefix}/lib/clang/${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}/lib/linux/*.syms \
                     ${exec_prefix}/lib/clang/${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}/lib/linux/clang_rt.crt*.o \
                    "
-INSANE_SKIP_${PN} = "dev-so"
+INSANE_SKIP_${PN} = "dev-so libdir"
 
 #PROVIDES_append_class-target = "\
 #        virtual/${TARGET_PREFIX}compilerlibs \

--- a/recipes-devtools/clang/libcxx_git.bb
+++ b/recipes-devtools/clang/libcxx_git.bb
@@ -44,11 +44,12 @@ EXTRA_OECMAKE += "\
                   -DLIBCXX_STATICALLY_LINK_ABI_IN_SHARED_LIBRARY=OFF \
                   -DLIBCXXABI_LIBCXX_INCLUDES=${S}/libcxx/include \
                   -DLIBCXX_CXX_ABI_INCLUDE_PATHS=${S}/libcxxabi/include \
-                  -DLIBCXX_CXX_ABI_LIBRARY_PATH=${B}/lib \
+                  -DLIBCXX_CXX_ABI_LIBRARY_PATH=${B}/${baselib} \
                   -DCMAKE_AR=${STAGING_BINDIR_TOOLCHAIN}/${AR} \
                   -DCMAKE_NM=${STAGING_BINDIR_TOOLCHAIN}/${NM} \
                   -DCMAKE_RANLIB=${STAGING_BINDIR_TOOLCHAIN}/${RANLIB} \
                   -DLLVM_ENABLE_PROJECTS='libcxx;libcxxabi${LIBUNWIND}' \
+                  -DLLVM_LIBDIR_SUFFIX=${@d.getVar('baselib').replace('lib', '')} \
                   -G Ninja \
                   ${S}/llvm \
 "


### PR DESCRIPTION
This makes sure that correct Python (python3native) is detected when compiling target clang and that we're able to compile when multilib is enabled.