### PR TITLE
clang.bbclass: Add clang override ad space in DEBUG_PREFIX_MAP

### DIFF
--- a/classes/clang.bbclass
+++ b/classes/clang.bbclass
@@ -30,7 +30,7 @@ TOOLCHAIN_class-crosssdk = "gcc"
 TOOLCHAIN_class-cross = "gcc"
 
 # -fmacro-prefix-map does not exist in clang 7.x
-DEBUG_PREFIX_MAP = ""
+DEBUG_PREFIX_MAP_toolchain-clang = " "
 
 OVERRIDES =. "${@['', 'toolchain-${TOOLCHAIN}:']['${TOOLCHAIN}' != '']}"
 OVERRIDES[vardepsexclude] += "TOOLCHAIN"


### PR DESCRIPTION
The variable is expected in some code usages as having some
content. With an empty variable, sed fails in some locations.

sed 's,,,g'

sed: -e expression #1, char 0: no previous regular expression

Also since clang can be included an not used the variable
should only be set when the toolchain setting is clang.

Signed-off-by: Jeremy Puhlman <jpuhlman@mvista.com>