### PR TITLE
nonclangable: Use libgcc for libc-bench, aufs-util, libhugetlbfs, tsocks

### DIFF
--- a/conf/nonclangable.conf
+++ b/conf/nonclangable.conf
@@ -171,11 +171,6 @@ CFLAGS_append_pn-userland_toolchain-clang = " -no-integrated-as"
 # ^
 CFLAGS_append_pn-libjpeg-turbo_toolchain-clang_mipsarch = " -no-integrated-as"
 
-# src/libswscale/arm/rgb2yuv_neon_common.S:239:11: error: unexpected token in argument list
-# CO_RY .dn d0.s16[0]
-#          ^
-CPPFLAGS_append_pn-gstreamer1.0-libav_toolchain-clang = " -no-integrated-as"
-
 #../kexec-tools-2.0.18/purgatory/arch/i386/entry32-16.S:23:2: error: unknown directive
 # .arch i386
 # ^

--- a/conf/nonclangable.conf
+++ b/conf/nonclangable.conf
@@ -228,6 +228,10 @@ COMPILER_RT_pn-libc-bench_libc-glibc_toolchain-clang_x86 = "--rtlib=libgcc"
 COMPILER_RT_pn-aufs-util_libc-glibc_toolchain-clang_x86 = "--rtlib=libgcc"
 COMPILER_RT_pn-libhugetlbfs_libc-glibc_toolchain-clang_x86 = "--rtlib=libgcc"
 COMPILER_RT_pn-tsocks_libc-glibc_toolchain-clang_x86 = "--rtlib=libgcc"
+COMPILER_RT_pn-libc-bench_libc-glibc_toolchain-clang_x86-64 = "--rtlib=libgcc"
+COMPILER_RT_pn-aufs-util_libc-glibc_toolchain-clang_x86-64 = "--rtlib=libgcc"
+COMPILER_RT_pn-libhugetlbfs_libc-glibc_toolchain-clang_x86-64 = "--rtlib=libgcc"
+COMPILER_RT_pn-tsocks_libc-glibc_toolchain-clang_x86-64 = "--rtlib=libgcc"
 
 #(unwind.o): in function `__pthread_unwind':
 #/usr/src/debug/glibc/2.29-r0/git/nptl/unwind.c:121: undefined reference to `_Unwind_ForcedUnwind'


### PR DESCRIPTION
They do static linking, and when linking with glibc it expects
intrinsics from libgcc since we do not use clang to build glibc
this is not an issue on musl since we use clang to build most of
musl ports

Signed-off-by: Khem Raj <raj.khem@gmail.com>