### PR TITLE
clang: Do not lock clang as only cross compiler option

### DIFF
--- a/recipes-devtools/clang/clang_git.bb
+++ b/recipes-devtools/clang/clang_git.bb
@@ -238,6 +238,5 @@ INSANE_SKIP_${PN}-lldb-python += "dev-so dev-deps"
 #Avoid SSTATE_SCAN_COMMAND running sed over llvm-config.
 SSTATE_SCAN_FILES_remove = "*-config"
 
-TOOLCHAIN = "clang"
 TOOLCHAIN_class-native = "gcc"
 TOOLCHAIN_class-nativesdk = "clang"


### PR DESCRIPTION
clang might be used for more than just static compiler on target and
therefore lock-stepping it with needing clang cross-compiler is not
right thing

Signed-off-by: Khem Raj <raj.khem@gmail.com>