### PR TITLE
qtwebengine: Link libatomic on x86/clang/gnu-runtime

### DIFF
--- a/conf/nonclangable.conf
+++ b/conf/nonclangable.conf
@@ -217,6 +217,7 @@ COMPILER_RT_remove_pn-m4_powerpc = "--rtlib=compiler-rt"
 
 LDFLAGS_append_pn-gnutls_toolchain-clang_riscv64 = " -latomic"
 LDFLAGS_append_pn-harfbuzz_toolchain-clang_riscv64 = " -latomic"
+LDFLAGS_append_pn-qtwebengine_toolchain-clang_runtime-gnu_x86 = " -latomic"
 
 # glibc is built with gcc and hence encodes some libgcc specific builtins which are not found
 # when doing static linking with clang using compiler-rt, so use libgcc


### PR DESCRIPTION
gcc uses intrinsics for atomic<double> but clang does not for x86
when using libstdc++

./media/audio/pulse/pulse_input.cc uses this atomic variable

Signed-off-by: Khem Raj <raj.khem@gmail.com>