### PR TITLE
llvm: Check for built-in atomic<double> during configure

### DIFF
--- a/recipes-devtools/clang/clang/0021-Check-for-atomic-double-intrinsics.patch
+++ b/recipes-devtools/clang/clang/0021-Check-for-atomic-double-intrinsics.patch
@@ -1,0 +1,33 @@
+From a580e8fcf17fb9cb9056debdd342ac4eabef4762 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Mon, 18 Nov 2019 17:00:29 -0800
+Subject: [PATCH] Check for atomic<double> intrinsics
+
+On some architectures e.g. x86/32bit gcc decides to inline calls to
+double atomic variables but clang does not and defers it to libatomic
+therefore detect if clang can use built-ins for atomic<double> if not
+then link libatomic, this helps building clangd for x86 on linux systems
+with gcc runtime
+
+Upstream-Status: Pending
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ llvm/cmake/modules/CheckAtomic.cmake | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/llvm/cmake/modules/CheckAtomic.cmake b/llvm/cmake/modules/CheckAtomic.cmake
+index 9a4cdf12a62..e70ce924df9 100644
+--- a/llvm/cmake/modules/CheckAtomic.cmake
++++ b/llvm/cmake/modules/CheckAtomic.cmake
+@@ -26,9 +26,10 @@ function(check_working_cxx_atomics64 varname)
+ #include <atomic>
+ #include <cstdint>
+ std::atomic<uint64_t> x (0);
++std::atomic<double> y (0);
+ int main() {
+   uint64_t i = x.load(std::memory_order_relaxed);
+-  return 0;
++  return int(y);
+ }
+ " ${varname})
+   set(CMAKE_REQUIRED_FLAGS ${OLD_CMAKE_REQUIRED_FLAGS})

--- a/recipes-devtools/clang/common.inc
+++ b/recipes-devtools/clang/common.inc
@@ -28,6 +28,7 @@ SRC_URI = "\
     file://0018-compiler-rt-Disable-tsan-on-OE-glibc.patch \
     file://0019-llvm-Enhance-path-prefix-mapping.patch \
     file://0020-clang-Initial-implementation-of-fmacro-prefix-map-an.patch \
+    file://0021-Check-for-atomic-double-intrinsics.patch \
 "
 
 # Fallback to no-PIE if not set


### PR DESCRIPTION
This helps in deciding on linking libatomic, therefore its important to
check for atomic<double> because on x86, clang decides to not use
built-in whereas gcc does, so clangd e.g. links ok when using gcc but
fails when using clang with gcc-runtime on x86

Backport of ba6e545b1d0ee93b4ef698fae2d5a018a062b46a
Signed-off-by: Michael Davis <michael.davis@essvote.com>