### PR TITLE
Fix mesa builds in zeus with gallium-llvm enabled.

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -28,5 +28,7 @@ INHERIT += "clang"
 # include clang in SDK
 CLANGSDK ??= "1"
 
+LLVMVERSION = "9.0.0"
+
 require conf/nonclangable.conf
 require conf/nonscanable.conf

--- a/recipes-devtools/clang/clang_git.bb
+++ b/recipes-devtools/clang/clang_git.bb
@@ -87,10 +87,10 @@ LLVM_ENABLE_LIBEDIT;LLDB_DISABLE_LIBEDIT; \
 #
 # Default to build all OE-Core supported target arches (user overridable).
 #
-LLVM_TARGETS_TO_BUILD ?= "AArch64;ARM;BPF;Mips;PowerPC;RISCV;X86"
+LLVM_TARGETS_TO_BUILD ?= "AMDGPU;AArch64;ARM;BPF;Mips;PowerPC;RISCV;X86"
 LLVM_TARGETS_TO_BUILD_append = ";${@get_clang_host_arch(bb, d)};${@get_clang_target_arch(bb, d)}"
 
-LLVM_TARGETS_TO_BUILD_TARGET ?= "AMDGPU;${LLVM_TARGETS_TO_BUILD}"
+LLVM_TARGETS_TO_BUILD_TARGET ?= "${LLVM_TARGETS_TO_BUILD}"
 LLVM_TARGETS_TO_BUILD_TARGET_append ?= ";${@get_clang_target_arch(bb, d)}"
 
 LLVM_EXPERIMENTAL_TARGETS_TO_BUILD ?= ""


### PR DESCRIPTION
Not positive the following patches are the right way to go about this, but they do restore my ability to use openembedded-core/meta-clang in zeus and build mesa with gallium-llvm without over-riding any defaults.