### PR TITLE
clang: enable AMDGPU for all targets

### DIFF
--- a/recipes-devtools/clang/clang_git.bb
+++ b/recipes-devtools/clang/clang_git.bb
@@ -87,10 +87,10 @@ LLVM_ENABLE_LIBEDIT;LLDB_DISABLE_LIBEDIT; \
 #
 # Default to build all OE-Core supported target arches (user overridable).
 #
-LLVM_TARGETS_TO_BUILD ?= "AArch64;ARM;BPF;Mips;PowerPC;RISCV;X86"
+LLVM_TARGETS_TO_BUILD ?= "AMDGPU;AArch64;ARM;BPF;Mips;PowerPC;RISCV;X86"
 LLVM_TARGETS_TO_BUILD_append = ";${@get_clang_host_arch(bb, d)};${@get_clang_target_arch(bb, d)}"
 
-LLVM_TARGETS_TO_BUILD_TARGET ?= "AMDGPU;${LLVM_TARGETS_TO_BUILD}"
+LLVM_TARGETS_TO_BUILD_TARGET ?= "${LLVM_TARGETS_TO_BUILD}"
 LLVM_TARGETS_TO_BUILD_TARGET_append ?= ";${@get_clang_target_arch(bb, d)}"
 
 LLVM_EXPERIMENTAL_TARGETS_TO_BUILD ?= ""


### PR DESCRIPTION
In 003dd05e4c168f7c3cccb9cbfad3fd8f38fe8741, clang replaced the oe-core
provided llvm for building mesa.  However, mesa needs AMDGPU to be
enabled on the native target in order to build.  Following the example
of oe-core's recipe, just enable AMDGPU for all targets.

Signed-off-by: Justin Bronder <jsbronder@cold-front.org>
Signed-off-by: Khem Raj <raj.khem@gmail.com>