### PR TITLE
packagegroup: be lenient about CLANGSDK setting

### DIFF
--- a/recipes-core/packagegroups/nativesdk-packagegroup-sdk-host.bbappend
+++ b/recipes-core/packagegroups/nativesdk-packagegroup-sdk-host.bbappend
@@ -1,1 +1,1 @@
-RDEPENDS_${PN} += "${@'nativesdk-clang' if '${CLANGSDK}' else ''}"
+RDEPENDS_${PN} += "${@bb.utils.contains('CLANGSDK', '1', 'nativesdk-clang', '', d)}"

--- a/recipes-core/packagegroups/packagegroup-core-standalone-sdk-target.bbappend
+++ b/recipes-core/packagegroups/packagegroup-core-standalone-sdk-target.bbappend
@@ -1,1 +1,1 @@
-RRECOMMENDS_${PN} += "${@'libcxx-dev libcxx-staticdev compiler-rt-dev compiler-rt-staticdev' if '${CLANGSDK}' else ''}"
+RRECOMMENDS_${PN} += "${@bb.utils.contains('CLANGSDK', '1', 'libcxx-dev libcxx-staticdev compiler-rt-dev compiler-rt-staticdev', '', d)}"


### PR DESCRIPTION
As CLANGSDK defaults to '1', users who have not read the README may
think that setting it to '0' would disable adding Clang to the SDK.
Little do they know that you need to *unset* the value for this to work
(as bool('0') -> True).

Change the logic to use bb.utils.contains(), so that '0' is not true.

Signed-off-by: Ross Burton <ross.burton@intel.com>