### PR TITLE
clang: Use cmake variable for libdl

### DIFF
--- a/recipes-devtools/clang/clang/0026-libclang-Use-CMAKE_DL_LIBS-for-deducing-libdl.patch
+++ b/recipes-devtools/clang/clang/0026-libclang-Use-CMAKE_DL_LIBS-for-deducing-libdl.patch
@@ -1,0 +1,33 @@
+From 9c37e644d96de108d931a6bcce1819a666ae91d8 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Wed, 11 Dec 2019 10:23:15 -0800
+Subject: [PATCH] libclang: Use CMAKE_DL_LIBS for deducing libdl
+
+This helps in getting right settings for libdl irrespective of platform
+it also fixes build with -DLLVM_BUILD_LLVM_DYLIB=ON -DLLVM_LINK_LLVM_DYLIB=ON
+
+Fixes
+
+tools/clang/tools/libclang/CMakeFiles/libclang.dir/CIndexer.cpp.o: In function clang::CIndexer::getClangResourcesPath[abi:cxx11]()': 2019-12-06T06:04:39.2987601Z | CIndexer.cpp:(.text._ZN5clang8CIndexer21getClangResourcesPathB5cxx11Ev+0x8b): undefined reference to dladdr'
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ clang/tools/libclang/CMakeLists.txt | 5 ++---
+ 1 file changed, 2 insertions(+), 3 deletions(-)
+
+diff --git a/clang/tools/libclang/CMakeLists.txt b/clang/tools/libclang/CMakeLists.txt
+index 613ead1a36b..9d5cd0ba9df 100644
+--- a/clang/tools/libclang/CMakeLists.txt
++++ b/clang/tools/libclang/CMakeLists.txt
+@@ -58,9 +58,8 @@ if (TARGET clangTidyPlugin)
+   endif()
+ endif ()
+ 
+-find_library(DL_LIBRARY_PATH dl)
+-if (DL_LIBRARY_PATH)
+-  list(APPEND LIBS dl)
++if (HAVE_LIBDL)
++  list(APPEND LIBS ${CMAKE_DL_LIBS})
+ endif()
+ 
+ option(LIBCLANG_BUILD_STATIC

--- a/recipes-devtools/clang/common.inc
+++ b/recipes-devtools/clang/common.inc
@@ -33,6 +33,7 @@ SRC_URI = "\
     file://0023-openmp-Recognise-ARMv7ve-machine-arch.patch \
     file://0024-Check-for-atomic-double-intrinsics.patch \
     file://0025-llvm-Let-llvm-ar-name-contain-lib.patch \
+    file://0026-libclang-Use-CMAKE_DL_LIBS-for-deducing-libdl.patch \
 "
 
 # Fallback to no-PIE if not set


### PR DESCRIPTION
This ensures that clang can link with libdl on platforms where needed

Fixes issue #241

Signed-off-by: Khem Raj <raj.khem@gmail.com>