### PR TITLE
hdf5: Use gcc on musl/x86_64

### DIFF
--- a/conf/nonclangable.conf
+++ b/conf/nonclangable.conf
@@ -17,6 +17,14 @@ TOOLCHAIN_pn-glibc-scripts = "gcc"
 TOOLCHAIN_pn-glibc-testsuite = "gcc"
 TOOLCHAIN_pn-grub = "gcc"
 TOOLCHAIN_pn-grub-efi = "gcc"
+
+# Clang crashes on musl/x86_64
+# Running pass 'Function Pass Manager' on module '/mnt/b/yoe/build/tmp/work/core2-64-
+# yoe-linux-musl/hdf5/1.8.21-r0/hdf5-1.8.21/src/H5detect.c'.
+# Running pass 'X86 Assembly Printer' on function '@detect_C99_floats'
+# clang-9: error: unable to execute command: Segmentation fault (core dumped)
+TOOLCHAIN_pn-hdf5_libc-musl_x86-64 = "gcc"
+
 # VLAs
 #| control.c:286:19: error: fields must have a constant size: 'variable length array in structure' extension will never be supported
 #|             __u32 buffer[cam->max_response_quads];


### PR DESCRIPTION
clang crashes for some reason

Signed-off-by: Khem Raj <raj.khem@gmail.com>