### PR TITLE
libexecinfo,openflow: Use gcc on mips

### DIFF
--- a/conf/nonclangable.conf
+++ b/conf/nonclangable.conf
@@ -31,6 +31,9 @@ TOOLCHAIN_pn-hdf5_libc-musl_x86-64 = "gcc"
 #|                   ^
 #| 1 error generated.
 TOOLCHAIN_pn-libdc1394 = "gcc"
+
+# error: return address can be determined only for current frame
+TOOLCHAIN_pn-libexecinfo_mipsarch = "gcc"
 TOOLCHAIN_pn-libgcc = "gcc"
 TOOLCHAIN_pn-libgcc-initial = "gcc"
 TOOLCHAIN_pn-libgfortran = "gcc"
@@ -50,6 +53,8 @@ TOOLCHAIN_pn-mesa_powerpc = "gcc"
 TOOLCHAIN_pn-mongodb = "gcc"
 # variant-impl.hpp:309:36: error: 'is_variant' does not name a template but is followed by template arguments
 TOOLCHAIN_pn-omxplayer = "gcc"
+# error: return address can be determined only for current frame
+TOOLCHAIN_pn-openflow_mipsarch = "gcc"
 TOOLCHAIN_pn-opensbi = "gcc"
 TOOLCHAIN_pn-openjdk-8 = "gcc"
 TOOLCHAIN_pn-openjre-8 = "gcc"


### PR DESCRIPTION
Fails with error on clang
error: return address can be determined only for current frame

Signed-off-by: Khem Raj <raj.khem@gmail.com>