### PR TITLE
Support multiarch Yocto environment on warrior

### DIFF
--- a/recipes-devtools/clang/clang.inc
+++ b/recipes-devtools/clang/clang.inc
@@ -18,4 +18,22 @@ CLANGMD5SUM = "9a0fe3a7846ba0ffc822a70d6f7f6903"
 LLDMD5SUM = "f4941ace8ddb3d6cf177fff94966319a"
 LLDBMD5SUM = "b6320ed0b0d00ae661dd94f277bbf024"
 
+def get_libdir_suffix(d, arch_var):
+    import re
+    multilibs = (d.getVar("MULTILIB_VARIANTS") or "").split()
+    if multilibs:
+        a = d.getVar(arch_var, True)
+        if   re.match('(i.86|athlon)$', a):          return '32'
+        elif re.match('x86.64$', a):                 return '64'
+        elif re.match('(arm|armbe)$', a):            return '32'
+        elif re.match('(aarch64|aarch64_be)$', a):   return '64'
+        elif re.match('mips(isa|)32(r6|)(el|)$', a): return '32'
+        elif re.match('mips(isa|)64(r6|)(el|)$', a): return '64'
+        elif re.match('p(pc|owerpc)', a):            return '32'
+        elif re.match('p(pc|owerpc)64', a):          return '64'
+    else:
+        return ''
+
+LLVM_LIBDIR_SUFFIX="${@get_libdir_suffix(d, 'TARGET_ARCH')}"
+
 require common.inc

--- a/recipes-devtools/clang/compiler-rt_git.bb
+++ b/recipes-devtools/clang/compiler-rt_git.bb
@@ -35,6 +35,7 @@ EXTRA_OECMAKE += "-DCOMPILER_RT_STANDALONE_BUILD=OFF \
                   -DCMAKE_RANLIB=${STAGING_BINDIR_TOOLCHAIN}/${TARGET_PREFIX}llvm-ranlib \
                   -DCMAKE_AR=${STAGING_BINDIR_TOOLCHAIN}/${TARGET_PREFIX}llvm-ar \
                   -DCMAKE_NM=${STAGING_BINDIR_TOOLCHAIN}/${TARGET_PREFIX}llvm-nm \
+                  -DLLVM_LIBDIR_SUFFIX=${LLVM_LIBDIR_SUFFIX} \
                   -G Ninja ${S}/llvm \
 "
 

--- a/recipes-devtools/clang/libcxx_git.bb
+++ b/recipes-devtools/clang/libcxx_git.bb
@@ -40,11 +40,12 @@ EXTRA_OECMAKE += "\
                   -DCXX_SUPPORTS_CXX11=ON \
                   -DLIBCXXABI_LIBCXX_INCLUDES=${S}/libcxx/include \
                   -DLIBCXX_CXX_ABI_INCLUDE_PATHS=${S}/libcxxabi/include \
-                  -DLIBCXX_CXX_ABI_LIBRARY_PATH=${B}/lib \
+                  -DLIBCXX_CXX_ABI_LIBRARY_PATH=${B}/${base_libdir} \
                   -DCMAKE_AR=${STAGING_BINDIR_TOOLCHAIN}/${TARGET_PREFIX}llvm-ar \
                   -DCMAKE_NM=${STAGING_BINDIR_TOOLCHAIN}/${TARGET_PREFIX}llvm-nm \
                   -DCMAKE_RANLIB=${STAGING_BINDIR_TOOLCHAIN}/${TARGET_PREFIX}llvm-ranlib \
                   -DLLVM_ENABLE_PROJECTS='libcxx;libcxxabi${LIBUNWIND}' \
+                  -DLLVM_LIBDIR_SUFFIX=${LLVM_LIBDIR_SUFFIX} \
                   -G Ninja \
                   ${S}/llvm \
 "


### PR DESCRIPTION
Our Yocto SDK is not compatible for zeus/master.
I created a PR for warrior branch.
But this PR is not still full covered for #247 issue.
This PR prevents QA error on multiarch environment.

Co-authored-by: INAJIMA Daisuke <inajima@soum.co.jp>