### PR TITLE
cpio: Link with compiler-rt when using clang

### DIFF
--- a/conf/nonclangable.conf
+++ b/conf/nonclangable.conf
@@ -222,6 +222,7 @@ TUNE_CCARGS_remove_pn-omxplayer_toolchain-clang = "-no-integrated-as"
 #| clang-7: error: linker command failed with exit code 1 (use -v to see invocation)
 COMPILER_RT_pn-ruby_toolchain-clang = "--rtlib=compiler-rt ${UNWINDLIB}"
 COMPILER_RT_pn-m4_toolchain-clang = "--rtlib=compiler-rt ${UNWINDLIB}"
+COMPILER_RT_pn-cpio_toolchain-clang = "--rtlib=compiler-rt ${UNWINDLIB}"
 COMPILER_RT_pn-webkitgtk_toolchain-clang = "--rtlib=compiler-rt ${UNWINDLIB}"
 COMPILER_RT_remove_pn-m4_powerpc = "--rtlib=compiler-rt"
 COMPILER_RT_remove_pn-ruby_powerpc = "--rtlib=compiler-rt"


### PR DESCRIPTION
Fixes
/usr/src/debug/cpio/2.13-r0/build/gnu/../../cpio-2.13/gnu/xmalloc.c:100: undefined reference to `__mulodi4'
clang-9: error: linker command failed with exit code 1 (use -v to see invocation)
Makefile:1124: recipe for target 'rmt' failed

Signed-off-by: Khem Raj <raj.khem@gmail.com>