### PR TITLE
Compute llvm libdir suffix on multiarch

### DIFF
--- a/recipes-devtools/clang/clang.inc
+++ b/recipes-devtools/clang/clang.inc
@@ -18,4 +18,22 @@ CLANGMD5SUM = "ff42885ed2ab98f1ecb8c1fc41205343"
 LLDMD5SUM = "ae7dc7c027b1fa89b5b013d391d3ee2b"
 LLDBMD5SUM = "2e0d44968471fcde980034dbb826bea9"
 
+def get_libdir_suffix(d, arch_var):
+    import re
+    multilibs = (d.getVar("MULTILIB_VARIANTS") or "").split()
+    if multilibs:
+        a = d.getVar(arch_var, True)
+        if   re.match('(i.86|athlon)$', a):          return '32'
+        elif re.match('x86.64$', a):                 return '64'
+        elif re.match('(arm|armbe)$', a):            return '32'
+        elif re.match('(aarch64|aarch64_be)$', a):   return '64'
+        elif re.match('mips(isa|)32(r6|)(el|)$', a): return '32'
+        elif re.match('mips(isa|)64(r6|)(el|)$', a): return '64'
+        elif re.match('p(pc|owerpc)', a):            return '32'
+        elif re.match('p(pc|owerpc)64', a):          return '64'
+    else:
+        return ''
+
+LLVM_LIBDIR_SUFFIX="${@get_libdir_suffix(d, 'TARGET_ARCH')}"
+
 require common.inc

--- a/recipes-devtools/clang/compiler-rt_git.bb
+++ b/recipes-devtools/clang/compiler-rt_git.bb
@@ -31,6 +31,7 @@ EXTRA_OECMAKE += "-DCOMPILER_RT_STANDALONE_BUILD=OFF \
                   -DCMAKE_RANLIB=${STAGING_BINDIR_TOOLCHAIN}/${TARGET_PREFIX}llvm-ranlib \
                   -DCMAKE_AR=${STAGING_BINDIR_TOOLCHAIN}/${TARGET_PREFIX}llvm-ar \
                   -DCMAKE_NM=${STAGING_BINDIR_TOOLCHAIN}/${TARGET_PREFIX}llvm-nm \
+                  -DLLVM_LIBDIR_SUFFIX=${LLVM_LIBDIR_SUFFIX} \
                   -G Ninja ${S}/llvm \
 "
 

--- a/recipes-devtools/clang/compiler-rt_git.bb
+++ b/recipes-devtools/clang/compiler-rt_git.bb
@@ -76,12 +76,12 @@ sysroot_stage_all_append_class-target() {
 }
 
 FILES_SOLIBSDEV = ""
-FILES_${PN} += "${exec_prefix}/lib/clang/${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}/lib/linux/lib*${SOLIBSDEV} \
-                ${exec_prefix}/lib/clang/${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}/*.txt \
-                ${exec_prefix}/lib/clang/${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}/share/*.txt"
-FILES_${PN}-staticdev += "${exec_prefix}/lib/clang/${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}/lib/linux/*.a"
-FILES_${PN}-dev += "${datadir} ${exec_prefix}/lib/clang/${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}/lib/linux/*.syms \
-                    ${exec_prefix}/lib/clang/${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}/lib/linux/clang_rt.crt*.o \
+FILES_${PN} += "${exec_prefix}/lib${LLVM_LIBDIR_SUFFIX}/clang/${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}/lib/linux/lib*${SOLIBSDEV} \
+                ${exec_prefix}/lib${LLVM_LIBDIR_SUFFIX}/clang/${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}/*.txt \
+                ${exec_prefix}/lib${LLVM_LIBDIR_SUFFIX}/clang/${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}/share/*.txt"
+FILES_${PN}-staticdev += "${exec_prefix}/lib${LLVM_LIBDIR_SUFFIX}/clang/${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}/lib/linux/*.a"
+FILES_${PN}-dev += "${datadir} ${exec_prefix}/lib${LLVM_LIBDIR_SUFFIX}/clang/${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}/lib/linux/*.syms \
+                    ${exec_prefix}/lib${LLVM_LIBDIR_SUFFIX}/clang/${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}/lib/linux/clang_rt.crt*.o \
                    "
 INSANE_SKIP_${PN} = "dev-so libdir"
 

--- a/recipes-devtools/clang/libcxx_git.bb
+++ b/recipes-devtools/clang/libcxx_git.bb
@@ -51,7 +51,7 @@ EXTRA_OECMAKE += "\
                   -DCMAKE_NM=${STAGING_BINDIR_TOOLCHAIN}/${NM} \
                   -DCMAKE_RANLIB=${STAGING_BINDIR_TOOLCHAIN}/${RANLIB} \
                   -DLLVM_ENABLE_PROJECTS='libcxx;libcxxabi;libunwind' \
-                  -DLLVM_LIBDIR_SUFFIX=${@d.getVar('baselib').replace('lib', '')} \
+                  -DLLVM_LIBDIR_SUFFIX=${LLVM_LIBDIR_SUFFIX} \
                   -G Ninja \
                   ${S}/llvm \
 "


### PR DESCRIPTION
This PR is uplift to master branch for #251.

Tested on raspberry3-64 multiarch image on Yocto master with the following additional config:

```
require conf/multilib.conf
MULTILIBS = "multilib:lib32"
DEFAULTTUNE_virtclass-multilib-lib32 = "armv7athf-neon
```