### PR TITLE
openmp: Mark mips64 unsupported host

### DIFF
--- a/recipes-devtools/clang/openmp_git.bb
+++ b/recipes-devtools/clang/openmp_git.bb
@@ -35,3 +35,4 @@ INSANE_SKIP_${PN} = "dev-so"
 
 COMPATIBLE_HOST_riscv64 = "null"
 COMPATIBLE_HOST_riscv32 = "null"
+COMPATIBLE_HOST_mips64 = "null"


### PR DESCRIPTION
Fixes
error Unknown or unsupported architecture

Signed-off-by: Khem Raj <raj.khem@gmail.com>