### PR TITLE
nfs-utils: Enable unknown-warnings as errors

### DIFF
--- a/conf/nonclangable.conf
+++ b/conf/nonclangable.conf
@@ -217,6 +217,8 @@ CPPFLAGS_append_pn-memcached_toolchain-clang = " -Wno-error=embedded-directive"
 #| clang-7: error: assembler command failed with exit code 1 (use -v to see invocation)
 TUNE_CCARGS_remove_pn-upm_toolchain-clang = "-no-integrated-as"
 TUNE_CCARGS_remove_pn-omxplayer_toolchain-clang = "-no-integrated-as"
+TUNE_CCARGS_remove_pn-nfs-utils_toolchain-clang = "-Wno-error=unused-command-line-argument -Qunused-arguments"
+TUNE_CCARGS_append_pn-nfs-utils_toolchain-clang = " -Werror=unknown-warning-option"
 
 #| /usr/src/debug/ruby/2.5.1-r0/build/../ruby-2.5.1/process.c:7073: undefined reference to `__mulodi4'
 #| clang-7: error: linker command failed with exit code 1 (use -v to see invocation)


### PR DESCRIPTION
This helps configure scripts to detect right set of
compiler specific options to enable

Signed-off-by: Khem Raj <raj.khem@gmail.com>