### PR TITLE
clang: Use git suffix instead of svn

### DIFF
--- a/recipes-devtools/clang/clang_git.bb
+++ b/recipes-devtools/clang/clang_git.bb
@@ -229,10 +229,11 @@ FILES_${PN} += "\
   ${datadir}/opt-viewer/ \
 "
 
-FILES_${PN}-libllvm += "\
+FILES_${PN}-libllvm =+ "\
   ${libdir}/libLLVM-${MAJOR_VER}.${MINOR_VER}.so \
   ${libdir}/libLLVM-${MAJOR_VER}.so \
-  ${libdir}/libLLVM-${MAJOR_VER}.${MINOR_VER}svn.so \
+  ${libdir}/libLLVM-${MAJOR_VER}git.so \
+  ${libdir}/libLLVM-${MAJOR_VER}.${MINOR_VER}git.so \
 "
 
 FILES_libclang = "\


### PR DESCRIPTION
src uri has long moved to git, and that is also being used as solib suffix

Fixes packaging errors
ERROR: clang-10.0.0-r0 do_package_qa: QA Issue: libclang rdepends on clang-dev [dev-deps]
ERROR: clang-10.0.0-r0 do_package_qa: QA Issue: clang rdepends on clang-dev [dev-deps]

Signed-off-by: Khem Raj <raj.khem@gmail.com>