### PR TITLE
mesa: Clang can compile it on mips

### DIFF
--- a/conf/nonclangable.conf
+++ b/conf/nonclangable.conf
@@ -25,6 +25,11 @@ TOOLCHAIN_pn-grub-efi = "gcc"
 # clang-9: error: unable to execute command: Segmentation fault (core dumped)
 TOOLCHAIN_pn-hdf5_libc-musl_x86-64 = "gcc"
 
+#| prelink-rtld: error while loading shared libraries: ld.so.1
+#| /lib64/ld.so.1: No such file or directory
+TOOLCHAIN_pn-gobject-intospection_mips64 = "gcc"
+TOOLCHAIN_pn-avahi_mips64 = "gcc"
+
 # VLAs
 #| control.c:286:19: error: fields must have a constant size: 'variable length array in structure' extension will never be supported
 #|             __u32 buffer[cam->max_response_quads];
@@ -45,8 +50,8 @@ TOOLCHAIN_pn-libssp-nonshared = "gcc"
 TOOLCHAIN_pn-libstd-rs = "gcc"
 TOOLCHAIN_pn-m4_powerpc = "gcc"
 # clang does not have 64bit atomics on mips32
-TOOLCHAIN_pn-mesa_mips = "gcc"
-TOOLCHAIN_pn-mesa_mipsel = "gcc"
+#TOOLCHAIN_pn-mesa_mips = "gcc"
+#TOOLCHAIN_pn-mesa_mipsel = "gcc"
 TOOLCHAIN_pn-mesa_riscv64 = "gcc"
 TOOLCHAIN_pn-mesa_powerpc = "gcc"
 # multiple definition of 'mongo::error_details::isNamedCode<0>'


### PR DESCRIPTION
gobject-intospection and avahi do not yet prelink with clang/mips64

Signed-off-by: Khem Raj <raj.khem@gmail.com>