### PR TITLE
libcxx: Correct link failure due to missing __divti3

### DIFF
--- a/recipes-devtools/clang/clang/0028-Add-libgcc-to-link-step-for-libcxx.patch
+++ b/recipes-devtools/clang/clang/0028-Add-libgcc-to-link-step-for-libcxx.patch
@@ -1,0 +1,30 @@
+From 397bd558b83ce7ff3ea69c1c8fb6f36c624b9ca6 Mon Sep 17 00:00:00 2001
+From: Jeremy Puhlman <jpuhlman@mvista.com>
+Date: Thu, 16 Jan 2020 21:16:10 +0000
+Subject: [PATCH] Add libgcc to link step for libcxx
+
+This corrects "undefined reference to __divti3"
+
+Upstream-Status: Inappropriate [configuration]
+
+Signed-off-by: Jeremy Puhlman <jpuhlman@mvista.com>
+---
+ libcxx/src/CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/libcxx/src/CMakeLists.txt b/libcxx/src/CMakeLists.txt
+index 31cd24333a5..d8ae826d7f5 100644
+--- a/libcxx/src/CMakeLists.txt
++++ b/libcxx/src/CMakeLists.txt
+@@ -234,7 +234,7 @@ if (LIBCXX_ENABLE_SHARED)
+     llvm_setup_rpath(cxx_shared)
+   endif()
+   cxx_link_system_libraries(cxx_shared)
+-  target_link_libraries(cxx_shared PRIVATE ${LIBCXX_LIBRARIES})
++  target_link_libraries(cxx_shared PRIVATE ${LIBCXX_LIBRARIES} "$$($$CC --print-libgcc-file-name)")
+   set_target_properties(cxx_shared
+     PROPERTIES
+       COMPILE_FLAGS "${LIBCXX_COMPILE_FLAGS}"
+-- 
+2.13.3
+

--- a/recipes-devtools/clang/common.inc
+++ b/recipes-devtools/clang/common.inc
@@ -35,6 +35,7 @@ SRC_URI = "\
     file://0025-llvm-Let-llvm-ar-name-contain-lib.patch \
     file://0026-libclang-Use-CMAKE_DL_LIBS-for-deducing-libdl.patch \
     file://0027-Fix-sanitizer-common-build-with-glibc-2.31.patch \
+    file://0028-Add-libgcc-to-link-step-for-libcxx.patch \
 "
 
 # Fallback to no-PIE if not set


### PR DESCRIPTION
Add libgcc as defined by $CC to link of libc++.

Signed-off-by: Jeremy Puhlman <jpuhlman@mvista.com>