### PR TITLE
Use simplier libdir suffix computation

### DIFF
--- a/recipes-devtools/clang/clang.inc
+++ b/recipes-devtools/clang/clang.inc
@@ -18,22 +18,6 @@ CLANGMD5SUM = "ff42885ed2ab98f1ecb8c1fc41205343"
 LLDMD5SUM = "ae7dc7c027b1fa89b5b013d391d3ee2b"
 LLDBMD5SUM = "2e0d44968471fcde980034dbb826bea9"
 
-def get_libdir_suffix(d, arch_var):
-    import re
-    multilibs = (d.getVar("MULTILIB_VARIANTS") or "").split()
-    if multilibs:
-        a = d.getVar(arch_var, True)
-        if   re.match('(i.86|athlon)$', a):          return '32'
-        elif re.match('x86.64$', a):                 return '64'
-        elif re.match('(arm|armbe)$', a):            return '32'
-        elif re.match('(aarch64|aarch64_be)$', a):   return '64'
-        elif re.match('mips(isa|)32(r6|)(el|)$', a): return '32'
-        elif re.match('mips(isa|)64(r6|)(el|)$', a): return '64'
-        elif re.match('p(pc|owerpc)', a):            return '32'
-        elif re.match('p(pc|owerpc)64', a):          return '64'
-    else:
-        return ''
-
-LLVM_LIBDIR_SUFFIX="${@get_libdir_suffix(d, 'TARGET_ARCH')}"
+LLVM_LIBDIR_SUFFIX="${@d.getVar('baselib').replace('lib', '')}"
 
 require common.inc


### PR DESCRIPTION
An earlier commit added a suffix table to determine the libdir suffix
for multilib targets. This table failed at least in the lib32 case for
x86, where the suffix should have been '', but was instead '32'.

Use the same method as the cmake bbclass instead.

Signed-off-by: Daniel McGregor <daniel.mcgregor@vecima.com>