### PR TITLE
clang,llvm: cmake: Fix configure for packages using find_package() 

### DIFF
--- a/recipes-devtools/clang/clang/0029-clang-llvm-cmake-Fix-configure-for-packages-using-fi.patch
+++ b/recipes-devtools/clang/clang/0029-clang-llvm-cmake-Fix-configure-for-packages-using-fi.patch
@@ -1,0 +1,138 @@
+From b79837a3b7aa677b44110de4e9e7576fa34a96e3 Mon Sep 17 00:00:00 2001
+From: Ovidiu Panait <ovidiu.panait@windriver.com>
+Date: Fri, 31 Jan 2020 10:56:11 +0200
+Subject: [PATCH] clang,llvm: cmake: Fix configure for packages using
+ find_package()
+
+Currently, when a package (i.e. bcc [https://github.com/iovisor/bcc.git])
+that depends on LLVM/Clang tries to run cmake find_package() during
+do_configure, it will fail with a similar error:
+
+|   The imported target "llvm-tblgen" references the file
+|      ".../recipe-sysroot/usr/bin/llvm-tblgen"
+|
+|   but this file does not exist.  Possible reasons include:
+|   * The file was deleted, renamed, or moved to another location.
+|   * An install or uninstall procedure did not complete successfully.
+|   * The installation package was faulty and contained
+|      ".../recipe-sysroot/usr/lib/cmake/LLVMExports.cmake"
+|   but not all the files it references.
+
+This is due to the fact that currently the cmake scripts look for target
+binaries in sysroot. Work around this by not exporting the target binaries in
+Exports-* cmake files.
+
+Upstream-Status: Innapropriate [oe-specific]
+
+Signed-off-by: Ovidiu Panait <ovidiu.panait@windriver.com>
+---
+ clang/cmake/modules/AddClang.cmake |  9 ---------
+ llvm/cmake/modules/AddLLVM.cmake   | 20 --------------------
+ llvm/cmake/modules/TableGen.cmake  |  8 --------
+ 3 files changed, 37 deletions(-)
+
+diff --git a/clang/cmake/modules/AddClang.cmake b/clang/cmake/modules/AddClang.cmake
+index cbd618e18af..b864c2b2303 100644
+--- a/clang/cmake/modules/AddClang.cmake
++++ b/clang/cmake/modules/AddClang.cmake
+@@ -146,15 +146,7 @@ macro(add_clang_tool name)
+   add_dependencies(${name} clang-resource-headers)
+ 
+   if (CLANG_BUILD_TOOLS)
+-    set(export_to_clangtargets)
+-    if(${name} IN_LIST LLVM_DISTRIBUTION_COMPONENTS OR
+-        NOT LLVM_DISTRIBUTION_COMPONENTS)
+-      set(export_to_clangtargets EXPORT ClangTargets)
+-      set_property(GLOBAL PROPERTY CLANG_HAS_EXPORTS True)
+-    endif()
+-
+     install(TARGETS ${name}
+-      ${export_to_clangtargets}
+       RUNTIME DESTINATION bin
+       COMPONENT ${name})
+ 
+@@ -163,7 +155,6 @@ macro(add_clang_tool name)
+                                DEPENDS ${name}
+                                COMPONENT ${name})
+     endif()
+-    set_property(GLOBAL APPEND PROPERTY CLANG_EXPORTS ${name})
+   endif()
+ endmacro()
+ 
+diff --git a/llvm/cmake/modules/AddLLVM.cmake b/llvm/cmake/modules/AddLLVM.cmake
+index 619e986b8aa..ab4b2234fa5 100644
+--- a/llvm/cmake/modules/AddLLVM.cmake
++++ b/llvm/cmake/modules/AddLLVM.cmake
+@@ -898,15 +898,7 @@ macro(add_llvm_tool name)
+ 
+   if ( ${name} IN_LIST LLVM_TOOLCHAIN_TOOLS OR NOT LLVM_INSTALL_TOOLCHAIN_ONLY)
+     if( LLVM_BUILD_TOOLS )
+-      set(export_to_llvmexports)
+-      if(${name} IN_LIST LLVM_DISTRIBUTION_COMPONENTS OR
+-          NOT LLVM_DISTRIBUTION_COMPONENTS)
+-        set(export_to_llvmexports EXPORT LLVMExports)
+-        set_property(GLOBAL PROPERTY LLVM_HAS_EXPORTS True)
+-      endif()
+-
+       install(TARGETS ${name}
+-              ${export_to_llvmexports}
+               RUNTIME DESTINATION ${LLVM_TOOLS_INSTALL_DIR}
+               COMPONENT ${name})
+ 
+@@ -917,9 +909,6 @@ macro(add_llvm_tool name)
+       endif()
+     endif()
+   endif()
+-  if( LLVM_BUILD_TOOLS )
+-    set_property(GLOBAL APPEND PROPERTY LLVM_EXPORTS ${name})
+-  endif()
+   set_target_properties(${name} PROPERTIES FOLDER "Tools")
+ endmacro(add_llvm_tool name)
+ 
+@@ -946,15 +935,7 @@ macro(add_llvm_utility name)
+   set_target_properties(${name} PROPERTIES FOLDER "Utils")
+   if (NOT LLVM_INSTALL_TOOLCHAIN_ONLY)
+     if (LLVM_INSTALL_UTILS AND LLVM_BUILD_UTILS)
+-      set(export_to_llvmexports)
+-      if (${name} IN_LIST LLVM_DISTRIBUTION_COMPONENTS OR
+-          NOT LLVM_DISTRIBUTION_COMPONENTS)
+-        set(export_to_llvmexports EXPORT LLVMExports)
+-        set_property(GLOBAL PROPERTY LLVM_HAS_EXPORTS True)
+-      endif()
+-
+       install(TARGETS ${name}
+-              ${export_to_llvmexports}
+               RUNTIME DESTINATION ${LLVM_UTILS_INSTALL_DIR}
+               COMPONENT ${name})
+ 
+@@ -963,7 +944,6 @@ macro(add_llvm_utility name)
+                                  DEPENDS ${name}
+                                  COMPONENT ${name})
+       endif()
+-      set_property(GLOBAL APPEND PROPERTY LLVM_EXPORTS ${name})
+     elseif(LLVM_BUILD_UTILS)
+       set_property(GLOBAL APPEND PROPERTY LLVM_EXPORTS_BUILDTREE_ONLY ${name})
+     endif()
+diff --git a/llvm/cmake/modules/TableGen.cmake b/llvm/cmake/modules/TableGen.cmake
+index 36c026b5c0f..c588ce6e38b 100644
+--- a/llvm/cmake/modules/TableGen.cmake
++++ b/llvm/cmake/modules/TableGen.cmake
+@@ -148,15 +148,7 @@ macro(add_tablegen target project)
+   endif()
+ 
+   if (${project} STREQUAL LLVM AND NOT LLVM_INSTALL_TOOLCHAIN_ONLY AND LLVM_BUILD_UTILS)
+-    set(export_to_llvmexports)
+-    if(${target} IN_LIST LLVM_DISTRIBUTION_COMPONENTS OR
+-        NOT LLVM_DISTRIBUTION_COMPONENTS)
+-      set(export_to_llvmexports EXPORT LLVMExports)
+-    endif()
+-
+     install(TARGETS ${target}
+-            ${export_to_llvmexports}
+             RUNTIME DESTINATION ${LLVM_TOOLS_INSTALL_DIR})
+   endif()
+-  set_property(GLOBAL APPEND PROPERTY LLVM_EXPORTS ${target})
+ endmacro()
+-- 
+2.17.1
+

--- a/recipes-devtools/clang/common.inc
+++ b/recipes-devtools/clang/common.inc
@@ -36,6 +36,7 @@ SRC_URI = "\
     file://0026-libclang-Use-CMAKE_DL_LIBS-for-deducing-libdl.patch \
     file://0027-Fix-sanitizer-common-build-with-glibc-2.31.patch \
     file://0028-Add-libgcc-to-link-step-for-libcxx.patch \
+    file://0029-clang-llvm-cmake-Fix-configure-for-packages-using-fi.patch \
 "
 
 # Fallback to no-PIE if not set


### PR DESCRIPTION
Currently, when a package (i.e. bcc [https://github.com/iovisor/bcc.git])
that depends on LLVM tries to run find_package(LLVM) during do_configure,
it will fail with the following error:

|   The imported target "llvm-tblgen" references the file
|      ".../recipe-sysroot/usr/bin/llvm-tblgen"
|
|   but this file does not exist.  Possible reasons include:
|   * The file was deleted, renamed, or moved to another location.
|   * An install or uninstall procedure did not complete successfully.
|   * The installation package was faulty and contained
|      ".../recipe-sysroot/usr/lib/cmake/LLVMExports.cmake"
|   but not all the files it references.

This is due to the fact that LLVM target binaries will not be present in the
sysroot, only the libraries will. Work around this by not exporting the LLVM
target binaries in LLVMExports cmake files.

Signed-off-by: Ovidiu Panait <ovidiu.panait@windriver.com>