### PR TITLE
gcr: Do not disable gobject-introspection

### DIFF
--- a/recipes-gnome/gcr/gcr_%.bbappend
+++ b/recipes-gnome/gcr/gcr_%.bbappend
@@ -1,4 +1,0 @@
-# qemu crashes when built with hardening flags
-#
-GI_DATA_ENABLED_toolchain-clang = "False"
-


### PR DESCRIPTION
QEMU crash has fixed itself overtime now.

Signed-off-by: Khem Raj <raj.khem@gmail.com>