### PR TITLE
[zeus] conf/nonclangable.conf: Always build mesa with gcc

### DIFF
--- a/conf/nonclangable.conf
+++ b/conf/nonclangable.conf
@@ -45,10 +45,9 @@ TOOLCHAIN_pn-libssp-nonshared = "gcc"
 TOOLCHAIN_pn-libstd-rs = "gcc"
 TOOLCHAIN_pn-m4_powerpc = "gcc"
 # clang does not have 64bit atomics on mips32
-TOOLCHAIN_pn-mesa_mips = "gcc"
-TOOLCHAIN_pn-mesa_mipsel = "gcc"
-TOOLCHAIN_pn-mesa_riscv64 = "gcc"
-TOOLCHAIN_pn-mesa_powerpc = "gcc"
+# building Mesa 19.3.x with clang causes linker errors on x86/x86-64
+# See https://gitlab.freedesktop.org/mesa/mesa/issues/2533
+TOOLCHAIN_pn-mesa = "gcc"
 # multiple definition of 'mongo::error_details::isNamedCode<0>'
 TOOLCHAIN_pn-mongodb = "gcc"
 # variant-impl.hpp:309:36: error: 'is_variant' does not name a template but is followed by template arguments


### PR DESCRIPTION
Building mesa (at least version 19.3.4) with clang 9.0.1 leads
to linker errors on x86/x86-64:

"undefined reference to `typeinfo for llvm::raw_pwrite_stream'"
in libvulkan_radeon.so

and

"undefined reference to `typeinfo for llvm::RTDyldMemoryManager'"
in libgallium.a.

It was reported at https://gitlab.freedesktop.org/mesa/mesa/issues/2533

It seems it is related to rtti not being enabled, at least reports
from a few years ago on forums lead to that conclusion.
But enabling rtti for clang in PACKAGECONFIG doesn't help.

Just build mesa with gcc, it fixes the linker errors.

Signed-off-by: Böszörményi Zoltán <zboszor@pr.hu>