### PR TITLE
Mark BCC/bpftrace incompatible libc-musl

### DIFF
--- a/recipes-devtools/bcc/bcc_0.13.0.bb
+++ b/recipes-devtools/bcc/bcc_0.13.0.bb
@@ -38,3 +38,4 @@ EXTRA_OECMAKE = " \
 FILES_${PN} += "${libdir}/python*/dist-packages"
 
 COMPATIBLE_HOST = "(x86_64.*|aarch64.*|powerpc64.*)-linux"
+COMPATIBLE_HOST_libc-musl = "null"

--- a/recipes-devtools/bpftrace/bpftrace_0.9.4.bb
+++ b/recipes-devtools/bpftrace/bpftrace_0.9.4.bb
@@ -36,3 +36,4 @@ EXTRA_OECMAKE = " \
 FILES_${PN} += "${prefix}/man/*"
 
 COMPATIBLE_HOST = "(x86_64.*|aarch64.*|powerpc64.*)-linux"
+COMPATIBLE_HOST_libc-musl = "null"


### PR DESCRIPTION
These two patches mark BCC and bpftrace incompatible with libc-musl.