### PR TITLE
libde265: Do not use internal assembler on arm

### DIFF
--- a/conf/nonclangable.conf
+++ b/conf/nonclangable.conf
@@ -204,6 +204,7 @@ CFLAGS_append_pn-tinymembench_toolchain-clang_x86 = " -no-integrated-as"
 CFLAGS_append_pn-tinymembench_toolchain-clang_mipsarch = " -no-integrated-as"
 
 CFLAGS_append_pn-ne10_toolchain-clang_arm = " -no-integrated-as"
+CFLAGS_append_pn-libde265_toolchain-clang_arm = " -no-integrated-as"
 
 # regtest.cc:374:39: error: invalid suffix on literal; C++11 requires a
 # space between literal and identifier [-Wreserved-user-defined-literal]


### PR DESCRIPTION
.S files use GNU syntax which does not work with integrated asm

Signed-off-by: Khem Raj <raj.khem@gmail.com>