### PR TITLE
bcc, bpftrace fixes

### DIFF
--- a/recipes-devtools/bcc/bcc_0.13.0.bb
+++ b/recipes-devtools/bcc/bcc_0.13.0.bb
@@ -14,7 +14,7 @@ DEPENDS += "bison-native \
 
 RDEPENDS_${PN} += "bash python3 python3-core"
 
-SRC_URI = "git://github.com/iovisor/bcc \
+SRC_URI = "gitsm://github.com/iovisor/bcc \
            file://0001-python-CMakeLists.txt-Remove-check-for-host-etc-debi.patch \
            "
 

--- a/recipes-devtools/bcc/bcc_0.13.0.bb
+++ b/recipes-devtools/bcc/bcc_0.13.0.bb
@@ -30,6 +30,7 @@ EXTRA_OECMAKE = " \
     -DENABLE_CLANG_JIT=ON \
     -DLLVM_PACKAGE_VERSION=${LLVMVERSION} \
     -DPYTHON_CMD=${PYTHON} \
+    -DPYTHON_FLAGS=--install-lib=${PYTHON_SITEPACKAGES_DIR} \
 "
 
 do_install_append() {

--- a/recipes-devtools/bpftrace/bpftrace_0.9.4.bb
+++ b/recipes-devtools/bpftrace/bpftrace_0.9.4.bb
@@ -5,8 +5,6 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 DEPENDS += "bison-native \
             flex-native \
-            gtest-native \
-            git-native \
             elfutils \
             bcc \
             "
@@ -23,6 +21,7 @@ inherit cmake
 
 EXTRA_OECMAKE = " \
     -DCMAKE_BUILD_TYPE=Release \
+    -DBUILD_TESTING=OFF \
 "
 
 COMPATIBLE_HOST = "(x86_64.*|aarch64.*|powerpc64.*)-linux"

--- a/recipes-devtools/bpftrace/bpftrace_0.9.4.bb
+++ b/recipes-devtools/bpftrace/bpftrace_0.9.4.bb
@@ -5,6 +5,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 DEPENDS += "bison-native \
             flex-native \
+            gzip-native \
             elfutils \
             bcc \
             "


### PR DESCRIPTION
bcc:
* use gitsm fetcher to make sure src/cc/libbpf submodule is always present
* Fix do_package QA errors when baselib=lib64

bpftrace:
* Disable building unit tests
* Add dependency on gzip-native