### PR TITLE
pipewire: Do no mis-detect SSE support

### DIFF
--- a/conf/nonclangable.conf
+++ b/conf/nonclangable.conf
@@ -228,6 +228,9 @@ TUNE_CCARGS_remove_pn-omxplayer_toolchain-clang = "-no-integrated-as"
 TUNE_CCARGS_remove_pn-nfs-utils_toolchain-clang = "-Wno-error=unused-command-line-argument -Qunused-arguments"
 TUNE_CCARGS_append_pn-nfs-utils_toolchain-clang = " -Werror=unknown-warning-option"
 
+# We want to error out when -msse option is used otherwise it enables sse on non-x86 arches
+TUNE_CCARGS_remove_pn-pipewire_toolchain-clang = "-Wno-error=unused-command-line-argument -Qunused-arguments"
+
 #| /usr/src/debug/ruby/2.5.1-r0/build/../ruby-2.5.1/process.c:7073: undefined reference to `__mulodi4'
 #| clang-7: error: linker command failed with exit code 1 (use -v to see invocation)
 COMPILER_RT_pn-ruby_toolchain-clang = "--rtlib=compiler-rt ${UNWINDLIB}"


### PR DESCRIPTION
meson logic in pipewire uses compiler cmdline to find if SSE is
supported or not but if we use -Wno-error=unused-command-line-argument
then the error is turned into warning and tests pass even on non-x86
machines which is not correct

Signed-off-by: Khem Raj <raj.khem@gmail.com>