### PR TITLE
recipes: Do not Add -Wno-error=unused-command-line-argument globally

### DIFF
--- a/classes/clang.bbclass
+++ b/classes/clang.bbclass
@@ -30,7 +30,7 @@ TUNE_CCARGS_append_toolchain-clang = "${@bb.utils.contains("TUNE_FEATURES", "big
 TUNE_CCARGS_remove_toolchain-clang_powerpc = "-mhard-float"
 TUNE_CCARGS_remove_toolchain-clang_powerpc = "-mno-spe"
 
-TUNE_CCARGS_append_toolchain-clang = " -Wno-error=unused-command-line-argument -Qunused-arguments"
+TUNE_CCARGS_append_toolchain-clang = " -Qunused-arguments"
 TUNE_CCARGS_append_toolchain-clang_libc-musl_powerpc64 = " -mlong-double-64"
 TUNE_CCARGS_append_toolchain-clang_libc-musl_powerpc64le = " -mlong-double-64"
 

--- a/conf/nonclangable.conf
+++ b/conf/nonclangable.conf
@@ -225,11 +225,10 @@ CPPFLAGS_append_pn-memcached_toolchain-clang = " -Wno-error=embedded-directive"
 #| clang-7: error: assembler command failed with exit code 1 (use -v to see invocation)
 TUNE_CCARGS_remove_pn-upm_toolchain-clang = "-no-integrated-as"
 TUNE_CCARGS_remove_pn-omxplayer_toolchain-clang = "-no-integrated-as"
-TUNE_CCARGS_remove_pn-nfs-utils_toolchain-clang = "-Wno-error=unused-command-line-argument -Qunused-arguments"
-TUNE_CCARGS_append_pn-nfs-utils_toolchain-clang = " -Werror=unknown-warning-option"
+TUNE_CCARGS_remove_pn-nfs-utils_toolchain-clang = "-Qunused-arguments"
 
 # We want to error out when -msse option is used otherwise it enables sse on non-x86 arches
-TUNE_CCARGS_remove_pn-pipewire_toolchain-clang = "-Wno-error=unused-command-line-argument -Qunused-arguments"
+TUNE_CCARGS_remove_pn-pipewire_toolchain-clang = "-Qunused-arguments"
 
 #| /usr/src/debug/ruby/2.5.1-r0/build/../ruby-2.5.1/process.c:7073: undefined reference to `__mulodi4'
 #| clang-7: error: linker command failed with exit code 1 (use -v to see invocation)


### PR DESCRIPTION
This option can turn Valid options into warnings and cause unintended
behaviour

Signed-off-by: Khem Raj <raj.khem@gmail.com>