### PR TITLE
libsdl2: Do not use internal asm

### DIFF
--- a/conf/nonclangable.conf
+++ b/conf/nonclangable.conf
@@ -206,6 +206,12 @@ CFLAGS_append_pn-tinymembench_toolchain-clang_mipsarch = " -no-integrated-as"
 CFLAGS_append_pn-ne10_toolchain-clang_arm = " -no-integrated-as"
 CFLAGS_append_pn-libde265_toolchain-clang_arm = " -no-integrated-as"
 
+# :5 :    error:    unknown directive 
+#^
+#    .endfunc
+#    ^
+CFLAGS_append_pn-libsdl2_toolchain-clang_arm = " -no-integrated-as"
+
 # regtest.cc:374:39: error: invalid suffix on literal; C++11 requires a
 # space between literal and identifier [-Wreserved-user-defined-literal]
 #|   snprintf_func (buf, sizeof(buf), "%"Q"u", x);


### PR DESCRIPTION
it seems to not use unified syntax

Signed-off-by: Khem Raj <raj.khem@gmail.com>