### PR TITLE
fix build errors when using libLLVMInterpreter

### DIFF
--- a/recipes-devtools/clang/clang/0024-fix-path-to-libffi.patch
+++ b/recipes-devtools/clang/clang/0024-fix-path-to-libffi.patch
@@ -1,0 +1,28 @@
+From 52b4e74809eba796663f0f65194ab4f3eafe2cb1 Mon Sep 17 00:00:00 2001
+From: Anuj Mittal <anuj.mittal@intel.com>
+Date: Fri, 3 Apr 2020 15:10:37 +0800
+Subject: [PATCH] fix path to libffi
+
+FFI_LIBRARY_PATH is the full path to libffi so when building something that links to
+libLLVMInterpreter, we were looking for libffi in clang's recipe-sysroot instead of
+the recipe's sysroot.
+
+Signed-off-by: Anuj Mittal <anuj.mittal@intel.com>
+---
+ llvm/lib/ExecutionEngine/Interpreter/CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/llvm/lib/ExecutionEngine/Interpreter/CMakeLists.txt b/llvm/lib/ExecutionEngine/Interpreter/CMakeLists.txt
+index b8adea5..7d8434c 100644
+--- a/llvm/lib/ExecutionEngine/Interpreter/CMakeLists.txt
++++ b/llvm/lib/ExecutionEngine/Interpreter/CMakeLists.txt
+@@ -16,5 +16,5 @@ add_llvm_component_library(LLVMInterpreter
+   )
+ 
+ if( LLVM_ENABLE_FFI )
+-  target_link_libraries( LLVMInterpreter PRIVATE ${FFI_LIBRARY_PATH} )
++  target_link_libraries( LLVMInterpreter PRIVATE ffi )
+ endif()
+-- 
+2.7.4
+

--- a/recipes-devtools/clang/common.inc
+++ b/recipes-devtools/clang/common.inc
@@ -31,6 +31,7 @@ SRC_URI = "\
     file://0021-libcxx-Add-compiler-runtime-library-to-link-step-for.patch \
     file://0022-clang-llvm-cmake-Fix-configure-for-packages-using-fi.patch \
     file://0023-clang-Fix-resource-dir-location-for-cross-toolchains.patch \
+    file://0024-fix-path-to-libffi.patch \
 "
 
 # Fallback to no-PIE if not set


### PR DESCRIPTION
Don't use the full path to libffi and avoid linking to the one
from clang's sysroot. Prevents errors like:

Log data follows:
| DEBUG: Executing shell function do_compile
| NOTE: VERBOSE=1 cmake --build /build/build/tmp/work/corei7-64-poky-linux/opencl-clang/10.0.0-r0/build --target all --
| ninja: error: '/build/build/tmp/work/corei7-64-poky-linux/clang/10.0.0-r0/recipe-sysroot/usr/lib/libffi.so', needed by 'libopencl-clang.so.10', missing and no known rule to make it
| WARNING: exit code 1 from a shell command.
| ERROR: Execution of '/build/build/tmp/work/corei7-64-poky-linux/opencl-clang/10.0.0-r0/temp/run.do_compile.72389' failed with exit code 1:
| ninja: error: '/build/build/tmp/work/corei7-64-poky-linux/clang/10.0.0-r0/recipe-sysroot/usr/lib/libffi.so', needed by 'libopencl-clang.so.10', missing and no known rule to make it
| WARNING: exit code 1 from a shell command.
|

Signed-off-by: Anuj Mittal <anuj.mittal@intel.com>