### PR TITLE
layer.conf: Add bcc to non-multilib list

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -33,3 +33,5 @@ LLVMVERSION = "10.0.0"
 
 require conf/nonclangable.conf
 require conf/nonscanable.conf
+
+NON_MULTILIB_RECIPES_append = " bcc"


### PR DESCRIPTION
bcc is only compatible with x86_64, aarch64 and powerpc64. So it's not able to
built as 32 bit binary.

Signed-off-by: He Zhe <zhe.he@windriver.com>