### PR TITLE
compiler-rt: disable ccache

### DIFF
--- a/recipes-devtools/clang/compiler-rt_git.bb
+++ b/recipes-devtools/clang/compiler-rt_git.bb
@@ -90,3 +90,6 @@ ALLOW_EMPTY_${PN}-dev = "1"
 
 TOOLCHAIN_forcevariable = "clang"
 SYSROOT_DIRS_append_class-target = " ${nonarch_libdir}"
+
+# Can't be built with ccache
+CCACHE_DISABLE = "1"


### PR DESCRIPTION
It fails to build compiler-rt with ccache. Disable it.

Signed-off-by: Kai Kang <kai.kang@windriver.com>