### PR TITLE
Fix error when ccache enabled

### DIFF
--- a/classes/clang.bbclass
+++ b/classes/clang.bbclass
@@ -1,4 +1,5 @@
 # Add the necessary override
+CCACHE_COMPILERCHECK_toolchain-clang = "%compiler% -v"
 CC_toolchain-clang  = "${CCACHE}${HOST_PREFIX}clang ${HOST_CC_ARCH}${TOOLCHAIN_OPTIONS}"
 CXX_toolchain-clang = "${CCACHE}${HOST_PREFIX}clang++ ${HOST_CC_ARCH}${TOOLCHAIN_OPTIONS}"
 CPP_toolchain-clang = "${CCACHE}${HOST_PREFIX}clang ${HOST_CC_ARCH}${TOOLCHAIN_OPTIONS} -E"

--- a/classes/cmake-native.bbclass
+++ b/classes/cmake-native.bbclass
@@ -1,6 +1,3 @@
-# We need to unset CCACHE otherwise cmake gets too confused
-CCACHE = ""
-
 # Native C/C++ compiler (without cpu arch/tune arguments)
 OECMAKE_NATIVE_C_COMPILER ?= "`echo ${BUILD_CC} | sed 's/^\([^ ]*\).*/\1/'`"
 OECMAKE_NATIVE_CXX_COMPILER ?= "`echo ${BUILD_CXX} | sed 's/^\([^ ]*\).*/\1/'`"


### PR DESCRIPTION
It fails to build compiler-rt when ccache enabled:

| ccache: error: Failure running compiler check command: %compiler% -dumpspecs
    
Because clang doesn't recognize option '-dumpspecs' from default value
of CCACHE_COMPILERCHECK, override CCACHE_COMPILERCHECK for toolchain
clang in clang.bbclass.

And it reset variable CCACHE to disable ccache in cmake-native.bbclass:. But that doesn't effect that  CCACHE is set in an anonymous function from ccache.bbclass at last and  ccache is always not disabled with cmake.

So remove these useless piece of code.

Test steps:
1 create 2 build projects build-A and build-B, and update local.conf
INHERIT += "ccache"
CCACHE_DIR = "${TMPDIR}/ccache/${MULTIMACH_TARGET_SYS}/${PN}"
CCACHE_TOP_DIR = "/buildarea5/kkang/WRL10.CD/build-clang-May14/tmp-glibc/ccache"

export CCACHE_DEBUG = "1"
export CCACHE_LOGFILE = "${CCACHE_DIR}/logfile.log"

2 In build-A
$ bitbake compiler-rt
$ bitbake clang clang-native nativesdk-clang

3 In build-B
$ bitbake compiler-rt -c cleansstate
$ bitbake compiler-rt
$ bitbake clang clang-native nativesdk-clang -c cleansstate
$ bitbake clang clang-native nativesdk-clang

$ bitbake compiler-rt -c devshell

check ccache stats that ccache is used:

root@pek-lpg-core3:/buildarea5/kkang/WRL10.CD/build-clang-333/tmp-glibc/work-shared/llvm-project-source-10.0.0-r0/git
$ ccache -s
cache directory                     /buildarea5/kkang/WRL10.CD/build-clang-333/tmp-glibc/ccache/core2-64-wrs-linux/compiler-rt
primary config                      /buildarea5/kkang/WRL10.CD/repo/layers/oe-core/meta/conf/ccache.conf
secondary config      (readonly)
stats updated                       Fri May 15 05:52:04 2020
cache hit (direct)                    95
cache hit (preprocessed)               1
cache miss                           660
cache hit rate                     12.70 %
compile failed                         8
preprocessor error                    35
cleanups performed                     0
files in cache                      1833
cache size                          24.8 MB
