### PR TITLE
Fix libcxx build for armv5e on zeus

### DIFF
--- a/conf/nonclangable.conf
+++ b/conf/nonclangable.conf
@@ -217,6 +217,8 @@ CPPFLAGS_append_pn-memcached_toolchain-clang = " -Wno-error=embedded-directive"
 #| clang-7: error: assembler command failed with exit code 1 (use -v to see invocation)
 TUNE_CCARGS_remove_pn-upm_toolchain-clang = "-no-integrated-as"
 TUNE_CCARGS_remove_pn-omxplayer_toolchain-clang = "-no-integrated-as"
+TUNE_CCARGS_remove_pn-nfs-utils_toolchain-clang = "-Wno-error=unused-command-line-argument -Qunused-arguments"
+TUNE_CCARGS_append_pn-nfs-utils_toolchain-clang = " -Werror=unknown-warning-option"
 
 #| /usr/src/debug/ruby/2.5.1-r0/build/../ruby-2.5.1/process.c:7073: undefined reference to `__mulodi4'
 #| clang-7: error: linker command failed with exit code 1 (use -v to see invocation)

--- a/recipes-devtools/clang/clang/0028-Add-libgcc-to-link-step-for-libcxx.patch
+++ b/recipes-devtools/clang/clang/0028-Add-libgcc-to-link-step-for-libcxx.patch
@@ -1,0 +1,30 @@
+From 397bd558b83ce7ff3ea69c1c8fb6f36c624b9ca6 Mon Sep 17 00:00:00 2001
+From: Jeremy Puhlman <jpuhlman@mvista.com>
+Date: Thu, 16 Jan 2020 21:16:10 +0000
+Subject: [PATCH] Add libgcc to link step for libcxx
+
+This corrects "undefined reference to __divti3"
+
+Upstream-Status: Inappropriate [configuration]
+
+Signed-off-by: Jeremy Puhlman <jpuhlman@mvista.com>
+---
+ libcxx/src/CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/libcxx/src/CMakeLists.txt b/libcxx/src/CMakeLists.txt
+index 31cd24333a5..d8ae826d7f5 100644
+--- a/libcxx/src/CMakeLists.txt
++++ b/libcxx/src/CMakeLists.txt
+@@ -234,7 +234,7 @@ if (LIBCXX_ENABLE_SHARED)
+     llvm_setup_rpath(cxx_shared)
+   endif()
+   cxx_link_system_libraries(cxx_shared)
+-  target_link_libraries(cxx_shared PRIVATE ${LIBCXX_LIBRARIES})
++  target_link_libraries(cxx_shared PRIVATE ${LIBCXX_LIBRARIES} "$$($$CC --print-libgcc-file-name)")
+   set_target_properties(cxx_shared
+     PROPERTIES
+       COMPILE_FLAGS "${LIBCXX_COMPILE_FLAGS}"
+-- 
+2.13.3
+

--- a/recipes-devtools/clang/clang_git.bb
+++ b/recipes-devtools/clang/clang_git.bb
@@ -229,10 +229,11 @@ FILES_${PN} += "\
   ${datadir}/opt-viewer/ \
 "
 
-FILES_${PN}-libllvm += "\
+FILES_${PN}-libllvm =+ "\
   ${libdir}/libLLVM-${MAJOR_VER}.${MINOR_VER}.so \
   ${libdir}/libLLVM-${MAJOR_VER}.so \
-  ${libdir}/libLLVM-${MAJOR_VER}.${MINOR_VER}svn.so \
+  ${libdir}/libLLVM-${MAJOR_VER}git.so \
+  ${libdir}/libLLVM-${MAJOR_VER}.${MINOR_VER}git.so \
 "
 
 FILES_libclang = "\

--- a/recipes-devtools/clang/common.inc
+++ b/recipes-devtools/clang/common.inc
@@ -35,6 +35,7 @@ SRC_URI = "\
     file://0025-llvm-Let-llvm-ar-name-contain-lib.patch \
     file://0026-libclang-Use-CMAKE_DL_LIBS-for-deducing-libdl.patch \
     file://0027-Fix-sanitizer-common-build-with-glibc-2.31.patch \
+    file://0028-Add-libgcc-to-link-step-for-libcxx.patch \
 "
 
 # Fallback to no-PIE if not set

--- a/recipes-devtools/clang/compiler-rt_git.bb
+++ b/recipes-devtools/clang/compiler-rt_git.bb
@@ -19,7 +19,7 @@ TUNE_CCARGS_remove = "-no-integrated-as"
 
 INHIBIT_DEFAULT_DEPS = "1"
 
-DEPENDS += "ninja-native clang-cross-${TARGET_ARCH} virtual/${MLPREFIX}libc virtual/${TARGET_PREFIX}compilerlibs"
+DEPENDS += "ninja-native clang-cross-${TARGET_ARCH} virtual/${MLPREFIX}libc virtual/${TARGET_PREFIX}compilerlibs virtual/crypt"
 DEPENDS_append_class-nativesdk = " clang-native"
 
 HF = "${@ bb.utils.contains('TUNE_CCARGS_MFLOAT', 'hard', 'hf', '', d)}"

--- a/recipes-devtools/clang/openmp_git.bb
+++ b/recipes-devtools/clang/openmp_git.bb
@@ -21,6 +21,13 @@ inherit cmake pkgconfig perlnative
 
 EXTRA_OECMAKE = "-G Ninja ${S}/openmp"
 
+PACKAGECONFIG ?= "ompt-tools"
+PACKAGECONFIG_remove_arm = "ompt-tools"
+PACKAGECONFIG_remove_mipsarch = "ompt-tools"
+PACKAGECONFIG_remove_powerpc = "ompt-tools"
+
+PACKAGECONFIG[ompt-tools] = "-DOPENMP_ENABLE_OMPT_TOOLS=ON,-DOPENMP_ENABLE_OMPT_TOOLS=OFF,"
+
 do_compile() {
 	ninja ${PARALLEL_MAKE}
 }


### PR DESCRIPTION
When working on #327, I have noticed that even on poky/OE zeus branches, when using meta-clang master, everything was fine for libcxx on armv5e, and that the fix was actually not far from the current zeus HEAD.

This fixes #327 by merging the few commits between the fix from master to zeus.
