### PR TITLE
apt: Disable c++11-narrowing and fortify

### DIFF
--- a/conf/nonclangable.conf
+++ b/conf/nonclangable.conf
@@ -276,3 +276,13 @@ RUNTIME_pn-gerbera_toolchain-clang = "llvm"
 # let same compiler ( gcc or clang) be native/cross compiler
 # | gcc: error: unrecognized command line option ‘-Qunused-arguments’
 BUILD_CC_pn-nss_toolchain-clang = "clang"
+
+# libnoprofile.c:19:5: error: expected parameter declarator
+# int printf(const char *format, ...) {
+#    ^
+# error: non-constant-expression cannot be narrowed from type 'std::chrono::duration<
+#long long, std::ratio<1, 1> >::rep' (aka 'long long') to '__time_t' (aka 'long') in initializer list
+# [-Wc++11-narrowing]
+CXXFLAGS_append_pn-apt_toolchain-clang = " -Wno-c++11-narrowing"
+lcl_maybe_fortify_pn-apt_toolchain-clang = ""
+

--- a/recipes-devtools/clang/clang.inc
+++ b/recipes-devtools/clang/clang.inc
@@ -8,7 +8,7 @@ MAJOR_VER = "10"
 MINOR_VER = "0"
 PATCH_VER = "1"
 
-SRCREV ?= "f79cd71e145c6fd005ba4dd1238128dfa0dc2cb6"
+SRCREV ?= "a634a80615b1e012f1a61aa0cd1e2e67ef77d0bd"
 
 PV = "${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}"
 BRANCH = "release/${MAJOR_VER}.x"


### PR DESCRIPTION
apt 1.8.2+ does not compile with clang, clang is finding narrowing
warnings and printf function is redefined in tests which confuses the
function signatures from libc when fortify is enabled, its therefore
disabled for now

Signed-off-by: Khem Raj <raj.khem@gmail.com>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
