### PR TITLE
bcc: Make opensnoop compatible with kernel v5.6 and later

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-devtools/bcc/bcc/0001-tools-opensnoop-snoop-do_sys_openat2-for-kernel-v5.6.patch
+++ b/dynamic-layers/openembedded-layer/recipes-devtools/bcc/bcc/0001-tools-opensnoop-snoop-do_sys_openat2-for-kernel-v5.6.patch
@@ -1,0 +1,51 @@
+From 935f7e47f54df1af30f4a1cdfd2f385863ab9dec Mon Sep 17 00:00:00 2001
+From: He Zhe <zhe.he@windriver.com>
+Date: Mon, 15 Jun 2020 07:05:24 +0000
+Subject: [PATCH] tools: opensnoop: snoop do_sys_openat2 for kernel v5.6 and
+ later
+
+Since kernel v5.6, fddb5d430ad9 ("open: introduce openat2(2) syscall"),
+do_sys_openat2 instead of do_sys_open has been used as entry function for open.
+
+Upstream-Status: Inappropriate, upstream context has changed and needs more
+                 tweak.
+
+Signed-off-by: He Zhe <zhe.he@windriver.com>
+---
+ tools/opensnoop.py | 13 +++++++++++--
+ 1 file changed, 11 insertions(+), 2 deletions(-)
+
+diff --git a/tools/opensnoop.py b/tools/opensnoop.py
+index 6d1388b3..3f7e48a3 100755
+--- a/tools/opensnoop.py
++++ b/tools/opensnoop.py
+@@ -21,6 +21,8 @@ from bcc.utils import printb
+ import argparse
+ from datetime import datetime, timedelta
+ import os
++import platform
++from pkg_resources import parse_version
+ 
+ # arguments
+ examples = """examples:
+@@ -195,8 +197,15 @@ if debug or args.ebpf:
+ 
+ # initialize BPF
+ b = BPF(text=bpf_text)
+-b.attach_kprobe(event="do_sys_open", fn_name="trace_entry")
+-b.attach_kretprobe(event="do_sys_open", fn_name="trace_return")
++
++# Since kernel v5.6, do_sys_openat2 instead of do_sys_open has been used as entry function for open
++if parse_version(platform.uname().release.split('-')[0]) > parse_version('5.6.0'):
++    entry = "do_sys_openat2"
++else:
++    entry = "do_sys_open"
++
++b.attach_kprobe(event=entry, fn_name="trace_entry")
++b.attach_kretprobe(event=entry, fn_name="trace_return")
+ 
+ initial_ts = 0
+ 
+-- 
+2.24.1
+

--- a/dynamic-layers/openembedded-layer/recipes-devtools/bcc/bcc_0.13.0.bb
+++ b/dynamic-layers/openembedded-layer/recipes-devtools/bcc/bcc_0.13.0.bb
@@ -12,10 +12,11 @@ DEPENDS += "bison-native \
             clang \
             "
 
-RDEPENDS_${PN} += "bash python3 python3-core xz"
+RDEPENDS_${PN} += "bash python3 python3-core python3-setuptools xz"
 
 SRC_URI = "gitsm://github.com/iovisor/bcc \
            file://0001-python-CMakeLists.txt-Remove-check-for-host-etc-debi.patch \
+           file://0001-tools-opensnoop-snoop-do_sys_openat2-for-kernel-v5.6.patch \
            "
 
 SRCREV = "942227484d3207f6a42103674001ef01fb5335a0"


### PR DESCRIPTION
Since kernel v5.6, fddb5d430ad9 ("open: introduce openat2(2) syscall"),
do_sys_openat2 instead of do_sys_open has been used as entry function for open.

Signed-off-by: He Zhe <zhe.he@windriver.com>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
