### PR TITLE
Usrmerge support for Clang

### DIFF
--- a/classes/clang.bbclass
+++ b/classes/clang.bbclass
@@ -43,6 +43,8 @@ TUNE_CCARGS_remove_toolchain-clang_powerpc = "-mno-spe"
 TUNE_CCARGS_append_toolchain-clang = " -Qunused-arguments"
 TUNE_CCARGS_append_toolchain-clang_libc-musl_powerpc64 = " -mlong-double-64"
 TUNE_CCARGS_append_toolchain-clang_libc-musl_powerpc64le = " -mlong-double-64"
+# usrmerge workaround
+TUNE_CCARGS_append_toolchain-clang = "${@bb.utils.contains("DISTRO_FEATURES", "usrmerge", " --dyld-prefix=/usr", "", d)}"
 
 LDFLAGS_append_toolchain-clang_class-nativesdk_x86-64 = " -Wl,-dynamic-linker,${base_libdir}/ld-linux-x86-64.so.2"
 LDFLAGS_append_toolchain-clang_class-nativesdk_x86 = " -Wl,-dynamic-linker,${base_libdir}/ld-linux.so.2"

--- a/recipes-devtools/clang/clang/0025-clang-driver-Add-dyld-prefix-when-checking-sysroot-f.patch
+++ b/recipes-devtools/clang/clang/0025-clang-driver-Add-dyld-prefix-when-checking-sysroot-f.patch
@@ -1,0 +1,69 @@
+From fcafd24f9062eeecc9c87ac2fe9bce9accbe7534 Mon Sep 17 00:00:00 2001
+From: Oleksandr Ocheretnyi <oocheret@cisco.com>
+Date: Wed, 15 Apr 2020 00:08:39 +0300
+Subject: [PATCH] clang: driver: Add dyld-prefix when checking sysroot for ldso
+ path
+
+ * the dyld-prefix shall be taken into account when the default
+   path for the dynamic linker has to be checked.
+
+ * this patch shall be used as annex to the next patch:
+   'clang: driver: Check sysroot for ldso path' which includes
+   the usrmerge scenario.
+
+Signed-off-by: Oleksandr Ocheretnyi <oocheret@cisco.com>
+---
+ clang/lib/Driver/ToolChains/Linux.cpp | 16 ++++++++--------
+ 1 file changed, 8 insertions(+), 8 deletions(-)
+
+diff --git a/clang/lib/Driver/ToolChains/Linux.cpp b/clang/lib/Driver/ToolChains/Linux.cpp
+index fb579e7ad60..4ed5938cc59 100644
+--- a/clang/lib/Driver/ToolChains/Linux.cpp
++++ b/clang/lib/Driver/ToolChains/Linux.cpp
+@@ -604,8 +604,8 @@ std::string Linux::getDynamicLinker(const ArgList &Args) const {
+     LibDir = "lib64";
+     Loader =
+         (tools::ppc::hasPPCAbiArg(Args, "elfv2")) ? "ld64.so.2" : "ld64.so.1";
+-    if (!getVFS().exists(getDriver().SysRoot + "/" + LibDir + "/" + Loader) &&
+-         getVFS().exists(getDriver().SysRoot + "/lib/" + Loader)) {
++    if (!getVFS().exists(getDriver().SysRoot + getDriver().DyldPrefix + "/" + LibDir + "/" + Loader) &&
++         getVFS().exists(getDriver().SysRoot + getDriver().DyldPrefix + "/lib/" + Loader)) {
+         LibDir = "lib";
+     }
+     break;
+@@ -613,8 +613,8 @@ std::string Linux::getDynamicLinker(const ArgList &Args) const {
+     LibDir = "lib64";
+     Loader =
+         (tools::ppc::hasPPCAbiArg(Args, "elfv1")) ? "ld64.so.1" : "ld64.so.2";
+-    if (!getVFS().exists(getDriver().SysRoot + "/" + LibDir + "/" + Loader) &&
+-         getVFS().exists(getDriver().SysRoot + "/lib/" + Loader)) {
++    if (!getVFS().exists(getDriver().SysRoot + getDriver().DyldPrefix + "/" + LibDir + "/" + Loader) &&
++         getVFS().exists(getDriver().SysRoot + getDriver().DyldPrefix + "/lib/" + Loader)) {
+         LibDir = "lib";
+     }
+     break;
+@@ -638,8 +638,8 @@ std::string Linux::getDynamicLinker(const ArgList &Args) const {
+   case llvm::Triple::sparcv9:
+     LibDir = "lib64";
+     Loader = "ld-linux.so.2";
+-    if (!getVFS().exists(getDriver().SysRoot + "/" + LibDir + "/" + Loader) &&
+-         getVFS().exists(getDriver().SysRoot + "/lib/" + Loader)) {
++    if (!getVFS().exists(getDriver().SysRoot + getDriver().DyldPrefix + "/" + LibDir + "/" + Loader) &&
++         getVFS().exists(getDriver().SysRoot + getDriver().DyldPrefix + "/lib/" + Loader)) {
+         LibDir = "lib";
+     }
+     break;
+@@ -656,8 +656,8 @@ std::string Linux::getDynamicLinker(const ArgList &Args) const {
+ 
+     LibDir = X32 ? "libx32" : "lib64";
+     Loader = X32 ? "ld-linux-x32.so.2" : "ld-linux-x86-64.so.2";
+-    if (!getVFS().exists(getDriver().SysRoot + "/" + LibDir + "/" + Loader) &&
+-         getVFS().exists(getDriver().SysRoot + "/lib/" + Loader)) {
++    if (!getVFS().exists(getDriver().SysRoot + getDriver().DyldPrefix + "/" + LibDir + "/" + Loader) &&
++         getVFS().exists(getDriver().SysRoot + getDriver().DyldPrefix + "/lib/" + Loader)) {
+         LibDir = "lib";
+     }
+     break;
+-- 
+2.17.1
+

--- a/recipes-devtools/clang/common.inc
+++ b/recipes-devtools/clang/common.inc
@@ -32,6 +32,7 @@ SRC_URI = "\
     file://0022-clang-llvm-cmake-Fix-configure-for-packages-using-fi.patch \
     file://0023-clang-Fix-resource-dir-location-for-cross-toolchains.patch \
     file://0024-fix-path-to-libffi.patch \
+    file://0025-clang-driver-Add-dyld-prefix-when-checking-sysroot-f.patch \
 "
 
 # Fallback to no-PIE if not set


### PR DESCRIPTION
Supersedes #339 "Usrmerge support for Clang"
===================================================
These changes add usrmerge support for the Clang meta layer.

 * there is a fix for "clang: Search for dynamic linker." commit;
 * the usrmerge support is based on --dyld-prefix usage of the llvm-project-source;
