### PR TITLE
bcc: Fix KBUILD_MODNAME errors for kernel 5.7 and latter

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-devtools/bcc/bcc/0001-Add-KBUILD_MODNAME-flag-to-default-cflags.patch
+++ b/dynamic-layers/openembedded-layer/recipes-devtools/bcc/bcc/0001-Add-KBUILD_MODNAME-flag-to-default-cflags.patch
@@ -1,0 +1,27 @@
+From 9e2415679e41adacc59dd7a426d505232f0b7129 Mon Sep 17 00:00:00 2001
+From: William Findlay <william@williamfindlay.com>
+Date: Wed, 17 Jun 2020 12:07:48 -0400
+Subject: [PATCH 1/2] Add KBUILD_MODNAME flag to default cflags
+
+Upstream-Status: Backported [https://github.com/iovisor/bcc/pull/2974/commits/badd85c58549d0e7f0d536490c41213141e180c5]
+
+Signed-off-by: He Zhe <zhe.he@windriver.com>
+---
+ src/cc/frontends/clang/kbuild_helper.cc | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/cc/frontends/clang/kbuild_helper.cc b/src/cc/frontends/clang/kbuild_helper.cc
+index db5ca7f6..e3aade89 100644
+--- a/src/cc/frontends/clang/kbuild_helper.cc
++++ b/src/cc/frontends/clang/kbuild_helper.cc
+@@ -101,6 +101,7 @@ int KBuildHelper::get_flags(const char *uname_machine, vector<string> *cflags) {
+   cflags->push_back("-D__HAVE_BUILTIN_BSWAP16__");
+   cflags->push_back("-D__HAVE_BUILTIN_BSWAP32__");
+   cflags->push_back("-D__HAVE_BUILTIN_BSWAP64__");
++  cflags->push_back("-DKBUILD_MODNAME=\"bcc\"");
+ 
+   // If ARCH env variable is set, pass this along.
+   if (archenv)
+-- 
+2.26.2
+

--- a/dynamic-layers/openembedded-layer/recipes-devtools/bcc/bcc/0001-Delete-existing-kbuild_modname-definitions.patch
+++ b/dynamic-layers/openembedded-layer/recipes-devtools/bcc/bcc/0001-Delete-existing-kbuild_modname-definitions.patch
@@ -1,0 +1,176 @@
+From eb8b0487a05d650499b20fdd5edeb6e47c2c17a5 Mon Sep 17 00:00:00 2001
+From: William Findlay <william@williamfindlay.com>
+Date: Wed, 17 Jun 2020 18:59:43 -0400
+Subject: [PATCH 2/2] Delete existing kbuild_modname definitions
+
+Upstream-Status: Backported [https://github.com/iovisor/bcc/pull/2974/commits/a5bdc9c65746389d7072e1e8e583025dde78e91b]
+
+Adjust context
+
+Signed-off-by: He Zhe <zhe.he@windriver.com>
+---
+ examples/networking/xdp/xdp_drop_count.py    | 1 -
+ examples/networking/xdp/xdp_macswap_count.py | 1 -
+ examples/networking/xdp/xdp_redirect_cpu.py  | 1 -
+ examples/networking/xdp/xdp_redirect_map.py  | 1 -
+ tests/python/test_clang.py                   | 8 --------
+ tools/tcplife.lua                            | 1 -
+ tools/tcplife.py                             | 1 -
+ tools/tcpstates.py                           | 1 -
+ 8 files changed, 15 deletions(-)
+
+diff --git a/examples/networking/xdp/xdp_drop_count.py b/examples/networking/xdp/xdp_drop_count.py
+index f03273e9..512e0a20 100755
+--- a/examples/networking/xdp/xdp_drop_count.py
++++ b/examples/networking/xdp/xdp_drop_count.py
+@@ -52,7 +52,6 @@ else:
+ 
+ # load BPF program
+ b = BPF(text = """
+-#define KBUILD_MODNAME "foo"
+ #include <uapi/linux/bpf.h>
+ #include <linux/in.h>
+ #include <linux/if_ether.h>
+diff --git a/examples/networking/xdp/xdp_macswap_count.py b/examples/networking/xdp/xdp_macswap_count.py
+index 0e2b21ca..770ce8ca 100755
+--- a/examples/networking/xdp/xdp_macswap_count.py
++++ b/examples/networking/xdp/xdp_macswap_count.py
+@@ -50,7 +50,6 @@ else:
+ 
+ # load BPF program
+ b = BPF(text = """
+-#define KBUILD_MODNAME "foo"
+ #include <uapi/linux/bpf.h>
+ #include <linux/in.h>
+ #include <linux/if_ether.h>
+diff --git a/examples/networking/xdp/xdp_redirect_cpu.py b/examples/networking/xdp/xdp_redirect_cpu.py
+index 15b0d09b..470079f4 100755
+--- a/examples/networking/xdp/xdp_redirect_cpu.py
++++ b/examples/networking/xdp/xdp_redirect_cpu.py
+@@ -30,7 +30,6 @@ if (cpu_id > max_cpu):
+ 
+ # load BPF program
+ b = BPF(text = """
+-#define KBUILD_MODNAME "foo"
+ #include <uapi/linux/bpf.h>
+ #include <linux/in.h>
+ #include <linux/if_ether.h>
+diff --git a/examples/networking/xdp/xdp_redirect_map.py b/examples/networking/xdp/xdp_redirect_map.py
+index 4a622723..4936ac1e 100755
+--- a/examples/networking/xdp/xdp_redirect_map.py
++++ b/examples/networking/xdp/xdp_redirect_map.py
+@@ -29,7 +29,6 @@ out_idx = ip.link_lookup(ifname=out_if)[0]
+ 
+ # load BPF program
+ b = BPF(text = """
+-#define KBUILD_MODNAME "foo"
+ #include <uapi/linux/bpf.h>
+ #include <linux/in.h>
+ #include <linux/if_ether.h>
+diff --git a/tests/python/test_clang.py b/tests/python/test_clang.py
+index 886eebed..648494cf 100755
+--- a/tests/python/test_clang.py
++++ b/tests/python/test_clang.py
+@@ -78,7 +78,6 @@ int count_foo(struct pt_regs *ctx, unsigned long a, unsigned long b) {
+ 
+     def test_probe_read3(self):
+         text = """
+-#define KBUILD_MODNAME "foo"
+ #include <net/tcp.h>
+ #define _(P) ({typeof(P) val = 0; bpf_probe_read(&val, sizeof(val), &P); val;})
+ int count_tcp(struct pt_regs *ctx, struct sk_buff *skb) {
+@@ -90,7 +89,6 @@ int count_tcp(struct pt_regs *ctx, struct sk_buff *skb) {
+ 
+     def test_probe_read4(self):
+         text = """
+-#define KBUILD_MODNAME "foo"
+ #include <net/tcp.h>
+ #define _(P) ({typeof(P) val = 0; bpf_probe_read(&val, sizeof(val), &P); val;})
+ int test(struct pt_regs *ctx, struct sk_buff *skb) {
+@@ -102,7 +100,6 @@ int test(struct pt_regs *ctx, struct sk_buff *skb) {
+ 
+     def test_probe_read_whitelist1(self):
+         text = """
+-#define KBUILD_MODNAME "foo"
+ #include <net/tcp.h>
+ int count_tcp(struct pt_regs *ctx, struct sk_buff *skb) {
+     // The below define is in net/tcp.h:
+@@ -120,7 +117,6 @@ int count_tcp(struct pt_regs *ctx, struct sk_buff *skb) {
+ 
+     def test_probe_read_whitelist2(self):
+         text = """
+-#define KBUILD_MODNAME "foo"
+ #include <net/tcp.h>
+ int count_tcp(struct pt_regs *ctx, struct sk_buff *skb) {
+     // The below define is in net/tcp.h:
+@@ -1072,7 +1068,6 @@ int test(struct __sk_buff *ctx) {
+ 
+     def test_probe_read_return(self):
+         text = """
+-#define KBUILD_MODNAME "foo"
+ #include <uapi/linux/ptrace.h>
+ #include <linux/tcp.h>
+ static inline unsigned char *my_skb_transport_header(struct sk_buff *skb) {
+@@ -1088,7 +1083,6 @@ int test(struct pt_regs *ctx, struct sock *sk, struct sk_buff *skb) {
+ 
+     def test_probe_read_multiple_return(self):
+         text = """
+-#define KBUILD_MODNAME "foo"
+ #include <uapi/linux/ptrace.h>
+ #include <linux/tcp.h>
+ static inline u64 error_function() {
+@@ -1109,7 +1103,6 @@ int test(struct pt_regs *ctx, struct sock *sk, struct sk_buff *skb) {
+ 
+     def test_probe_read_return_expr(self):
+         text = """
+-#define KBUILD_MODNAME "foo"
+ #include <uapi/linux/ptrace.h>
+ #include <linux/tcp.h>
+ static inline unsigned char *my_skb_transport_header(struct sk_buff *skb) {
+@@ -1125,7 +1118,6 @@ int test(struct pt_regs *ctx, struct sock *sk, struct sk_buff *skb) {
+ 
+     def test_probe_read_return_call(self):
+         text = """
+-#define KBUILD_MODNAME "foo"
+ #include <uapi/linux/ptrace.h>
+ #include <linux/tcp.h>
+ static inline struct tcphdr *my_skb_transport_header(struct sk_buff *skb) {
+diff --git a/tools/tcplife.lua b/tools/tcplife.lua
+index 3f4f6afd..5e311631 100755
+--- a/tools/tcplife.lua
++++ b/tools/tcplife.lua
+@@ -25,7 +25,6 @@ uint16_t ntohs(uint16_t netshort);
+ 
+ local program = [[
+ #include <uapi/linux/ptrace.h>
+-#define KBUILD_MODNAME "foo"
+ #include <linux/tcp.h>
+ #include <net/sock.h>
+ #include <bcc/proto.h>
+diff --git a/tools/tcplife.py b/tools/tcplife.py
+index d4e679dd..c2bd8236 100755
+--- a/tools/tcplife.py
++++ b/tools/tcplife.py
+@@ -66,7 +66,6 @@ debug = 0
+ # define BPF program
+ bpf_text = """
+ #include <uapi/linux/ptrace.h>
+-#define KBUILD_MODNAME "foo"
+ #include <linux/tcp.h>
+ #include <net/sock.h>
+ #include <bcc/proto.h>
+diff --git a/tools/tcpstates.py b/tools/tcpstates.py
+index b9a64387..09bbe0ce 100755
+--- a/tools/tcpstates.py
++++ b/tools/tcpstates.py
+@@ -61,7 +61,6 @@ debug = 0
+ # define BPF program
+ bpf_text = """
+ #include <uapi/linux/ptrace.h>
+-#define KBUILD_MODNAME "foo"
+ #include <linux/tcp.h>
+ #include <net/sock.h>
+ #include <bcc/proto.h>
+-- 
+2.26.2
+

--- a/dynamic-layers/openembedded-layer/recipes-devtools/bcc/bcc_0.13.0.bb
+++ b/dynamic-layers/openembedded-layer/recipes-devtools/bcc/bcc_0.13.0.bb
@@ -17,6 +17,8 @@ RDEPENDS_${PN} += "bash python3 python3-core python3-setuptools xz"
 SRC_URI = "gitsm://github.com/iovisor/bcc \
            file://0001-python-CMakeLists.txt-Remove-check-for-host-etc-debi.patch \
            file://0001-tools-opensnoop-snoop-do_sys_openat2-for-kernel-v5.6.patch \
+           file://0001-Add-KBUILD_MODNAME-flag-to-default-cflags.patch \
+           file://0001-Delete-existing-kbuild_modname-definitions.patch \
            "
 
 SRCREV = "942227484d3207f6a42103674001ef01fb5335a0"


### PR DESCRIPTION
Backport two patches to fix the following runtime failures.

Networking tools fail with include/net/flow_offload.h:304:4: error: use of
undeclared identifier 'KBUILD_MODNAME'.

Signed-off-by: He Zhe <zhe.he@windriver.com>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
