### PR TITLE
Update drone triggers for dunfell

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -19,9 +19,9 @@ trigger:
 steps:
   - name: build
     commands:
-      - git clone --recurse-submodules -j8 -b $DRONE_SOURCE_BRANCH git://github.com/YoeDistro/yoe-distro.git yoe
+      - git clone --recurse-submodules -j8 git://github.com/YoeDistro/yoe-distro.git yoe
       - cd yoe
-      - git checkout dunfell
+      - git checkout -b test origin/dunfell
       - git pull
       - git submodule update --recursive --init
       - rm -rf sources/meta-clang
@@ -39,6 +39,10 @@ steps:
       - echo SSTATE_DIR = \"$SSTATE_CACHE_DIR\" >> conf/local.conf
       - echo IMAGE_CLASSES += \"testimage testsdk\" >> conf/local.conf
       - echo INHERIT += \"report-error rm_work blacklist\" >> conf/local.conf
+      - echo ERR_REPORT_SERVER = \"errors.yoctoproject.org\" >> conf/local.conf
+      - echo ERR_REPORT_PORT = \"80\" >> conf/local.conf
+      - echo ERR_REPORT_USERNAME = \"Drone Autobuilder\" >> conf/local.conf
+      - echo ERR_REPORT_EMAIL = \"info@yoedistro.org\" >> conf/local.conf
       - echo TOOLCHAIN = \"clang\" >> conf/local.conf
       - echo CLANGSDK = \"1\" >> conf/local.conf
       - echo IMAGE_INSTALL_append = \" clang \" >> conf/local.conf


### PR DESCRIPTION
Currently it expect the common branch names like master and dunfell
match between meta-clang and yoe which may not be case

Signed-off-by: Khem Raj <raj.khem@gmail.com>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
