### PR TITLE
clang: set the default pigz thread

### DIFF
--- a/recipes-devtools/clang/clang.inc
+++ b/recipes-devtools/clang/clang.inc
@@ -20,4 +20,7 @@ LLDBMD5SUM = "2e0d44968471fcde980034dbb826bea9"
 
 LLVM_LIBDIR_SUFFIX="${@d.getVar('baselib').replace('lib', '')}"
 
+# set the default pigz thread
+export PIGZ = "-p ${@oe.utils.cpu_count(at_least=2)}"
+
 require common.inc


### PR DESCRIPTION
pigz, which stands for parallel implementation of gzip, is a
fully functional replacement for gzip that exploits multiple
processors and multiple cores to the hilt when compressing data.

do_package uses pigz to compress data to speed up the time
if there is pigz available on the build server.

But for some big package such as clang, there comes below
error during do_package.
gzip: stdout: Cannot allocate memory
tar: TOPDIR/sstate-cache/20/80/sstate:clang:cortexa57-wrs-linux:10.0.1:r0:cortexa57:3:20808f8a746b00ec9470a81057c8595d878cfe8c565cfbcbbaa3ea870528ee34_package.tgz.QF5dss8M: Wrote only 8192 of 10240 bytes
tar: Child returned status 1
tar: Error is not recoverable: exiting now

So set the default pigz thread for clang and the user also can
customize the pigz thread such as PIGZ_pn-clang = "-p 3" for
clang in local.conf to avoid eating so much memory.

Signed-off-by: Mingli Yu <mingli.yu@windriver.com>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
