### PR TITLE
bcc: override the PY_CMD_ESCAPED

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-devtools/bcc/bcc/0001-CMakeLists.txt-override-the-PY_CMD_ESCAPED.patch
+++ b/dynamic-layers/openembedded-layer/recipes-devtools/bcc/bcc/0001-CMakeLists.txt-override-the-PY_CMD_ESCAPED.patch
@@ -1,0 +1,46 @@
+From 4f64ed40e1ffea7ea278627f30a01018e57dcbcf Mon Sep 17 00:00:00 2001
+From: Mingli Yu <mingli.yu@windriver.com>
+Date: Wed, 9 Sep 2020 05:48:19 +0000
+Subject: [PATCH] CMakeLists.txt: override the PY_CMD_ESCAPED
+
+Override the PY_CMD_ESCAPED as the PY_CMD_ESCAPED is constructed by
+the full path of the python3. In some cases, the path is so long and
+result in the PY_CMD_ESCAPED exceeds 255 characters and comes below
+do_configure error:
+ | CMake Error at src/python/CMakeLists.txt:18 (configure_file):
+ |   configure_file Problem configuring file
+ |
+ | CMake Error: Could not open file for write in copy operation /buildarea1/test/wr_build/wr1020_20200909_bcc/bcc_long_Kernel/auto-standalone_next/200827/lxbuilds/Intel-Snow-Ridge-NS_platform_up/intel-x86-64-standard-glibc-std/wrlinux/build/tmp-glibc/work/corei7-64-wrs-linux/bcc/0.15.0-r0/build/src/python/bcc--buildarea1-test-wr_build-wr1020_20200909_bcc-bcc_long_Kernel-auto-standalone_next-200827-lxbuilds-Intel-Snow-Ridge-NS_platform_up-intel-x86-64-standard-glibc-std-wrlinux-build-tmp-glibc-work-corei7-64-wrs-linux-bcc-0.15.0-r0-recipe-sysroot-native-usr-bin-python3-native-python3/bcc/version.py.tmp
+
+Upstream-Status: Pending
+
+Signed-off-by: Mingli Yu <mingli.yu@windriver.com>
+---
+ src/python/CMakeLists.txt | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/python/CMakeLists.txt b/src/python/CMakeLists.txt
+index 797e0d14..8afa6ffa 100644
+--- a/src/python/CMakeLists.txt
++++ b/src/python/CMakeLists.txt
+@@ -12,7 +12,7 @@ file(GLOB_RECURSE PYTHON_INCLUDES RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}
+ 
+ foreach(PY_CMD ${PYTHON_CMD})
+   string(REPLACE "/" "-" PY_CMD_ESCAPED ${PY_CMD})
+-  set(PY_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/bcc-${PY_CMD_ESCAPED})
++  set(PY_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/bcc-python3)
+ 
+   foreach(PY_SRC ${PYTHON_SOURCES})
+     configure_file(${PY_SRC} ${PY_DIRECTORY}/${PY_SRC} COPYONLY)
+@@ -31,7 +31,7 @@ foreach(PY_CMD ${PYTHON_CMD})
+     DEPENDS ${PYTHON_SOURCES} ${PYTHON_INCLUDES}
+     COMMENT "Building sdist for ${PY_CMD}"
+   )
+-  add_custom_target(bcc_py_${PY_CMD_ESCAPED} ALL DEPENDS ${PIP_INSTALLABLE})
++  add_custom_target(bcc_py_python3 ALL DEPENDS ${PIP_INSTALLABLE})
+ 
+   install(
+     CODE "
+-- 
+2.26.2
+

--- a/dynamic-layers/openembedded-layer/recipes-devtools/bcc/bcc_0.15.0.bb
+++ b/dynamic-layers/openembedded-layer/recipes-devtools/bcc/bcc_0.15.0.bb
@@ -19,6 +19,7 @@ SRC_URI = "gitsm://github.com/iovisor/bcc \
            file://0001-tools-opensnoop-snoop-do_sys_openat2-for-kernel-v5.6.patch \
            file://0001-Replace-kprobe-function-blk_account_io_completion-to.patch \
            file://0001-tools-trace.py-Fix-failing-to-exit.patch \
+           file://0001-CMakeLists.txt-override-the-PY_CMD_ESCAPED.patch \
            "
 
 SRCREV = "e41f7a3be5c8114ef6a0990e50c2fbabea0e928e"


### PR DESCRIPTION
Override the PY_CMD_ESCAPED as the PY_CMD_ESCAPED is constructed by
the full path of the python3. In some cases, the path is so long and
result in the PY_CMD_ESCAPED exceeds 255 characters and comes below
do_configure error:
 | CMake Error at src/python/CMakeLists.txt:18 (configure_file):
 |   configure_file Problem configuring file
 |
 | CMake Error: Could not open file for write in copy operation /buildarea1/test/wr_build/wr1020_20200909_bcc/bcc_long_Kernel/auto-standalone_next/200827/lxbuilds/Intel-Snow-Ridge-NS_platform_up/intel-x86-64-standard-glibc-std/wrlinux/build/tmp-glibc/work/corei7-64-wrs-linux/bcc/0.15.0-r0/build/src/python/bcc--buildarea1-test-wr_build-wr1020_20200909_bcc-bcc_long_Kernel-auto-standalone_next-200827-lxbuilds-Intel-Snow-Ridge-NS_platform_up-intel-x86-64-standard-glibc-std-wrlinux-build-tmp-glibc-work-corei7-64-wrs-linux-bcc-0.15.0-r0-recipe-sysroot-native-usr-bin-python3-native-python3/bcc/version.py.tmp

Signed-off-by: Mingli Yu <mingli.yu@windriver.com>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
