### PR TITLE
libffi: Do not use internal assembler on mips64

### DIFF
--- a/conf/nonclangable.conf
+++ b/conf/nonclangable.conf
@@ -154,6 +154,7 @@ CFLAGS_append_pn-mdadm_toolchain-clang = " -Wno-error=unknown-warning-option"
 #../libffi-3.2.1/src/arm/sysv.S:363:2: error: invalid instruction, did you mean: fldmiax?
 # fldmiadgt ip, {d0-d7}
 CFLAGS_append_pn-libffi_arm_toolchain-clang = " -no-integrated-as"
+CFLAGS_append_pn-libffi_mips64_toolchain-clang = " -no-integrated-as"
 
 # ../db-5.3.28/src/mutex/mut_tas.c:150:34: error: unknown directive
 #<inline asm>:9:2: note: instantiated into assembly here


### PR DESCRIPTION
It uses GNU asm which clang's internal assembler gets confused with
and can not interpret .eh_frame section permissions and type

Signed-off-by: Khem Raj <raj.khem@gmail.com>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
