### PR TITLE
clang: fix build failure, unrecogn. link option '-fuse-ld=gold' (#368)

### DIFF
--- a/recipes-devtools/clang/clang_git.bb
+++ b/recipes-devtools/clang/clang_git.bb
@@ -15,7 +15,7 @@ BUILD_CXX_class-nativesdk = "clang++"
 BUILD_AR_class-nativesdk = "llvm-ar"
 BUILD_RANLIB_class-nativesdk = "llvm-ranlib"
 BUILD_NM_class-nativesdk = "llvm-nm"
-LDFLAGS_append_class-nativesdk = " -fuse-ld=gold"
+LDFLAGS_append_class-nativesdk = " -fuse-ld=lld"
 
 inherit cmake cmake-native pkgconfig python3native
 


### PR DESCRIPTION
Command 'bitbake <myimage> -c populate_sdk' fails with
clang-9: error: invalid linker name in argument '-fuse-ld=gold'.
Using the lld linker fixes the problem.

Signed-off-by: Winfried Dobbe <winfried.dobbe@xmsnet.nl>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
