### PR TITLE
github/workflows: Do not sed weston.ini for fbdev-backend.so

### DIFF
--- a/.github/workflows/yoe.yml
+++ b/.github/workflows/yoe.yml
@@ -55,7 +55,6 @@ jobs:
           echo SDKMACHINE = \"aarch64\" >> conf/local.conf
           /bin/bash -c "sed -i -e 's/PACKAGE_FEED_URI.*$//' conf/site.conf"
           /bin/bash -c "sed -i -e 's/SDK_UPDATE_URL.*$//' conf/site.conf"
-          /bin/bash -c "sed -i -e 's/backend=fbdev-backend.so.*$//' sources/openembedded-core/meta/recipes-graphics/wayland/weston-init/qemuall/weston.ini"
       - name: Build Image
         run: |
           cd yoe


### PR DESCRIPTION
This is already taken care in oe-core now

Signed-off-by: Khem Raj <raj.khem@gmail.com>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
