### PR TITLE
clang: Create symlinks with cross compile tuples

### DIFF
--- a/recipes-devtools/clang/clang_git.bb
+++ b/recipes-devtools/clang/clang_git.bb
@@ -189,6 +189,9 @@ endif()\n" ${D}${libdir}/cmake/llvm/LLVMExports-release.cmake
         lnr ${D}${nonarch_libdir}/clang ${D}${libdir}/clang
         rmdir --ignore-fail-on-non-empty ${D}${libdir}
     fi
+    for t in clang clang++ llvm-nm llvm-ar llvm-as llvm-ranlib llvm-strip; do
+        ln -sf $t ${D}${bindir}/${TARGET_PREFIX}$t
+    done
 }
 
 do_install_append_class-native () {


### PR DESCRIPTION
This helps in running ptests e.g. perl which encodes the compiler during
cross-compile and it is <cross-compile>-clang and not simply `clang`
since these tests are configured and compiled on build host and run on
target, its requied to have same names on target as well.

Signed-off-by: Khem Raj <raj.khem@gmail.com>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
