### PR TITLE
make file command output in brief mode when searching for binaries to…

### DIFF
--- a/recipes-devtools/clang/clang_git.bb
+++ b/recipes-devtools/clang/clang_git.bb
@@ -195,7 +195,7 @@ do_install_append_class-native () {
     install -Dm 0755 ${B}${BINPATHPREFIX}/bin/clang-tblgen ${D}${bindir}/clang-tblgen
     install -Dm 0755 ${B}${BINPATHPREFIX}/bin/lldb-tblgen ${D}${bindir}/lldb-tblgen
     for f in `find ${D}${bindir} -executable -type f -not -type l`; do
-        test -n "`file $f|grep -i ELF`" && ${STRIP} $f
+        test -n "`file -b $f|grep -i ELF`" && ${STRIP} $f
         echo "stripped $f"
     done
     ln -sf clang-tblgen ${D}${bindir}/clang-tblgen${PV}
@@ -207,7 +207,7 @@ do_install_append_class-nativesdk () {
     install -Dm 0755 ${B}${BINPATHPREFIX}/bin/clang-tblgen ${D}${bindir}/clang-tblgen
     install -Dm 0755 ${B}${BINPATHPREFIX}/bin/lldb-tblgen ${D}${bindir}/lldb-tblgen
     for f in `find ${D}${bindir} -executable -type f -not -type l`; do
-        test -n "`file $f|grep -i ELF`" && ${STRIP} $f
+        test -n "`file -b $f|grep -i ELF`" && ${STRIP} $f
     done
     ln -sf clang-tblgen ${D}${bindir}/clang-tblgen${PV}
     ln -sf llvm-tblgen ${D}${bindir}/llvm-tblgen${PV}


### PR DESCRIPTION
… strip

otherwise we grep around in the absolute path to the binary which leads
to false positives when e.g. user THelfer put their tree under ~

Signed-off-by: Daniel Wagener <daniel.wagener@kernelconcepts.de>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
