### PR TITLE
classes/clang.bbclass: Remove -mmusl flag from toolchain.cmake.

### DIFF
--- a/classes/clang.bbclass
+++ b/classes/clang.bbclass
@@ -100,5 +100,6 @@ cmake_do_generate_toolchain_file_append_toolchain-clang () {
     cat >> ${WORKDIR}/toolchain.cmake <<EOF
 set( CMAKE_CLANG_TIDY ${CLANG_TIDY} )
 EOF
+    sed -i 's/ -mmusl / /g' ${WORKDIR}/toolchain.cmake
 }
 


### PR DESCRIPTION
The -mmusl flag is GCC specific, Clang supports MUSL differently.

Prevents clang-11: error: unknown argument: '-mmusl'

Verified it does not affect the GCC toolchain.cmake build.

Signed-off-by: Leon Woestenberg <leon@sidebranch.com>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
