### PR TITLE
CastXML: new recipe

### DIFF
--- a/recipes-devtools/castxml/castxml_git.bb
+++ b/recipes-devtools/castxml/castxml_git.bb
@@ -1,0 +1,29 @@
+SUMMARY = "C-family abstract syntax tree XML output tool."
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
+
+SRC_URI = "git://github.com/CastXML/CastXML"
+
+# 0.3.6 is the release for LLVM/Clang v11.0.0
+SRCREV = "902ac163f0291fcfc459f58691481e88c9f91dea"
+PV = "0.3.6"
+
+S = "${WORKDIR}/git"
+
+DEPENDS = "clang"
+
+# Match clang's idea of what TOOLCHAIN should be.
+TOOLCHAIN = "clang"
+TOOLCHAIN_class-native = "gcc"
+TOOLCHAIN_class-nativesdk = "clang"
+
+BUILD_CC_class-nativesdk = "clang"
+BUILD_CXX_class-nativesdk = "clang++"
+BUILD_AR_class-nativesdk = "llvm-ar"
+BUILD_RANLIB_class-nativesdk = "llvm-ranlib"
+BUILD_NM_class-nativesdk = "llvm-nm"
+LDFLAGS_append_class-nativesdk = " -fuse-ld=gold"
+
+inherit cmake cmake-native pkgconfig python3native
+
+BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
CastXML is an AST analysis tool similar to and succeeding gccxml. It
is used to generate an XML description of a C or C++ abstract syntax
tree.

Signed-off-by: Daniel McGregor <daniel.mcgregor@vecima.com>
Signed-off-by: Khem Raj <raj.khem@gmail.com>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
