### PR TITLE
Remove compiler arguments from CLANG_TIDY_EXE 

### DIFF
--- a/recipes-core/meta/clang-environment.inc
+++ b/recipes-core/meta/clang-environment.inc
@@ -14,6 +14,6 @@ create_sdk_files_append() {
             echo 'export CLANGCC="${TARGET_PREFIX}clang ${TARGET_CLANGCC_ARCH} --sysroot=$SDKTARGETSYSROOT"' >> $script
             echo 'export CLANGCXX="${TARGET_PREFIX}clang++ ${TARGET_CLANGCC_ARCH} --sysroot=$SDKTARGETSYSROOT"' >> $script
             echo 'export CLANGCPP="${TARGET_PREFIX}clang -E ${TARGET_CLANGCC_ARCH} --sysroot=$SDKTARGETSYSROOT"' >> $script
-            echo 'export CLANG_TIDY_EXE="${TARGET_PREFIX}clang-tidy ${TARGET_CLANGCC_ARCH} --sysroot=$SDKTARGETSYSROOT"' >> $script
+            echo 'export CLANG_TIDY_EXE="${TARGET_PREFIX}clang-tidy"' >> $script
         fi
 }


### PR DESCRIPTION
clang-tidy doesn't process compilation flags like "-mlittle-endian" and "sysroot". The current export tries to use those flags, which makes clang-tidy fail like in the following example:

> $ aarch64-poky-linux-clang-tidy fibonacci.cpp -mlittle-endian --sysroot=/opt/mgu22/sysroots/aarch64-poky-linux
> LLVM ERROR: CommonOptionsParser: failed to parse command-line arguments. [CommonOptionsParser]: aarch64-poky-linux-clang-tidy: Unknown command line argument '-mlittle-endian'.  Try: 'aarch64-poky-linux-clan$
> aarch64-poky-linux-clang-tidy: Did you mean '--list-checks'?
> aarch64-poky-linux-clang-tidy: Unknown command line argument '--sysroot=/opt/mgu22/sysroots/aarch64-poky-linux'.  Try: 'aarch64-poky-linux-clang-tidy --help'
> aarch64-poky-linux-clang-tidy: Did you mean '--color=/opt/mgu22/sysroots/aarch64-poky-linux'?

This change removes those compiler arguments:

> $ aarch64-poky-linux-clang-tidy fibonacci.cpp
> Error while trying to load a compilation database:
> Could not auto-detect compilation database for file "fibonacci.cpp"
> No compilation database found in /home/mqueiros/workspace/minimal-working-example/fibonacci or any parent directory
> fixed-compilation-database: Error while opening fixed database: No such file or directory
> json-compilation-database: Error while opening JSON database: No such file or directory
> Running without flags.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)

Signed-off-by: Mauro Queiros <maurofrqueiros@gmail.com>