### PR TITLE
do not use compiler arguments for clang-tidy (backport to dunfell)

### DIFF
--- a/recipes-core/meta/meta-environment.bbappend
+++ b/recipes-core/meta/meta-environment.bbappend
@@ -14,6 +14,6 @@ create_sdk_files_append() {
             echo 'export CLANGCC="${TARGET_PREFIX}clang ${TARGET_CLANGCC_ARCH} --sysroot=$SDKTARGETSYSROOT"' >> $script
             echo 'export CLANGCXX="${TARGET_PREFIX}clang++ ${TARGET_CLANGCC_ARCH} --sysroot=$SDKTARGETSYSROOT"' >> $script
             echo 'export CLANGCPP="${TARGET_PREFIX}clang -E ${TARGET_CLANGCC_ARCH} --sysroot=$SDKTARGETSYSROOT"' >> $script
-            echo 'export CLANG_TIDY_EXE="${TARGET_PREFIX}clang-tidy ${TARGET_CLANGCC_ARCH} --sysroot=$SDKTARGETSYSROOT"' >> $script
+            echo 'export CLANG_TIDY_EXE="${TARGET_PREFIX}clang-tidy"' >> $script
         fi
 }


### PR DESCRIPTION
clang-tidy does not know compiler arguments

Signed-off-by: Daniel Dittmann <daniel.dittmann@rohde-schwarz.com>
