### PR TITLE
llvm: Do not crash on weird `bitcast <1 x i8*> to i8*`

### DIFF
--- a/recipes-devtools/clang/clang/0027-InstCombine-visitBitCast-do-not-crash-on-weird-bitca.patch
+++ b/recipes-devtools/clang/clang/0027-InstCombine-visitBitCast-do-not-crash-on-weird-bitca.patch
@@ -1,0 +1,51 @@
+From 381054a989ebd0b585fee46f2a01a7c5de10acf7 Mon Sep 17 00:00:00 2001
+From: Roman Lebedev <lebedev.ri@gmail.com>
+Date: Wed, 24 Jun 2020 21:12:09 +0300
+Subject: [PATCH] [InstCombine] visitBitCast(): do not crash on weird `bitcast
+ <1 x i8*> to i8*`
+
+Even if we know that RHS of a bitcast is a pointer,
+we can't assume LHS is, because it might be
+a single-element vector of pointer.
+
+Upstream-Status: Backport [https://github.com/llvm/llvm-project/commit/381054a989ebd0b585fee46f2a01a7c5de10acf7]
+
+Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>
+
+---
+ lib/Transforms/InstCombine/InstCombineCasts.cpp | 3 ++-
+ test/Transforms/InstCombine/bitcast.ll          | 6 ++++++
+ 2 files changed, 8 insertions(+), 1 deletion(-)
+
+diff --git a/lib/Transforms/InstCombine/InstCombineCasts.cpp b/lib/Transforms/InstCombine/InstCombineCasts.cpp
+index 3750f31e3cf..a8c87ea3558 100644
+--- a/lib/Transforms/InstCombine/InstCombineCasts.cpp
++++ b/lib/Transforms/InstCombine/InstCombineCasts.cpp
+@@ -2471,8 +2471,9 @@ Instruction *InstCombiner::visitBitCast(BitCastInst &CI) {
+   if (DestTy == Src->getType())
+     return replaceInstUsesWith(CI, Src);
+
+-  if (PointerType *DstPTy = dyn_cast<PointerType>(DestTy)) {
++  if (isa<PointerType>(SrcTy) && isa<PointerType>(DestTy)) {
+     PointerType *SrcPTy = cast<PointerType>(SrcTy);
++    PointerType *DstPTy = cast<PointerType>(DestTy);
+     Type *DstElTy = DstPTy->getElementType();
+     Type *SrcElTy = SrcPTy->getElementType();
+
+diff --git a/test/Transforms/InstCombine/bitcast.ll b/test/Transforms/InstCombine/bitcast.ll
+index 0f0cbdb364a..c4ee52f27a8 100644
+--- a/test/Transforms/InstCombine/bitcast.ll
++++ b/test/Transforms/InstCombine/bitcast.ll
+@@ -561,3 +561,9 @@ define void @constant_fold_vector_to_half() {
+   store volatile half bitcast (<4 x i4> <i4 0, i4 0, i4 0, i4 4> to half), half* undef
+   ret void
+ }
++
++; Ensure that we do not crash when looking at such a weird bitcast.
++define i8* @bitcast_from_single_element_pointer_vector_to_pointer(<1 x i8*> %ptrvec) {
++  %ptr = bitcast <1 x i8*> %ptrvec to i8*
++  ret i8* %ptr
++}
+--
+2.17.1
+

--- a/recipes-devtools/clang/common.inc
+++ b/recipes-devtools/clang/common.inc
@@ -34,6 +34,7 @@ SRC_URI = "\
     file://0024-fix-path-to-libffi.patch \
     file://0025-clang-driver-Add-dyld-prefix-when-checking-sysroot-f.patch \
     file://0026-OpenCL-Fix-support-for-cl_khr_mipmap_image_writes.patch \
+    file://0027-InstCombine-visitBitCast-do-not-crash-on-weird-bitca.patch;patchdir=llvm \
 "
 
 # Fallback to no-PIE if not set


### PR DESCRIPTION
This patch is already merged in llvm-11.

Ref:
https://github.com/llvm/llvm-project/commit/381054a989ebd0b585fee46f2a01a7c5de10acf7

Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
