### PR TITLE
Fix QT on rv32 and use -mo-relax to compile so lld can be used for LTO

### DIFF
--- a/classes/clang.bbclass
+++ b/classes/clang.bbclass
@@ -9,6 +9,8 @@ RANLIB_toolchain-clang = "${HOST_PREFIX}llvm-ranlib"
 AR_toolchain-clang = "${HOST_PREFIX}llvm-ar"
 NM_toolchain-clang = "${HOST_PREFIX}llvm-nm"
 
+LTO_toolchain-clang = "${@bb.utils.contains('DISTRO_FEATURES', 'thin-lto', '-flto=thin', '-flto ', d)}"
+
 export CLANG_TIDY_toolchain-clang = "${HOST_PREFIX}clang-tidy"
 
 COMPILER_RT ??= "${@bb.utils.contains("RUNTIME", "llvm", "-rtlib=compiler-rt ${UNWINDLIB}", "", d)}"

--- a/classes/clang.bbclass
+++ b/classes/clang.bbclass
@@ -37,6 +37,10 @@ TUNE_CCARGS_append_toolchain-clang = "${@bb.utils.contains_any("TUNE_FEATURES", 
 TUNE_CCARGS_append_toolchain-clang = "${@bb.utils.contains_any("TUNE_FEATURES", "cortexa72-cortexa35", " -mtune=cortex-a35", "", d)}"
 TUNE_CCARGS_append_toolchain-clang = "${@bb.utils.contains_any("TUNE_FEATURES", "cortexa75-cortex-a55 cortexa76-cortex-a55", " -mtune=cortex-a55", "", d)}"
 
+# LLD does not yet support relaxation for RISCV e.g. https://reviews.freebsd.org/D25210
+TUNE_CCARGS_append_toolchain-clang_riscv32 = " -mno-relax"
+TUNE_CCARGS_append_toolchain-clang_riscv64 = " -mno-relax"
+
 TUNE_CCARGS_remove_toolchain-clang_powerpc = "-mhard-float"
 TUNE_CCARGS_remove_toolchain-clang_powerpc = "-mno-spe"
 

--- a/classes/clang.bbclass
+++ b/classes/clang.bbclass
@@ -9,7 +9,8 @@ RANLIB_toolchain-clang = "${HOST_PREFIX}llvm-ranlib"
 AR_toolchain-clang = "${HOST_PREFIX}llvm-ar"
 NM_toolchain-clang = "${HOST_PREFIX}llvm-nm"
 
-LTO_toolchain-clang = "${@bb.utils.contains('DISTRO_FEATURES', 'thin-lto', '-flto=thin', '-flto ', d)}"
+LTO_toolchain-clang = "${@bb.utils.contains('DISTRO_FEATURES', 'thin-lto', '-flto=thin', '-flto -fuse-ld=lld', d)}"
+PACKAGE_DEBUG_SPLIT_STYLE_toolchain-clang = "debug-without-src"
 
 export CLANG_TIDY_toolchain-clang = "${HOST_PREFIX}clang-tidy"
 

--- a/classes/lto.bbclass
+++ b/classes/lto.bbclass
@@ -1,7 +1,0 @@
-# Enable LTO based on global distro settings
-TOOLCHAIN_OPTIONS_append_toolchain-clang = "${@bb.utils.contains('DISTRO_FEATURES', 'thin-lto', ' -flto=thin -fuse-ld=gold', '', d)}"
-TOOLCHAIN_OPTIONS_append_toolchain-clang = "${@bb.utils.contains('DISTRO_FEATURES', 'full-lto', ' -flto=full -fuse-ld=gold', '', d)}"
-RANLIB_toolchain-clang = "${STAGING_BINDIR_TOOLCHAIN}/${TARGET_PREFIX}llvm-ranlib"
-AR_toolchain-clang = "${STAGING_BINDIR_TOOLCHAIN}/${TARGET_PREFIX}llvm-ar"
-NM_toolchain-clang = "${STAGING_BINDIR_TOOLCHAIN}/${TARGET_PREFIX}llvm-nm"
-

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -7,7 +7,7 @@ BBFILES += "${LAYERDIR}/recipes*/*/*.bb ${LAYERDIR}/recipes*/*/*.bbappend"
 BBFILE_COLLECTIONS += "clang-layer"
 BBFILE_PATTERN_clang-layer := "^${LAYERDIR}/"
 BBFILE_PRIORITY_clang-layer = "7"
-LAYERSERIES_COMPAT_clang-layer = "gatesgarth"
+LAYERSERIES_COMPAT_clang-layer = "gatesgarth hardknott"
 LAYERDEPENDS_clang-layer = "core"
 
 BBFILES_DYNAMIC += " \

--- a/conf/nonclangable.conf
+++ b/conf/nonclangable.conf
@@ -254,6 +254,10 @@ COMPILER_RT_remove_pn-m4_armeb = "--rtlib=compiler-rt"
 COMPILER_RT_remove_pn-ruby_armeb = "--rtlib=compiler-rt"
 COMPILER_RT_remove_pn-webkitgtk_armeb = "--rtlib=compiler-rt"
 
+# build/lib/libQt5Widgets.so: undefined reference to `__lshrti3'
+# __lshrti3 is missing in libgcc
+COMPILER_RT_pn-qtbase_toolchain-clang_riscv32 = "--rtlib=compiler-rt ${UNWINDLIB}"
+
 LDFLAGS_append_pn-gnutls_toolchain-clang_riscv64 = " -latomic"
 LDFLAGS_append_pn-harfbuzz_toolchain-clang_riscv64 = " -latomic"
 LDFLAGS_append_pn-qtwebengine_toolchain-clang_runtime-gnu_x86 = " -latomic"

--- a/conf/nonclangable.conf
+++ b/conf/nonclangable.conf
@@ -295,3 +295,11 @@ BUILD_CC_pn-nss_toolchain-clang = "clang"
 CXXFLAGS_append_pn-apt_toolchain-clang = " -Wno-c++11-narrowing"
 lcl_maybe_fortify_pn-apt_toolchain-clang = ""
 
+# LTO
+# Seems to use symver ASMs see https://stackoverflow.com/questions/46304742/how-to-combine-lto-with-symbol-versioning
+# lib/puny_encode.c:136: multiple definition of `_idn2_punycode_encode'
+LTO_pn-libidn2_toolchain-clang = ""
+
+#libcairo.so: undefined reference to pthread_mutexattr_init [--no-allow-shlib-undefined]
+LTO_pn-cairo_toolchain-clang = ""
+

--- a/recipes-core/musl/musl_%.bbappend
+++ b/recipes-core/musl/musl_%.bbappend
@@ -3,8 +3,6 @@ TOOLCHAIN_x86-x32 = "gcc"
 TOOLCHAIN_riscv64 = "gcc"
 TOOLCHAIN_powerpc64 = "gcc"
 
-inherit lto
-
 # workaround until https://bugs.llvm.org/show_bug.cgi?id=44384
 # is fixed
 do_configure_prepend_toolchain-clang () {

--- a/recipes-devtools/clang/clang_git.bb
+++ b/recipes-devtools/clang/clang_git.bb
@@ -52,17 +52,17 @@ def get_clang_experimental_target_arch(bb, d):
     return get_clang_experimental_arch(bb, d, 'TARGET_ARCH')
 
 PACKAGECONFIG ??= "compiler-rt libcplusplus shared-libs lldb-wchar \
-                   ${@bb.utils.filter('DISTRO_FEATURES', 'thin-lto full-lto', d)} \
+                   ${@bb.utils.filter('DISTRO_FEATURES', 'thin-lto lto', d)} \
                    rtti eh libedit \
                    "
 PACKAGECONFIG_class-native = "rtti eh libedit"
-PACKAGECONFIG_class-nativesdk = "rtti eh libedit shared-libs ${@bb.utils.filter('DISTRO_FEATURES', 'thin-lto full-lto', d)}"
+PACKAGECONFIG_class-nativesdk = "rtti eh libedit shared-libs ${@bb.utils.filter('DISTRO_FEATURES', 'thin-lto lto', d)}"
 
 PACKAGECONFIG[compiler-rt] = "-DCLANG_DEFAULT_RTLIB=compiler-rt,,libcxx,compiler-rt"
 PACKAGECONFIG[libcplusplus] = "-DCLANG_DEFAULT_CXX_STDLIB=libc++,,libcxx"
 PACKAGECONFIG[unwindlib] = "-DCLANG_DEFAULT_UNWINDLIB=libunwind,-DCLANG_DEFAULT_UNWINDLIB=libgcc,libcxx"
 PACKAGECONFIG[thin-lto] = "-DLLVM_ENABLE_LTO=Thin -DLLVM_BINUTILS_INCDIR=${STAGING_INCDIR},,binutils,"
-PACKAGECONFIG[full-lto] = "-DLLVM_ENABLE_LTO=Full -DLLVM_BINUTILS_INCDIR=${STAGING_INCDIR},,binutils,"
+PACKAGECONFIG[lto] = "-DLLVM_ENABLE_LTO=Full -DLLVM_BINUTILS_INCDIR=${STAGING_INCDIR},,binutils,"
 PACKAGECONFIG[shared-libs] = "-DLLVM_BUILD_LLVM_DYLIB=ON -DLLVM_LINK_LLVM_DYLIB=ON,,,"
 PACKAGECONFIG[terminfo] = "-DLLVM_ENABLE_TERMINFO=ON,-DLLVM_ENABLE_TERMINFO=OFF,ncurses,"
 PACKAGECONFIG[pfm] = "-DLLVM_ENABLE_LIBPFM=ON,-DLLVM_ENABLE_LIBPFM=OFF,libpfm,"


### PR DESCRIPTION
---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
