### PR TITLE
clang.bbclass: Remove -mcpu option for the octeontx2 core

### DIFF
--- a/classes/clang.bbclass
+++ b/classes/clang.bbclass
@@ -40,6 +40,9 @@ TUNE_CCARGS_append_toolchain-clang = "${@bb.utils.contains_any("TUNE_FEATURES", 
 TUNE_CCARGS_append_toolchain-clang = "${@bb.utils.contains_any("TUNE_FEATURES", "cortexa72-cortexa35", " -mtune=cortex-a35", "", d)}"
 TUNE_CCARGS_append_toolchain-clang = "${@bb.utils.contains_any("TUNE_FEATURES", "cortexa75-cortex-a55 cortexa76-cortex-a55", " -mtune=cortex-a55", "", d)}"
 
+# Clang does not support octeontx2 processor
+TUNE_CCARGS_remove_toolchain-clang = "-mcpu=octeontx2"
+
 # LLD does not yet support relaxation for RISCV e.g. https://reviews.freebsd.org/D25210
 TUNE_CCARGS_append_toolchain-clang_riscv32 = " -mno-relax"
 TUNE_CCARGS_append_toolchain-clang_riscv64 = " -mno-relax"


### PR DESCRIPTION
The tune file for octeontx2 has been added into oe-core by commit
ad4f82742c6f ("tune-octeontx2.inc: Add tune for Marvell OCTEON TX2
core"). But the clang doesn't support this core yet. So remove the
-mcpu from the TUNE_CCARGS to fix the build failure for the octeontx2
core.

Signed-off-by: Kevin Hao <kexin.hao@windriver.com>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
