### PR TITLE
ppp: Mark non-clangable

### DIFF
--- a/conf/nonclangable.conf
+++ b/conf/nonclangable.conf
@@ -279,6 +279,7 @@ COMPILER_RT_pn-qtbase_toolchain-clang_riscv32 = "--rtlib=compiler-rt ${UNWINDLIB
 LDFLAGS_append_pn-gnutls_toolchain-clang_riscv64 = " -latomic"
 LDFLAGS_append_pn-harfbuzz_toolchain-clang_riscv64 = " -latomic"
 LDFLAGS_append_pn-qtwebengine_toolchain-clang_runtime-gnu_x86 = " -latomic"
+LDFLAGS_append_pn-qemu_toolchain-clang_runtime-gnu_x86 = " -latomic"
 
 # glibc is built with gcc and hence encodes some libgcc specific builtins which are not found
 # when doing static linking with clang using compiler-rt, so use libgcc

--- a/conf/nonclangable.conf
+++ b/conf/nonclangable.conf
@@ -101,6 +101,10 @@ TOOLCHAIN_pn-pixman = "gcc"
 #|     ^
 TOOLCHAIN_pn-polkit = "gcc"
 
+# ppp uses nested functions and gcc specific option e.g. --print-sysroot
+#
+TOOLCHAIN_pn-ppp = "gcc"
+
 #| ./ports/linux/pseudo_wrappers.c:80:14: error: use of unknown builtin '__builtin_apply' [-Wimplicit-function-declaration]
 #|         void *res = __builtin_apply((void (*)()) real_syscall, __builtin_apply_args(), sizeof(long) * 7);
 #|                     ^


### PR DESCRIPTION
New version of ppp uses gcc specific options and nested functions which
clang does not support

Signed-off-by: Khem Raj <raj.khem@gmail.com>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
