### PR TITLE
clang: for x86_64, set Yocto GCC install search path

### DIFF
--- a/recipes-devtools/clang/clang/0027-For-x86_64-set-Yocto-based-GCC-install-search-path.patch
+++ b/recipes-devtools/clang/clang/0027-For-x86_64-set-Yocto-based-GCC-install-search-path.patch
@@ -1,0 +1,67 @@
+From d507046e9deec46f005ad164073d3cae4e0b8a47 Mon Sep 17 00:00:00 2001
+From: Hongxu Jia <hongxu.jia@windriver.com>
+Date: Mon, 25 Jan 2021 16:14:35 +0800
+Subject: [PATCH] For x86_64, set Yocto based GCC install search path
+
+Under Yocto host, while using clang-native to build, it searches
+install host gcc failed which causing the include file not found
+[snip]
+|clang++ -target x86_64-linux  -MMD -MF src/base/files/file_path_constants.o.d -I../../../tools/gn/src -I. \
+-isystem/tmp-glibc/work/x86_64-linux/gn-native/87.0.4280.141-r0/recipe-sysroot-native/usr/include -O2 -pipe \
+-std=c++17 -c ../../../tools/gn/src/base/files/file_path_constants.cc -o src/base/files/file_path_constants.o
+|../../../tools/gn/src/base/files/file_path_constants.cc:7:10: fatal error: 'iterator' file not found
+|#include <iterator>
+|         ^~~~~~~~
+[snip]
+
+Set three Yocto based GCC triple: poky, oe-core and wind river
+
+Before aplly the patch
+[snip]
+$ ../recipe-sysroot-native/usr/bin/clang++ -v
+clang version 11.0.1 (https://github.com/llvm/llvm-project 43ff75f2c3feef64f9d73328230d34dac8832a91)
+Target: x86_64-unknown-linux-gnu
+Thread model: posix
+InstalledDir:tmp-glibc/work/x86_64-linux/gn-native/87.0.4280.141-r0/chromium-87.0.4280.141/../recipe-sysroot-native/usr/bin
+[snip]
+
+After aplly the patch:
+[snip]
+$ ../recipe-sysroot-native/usr/bin/clang++ -v
+clang version 11.0.1 (https://github.com/llvm/llvm-project 22c3241ff9a6224261df48d0258957fd8acc3d64)
+Target: x86_64-unknown-linux-gnu
+Thread model: posix
+InstalledDir:tmp-glibc/work/x86_64-linux/gn-native/87.0.4280.141-r0/chromium-87.0.4280.141/../recipe-sysroot-native/usr/bin
+Found candidate GCC installation: /usr/lib//x86_64-wrs-linux/10.1.0
+Found candidate GCC installation: /usr/lib/gcc/x86_64-wrs-linux/10.1.0
+Selected GCC installation: /usr/lib//x86_64-wrs-linux/10.1.0
+Candidate multilib: .;@m64
+Selected multilib: .;@m64
+[snip]
+
+BTW, it is hardly to insert a triple by the replacement of TARGET_SYS
+(=${TARGET_ARCH}${TARGET_VENDOR}-${TARGET_OS}), since TARGET_VENDOR
+is different between clang and clang-native
+
+Upstream-Status: Inappropriate [oe specific]
+
+Signed-off-by: Hongxu Jia <hongxu.jia@windriver.com>
+---
+ clang/lib/Driver/ToolChains/Gnu.cpp | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/clang/lib/Driver/ToolChains/Gnu.cpp b/clang/lib/Driver/ToolChains/Gnu.cpp
+index d02e644c720b..fdcf6b91ebe1 100644
+--- a/clang/lib/Driver/ToolChains/Gnu.cpp
++++ b/clang/lib/Driver/ToolChains/Gnu.cpp
+@@ -2083,6 +2083,7 @@ void Generic_GCC::GCCInstallationDetector::AddDefaultGCCPrefixes(
+       "x86_64-redhat-linux",    "x86_64-suse-linux",
+       "x86_64-manbo-linux-gnu", "x86_64-linux-gnu",
+       "x86_64-slackware-linux", "x86_64-unknown-linux",
++      "x86_64-oe-linux", "x86_64-poky-linux", "x86_64-wrs-linux",
+       "x86_64-amazon-linux",    "x86_64-linux-android"};
+   static const char *const X32LibDirs[] = {"/libx32"};
+   static const char *const X86LibDirs[] = {"/lib32", "/lib"};
+-- 
+2.18.2
+

--- a/recipes-devtools/clang/common.inc
+++ b/recipes-devtools/clang/common.inc
@@ -34,6 +34,7 @@ SRC_URI = "\
     file://0024-clang-driver-Add-dyld-prefix-when-checking-sysroot-f.patch \
     file://0025-libcxx-Define-__NR_futex-to-be-__NR_futex_time64-on-.patch \
     file://0026-clang-Use-python3-in-python-scripts.patch \
+    file://0027-For-x86_64-set-Yocto-based-GCC-install-search-path.patch \
 "
 
 # Fallback to no-PIE if not set


### PR DESCRIPTION
Under Yocto host, while using clang-native to build, it searches
install host gcc failed which causing include file not found
[snip]
|clang++ -target x86_64-linux  -MMD -MF src/base/files/file_path_constants.o.d -I../../../tools/gn/src -I. \
-isystem/tmp-glibc/work/x86_64-linux/gn-native/87.0.4280.141-r0/recipe-sysroot-native/usr/include -O2 -pipe \
-std=c++17 -c ../../../tools/gn/src/base/files/file_path_constants.cc -o src/base/files/file_path_constants.o
|../../../tools/gn/src/base/files/file_path_constants.cc:7:10: fatal error: 'iterator' file not found
|#include <iterator>
|         ^~~~~~~~
[snip]

Set three Yocto based GCC triple: poky, oe-core and wind river

Before aplly the patch
[snip]
$ ../recipe-sysroot-native/usr/bin/clang++ -v
clang version 11.0.1 (https://github.com/llvm/llvm-project 43ff75f2c3feef64f9d73328230d34dac8832a91)
Target: x86_64-unknown-linux-gnu
Thread model: posix
InstalledDir:
/buildarea/raid5/hjia/wrlinux-20/build_master-wr_browser_2021012017/build-gn-native/tmp-glibc/work/x86_64-linux/gn-native/87.0.4280.141-r0/chromium-87.0.4280.141/../recipe-sysroot-native/usr/bin
[snip]

After aplly the patch:
[snip]
$ clang-11 -v
clang version 11.0.1 (https://github.com/llvm/llvm-project 22c3241ff9a6224261df48d0258957fd8acc3d64)
Target: x86_64-unknown-linux-gnu
Thread model: posix
InstalledDir: /buildarea/raid5/hjia/wrlinux-20/build_master-wr_browser_2021012017/build/tmp-glibc/work/x86_64-linux/clang-native/11.0.1-r0/build/bin
Found candidate GCC installation: /usr/lib//x86_64-wrs-linux/10.1.0
Found candidate GCC installation: /usr/lib/gcc/x86_64-wrs-linux/10.1.0
Selected GCC installation: /usr/lib//x86_64-wrs-linux/10.1.0
Candidate multilib: .;@m64
Selected multilib: .;@m64
[snip]

BTW, it is hardly to insert a triple by the replacement of TARGET_SYS
(=${TARGET_ARCH}${TARGET_VENDOR}-${TARGET_OS}), since TARGET_VENDOR
is different between clang and clang-native

Signed-off-by: Hongxu Jia <hongxu.jia@windriver.com>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
