### PR TITLE
clang.bbclass: Set CCACHE_COMPILERCHECK as default value

### DIFF
--- a/classes/clang.bbclass
+++ b/classes/clang.bbclass
@@ -1,5 +1,5 @@
 # Add the necessary override
-CCACHE_COMPILERCHECK_toolchain-clang = "%compiler% -v"
+CCACHE_COMPILERCHECK_toolchain-clang ?= "%compiler% -v"
 HOST_CC_ARCH_prepend_toolchain-clang = "-target ${HOST_SYS} "
 CC_toolchain-clang  = "${CCACHE}${HOST_PREFIX}clang ${HOST_CC_ARCH}${TOOLCHAIN_OPTIONS}"
 CXX_toolchain-clang = "${CCACHE}${HOST_PREFIX}clang++ ${HOST_CC_ARCH}${TOOLCHAIN_OPTIONS}"


### PR DESCRIPTION
oe-core's ccache.bbclass contains:

 export CCACHE_COMPILERCHECK ?= "%compiler% -dumpspecs"

which sets a default value and allows others to easily override the
value of CCACHE_COMPILERCHECK if they wish to. Let's update
clang.bbclass to also set only the default value of CCACHE_COMPILERCHECK
too.

Signed-off-by: Mike Crowe <mac@mcrowe.com>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
