### PR TITLE
layer.conf: remove bcc and bpftrace from NON_MULTILIB_RECIPES

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -33,5 +33,3 @@ LLVMVERSION = "11.1.0"
 
 require conf/nonclangable.conf
 require conf/nonscanable.conf
-
-NON_MULTILIB_RECIPES_append = " bcc bpftrace"


### PR DESCRIPTION
Because bcc and bpftrace have been set in NON_MULTILIB_RECIPES, 'bcc'
rprovides 'lib32-bcc'. So when multilib is enabled, it is 'bcc' rather
than 'lib32-bcc' installed to lib32 image such as lib32-core-image-minimal.
Then the runtime dependency 64-bit package python3-core is installed
accordingly. It causes 32-bit python modules which contains .so library
do not work any more. For example, it fails to run command 'dnf':

| ImportError: /usr/lib/python3.9/site-packages/libdnf/_error.so: wrong ELF class: ELFCLASS32

Remove bcc and bpftrace from NON_MULTILIB_RECIPES to make sure they are
not installed to lib32 images and mess images up.

Signed-off-by: Kai Kang <kai.kang@windriver.com>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
