### PR TITLE
libclc fixes

### DIFF
--- a/recipes-devtools/clang/libclc_git.bb
+++ b/recipes-devtools/clang/libclc_git.bb
@@ -15,11 +15,10 @@ DEPENDS_append = " qemu-native clang"
 
 OECMAKE_SOURCEPATH = "${S}/libclc"
 
+CXXFLAGS += "-std=c++17"
+
 EXTRA_OECMAKE += " \
 				-DCMAKE_CROSSCOMPILING_EMULATOR=${WORKDIR}/qemuwrapper \
-				-DCMAKE_CXX_FLAGS=-std=c++17 \
-				-DCMAKE_SHARED_LINKER_FLAGS=-std=c++17 \
-				-DCMAKE_EXE_LINKER_FLAGS=-std=c++17 \
 				-Dclc_comp_in:FILEPATH=${OECMAKE_SOURCEPATH}/cmake/CMakeCLCCompiler.cmake.in \
 				-Dll_comp_in:FILEPATH=${OECMAKE_SOURCEPATH}/cmake/CMakeLLAsmCompiler.cmake.in \
 			"

--- a/recipes-devtools/clang/libclc_git.bb
+++ b/recipes-devtools/clang/libclc_git.bb
@@ -35,3 +35,5 @@ EOF
 }
 
 FILES_${PN} += "${datadir}/clc"
+
+BBCLASSEXTEND = "native nativesdk"

--- a/recipes-devtools/clang/libclc_git.bb
+++ b/recipes-devtools/clang/libclc_git.bb
@@ -11,7 +11,9 @@ LIC_FILES_CHKSUM = "file://libclc/LICENSE.TXT;md5=7cc795f6cbb2d801d84336b83c8017
 
 inherit cmake pkgconfig python3native qemu
 
-DEPENDS_append = " qemu-native clang"
+SPIRV_DEP = "${@'spirv-tools spirv-tools-native' if int(d.getVar('MAJOR_VER')) >= 12 else ''}"
+
+DEPENDS_append = " qemu-native clang ${SPIRV_DEP}"
 
 OECMAKE_SOURCEPATH = "${S}/libclc"
 


### PR DESCRIPTION
Don't override cmake specific compiler options
Add BBCLASSEXTEND = "native nativesdk"
Depend on spirv-tools if LLVM version is 12 or newer

Signed-off-by: Zoltán Böszörményi <zboszor@pr.hu>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
