### PR TITLE
libclc: Fix linker issue if build host is the same arch as target

### DIFF
--- a/recipes-devtools/clang/libclc_git.bb
+++ b/recipes-devtools/clang/libclc_git.bb
@@ -14,6 +14,7 @@ inherit cmake pkgconfig python3native qemu
 SPIRV_DEP = "${@'spirv-tools spirv-tools-native' if int(d.getVar('MAJOR_VER')) >= 12 else ''}"
 
 DEPENDS_append = " qemu-native clang ${SPIRV_DEP}"
+DEPENDS_append_class-target = " llvm-common"
 
 OECMAKE_SOURCEPATH = "${S}/libclc"
 


### PR DESCRIPTION
llvm-config from clang-native leaks -L linker options to target builds.
Add llvm-common as build dependency for target builds to fix it.

Signed-off-by: Zoltán Böszörményi <zboszor@pr.hu>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [X] Changes have been tested
- [X] `Signed-off-by` is present
- [X] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
