### PR TITLE
spirv-llvm-translator: disable ccache

### DIFF
--- a/recipes-devtools/spirv-llvm-translator/spirv-llvm-translator/0001-cmake-allow-to-enable-disable-ccache.patch
+++ b/recipes-devtools/spirv-llvm-translator/spirv-llvm-translator/0001-cmake-allow-to-enable-disable-ccache.patch
@@ -1,0 +1,32 @@
+From 13b679eb76e6877b40fd41b91e71cb172bcf7b26 Mon Sep 17 00:00:00 2001
+From: Naveen Saini <naveen.kumar.saini@intel.com>
+Date: Thu, 4 Mar 2021 11:23:20 +0800
+Subject: [PATCH] cmake: allow to enable/disable ccache
+
+By default ccache is enabled.
+
+Upstream-Status: Submitted [https://github.com/KhronosGroup/SPIRV-LLVM-Translator/pull/930]
+
+Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>
+---
+ CMakeLists.txt | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 0ddb55c..c7d0498 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -50,8 +50,9 @@ if(LLVM_SPIRV_BUILD_EXTERNAL)
+ 
+   message(STATUS "Found LLVM: ${LLVM_VERSION}")
+ 
++  option(CCACHE_ALLOWED "allow use of ccache" TRUE)
+   find_program(CCACHE_EXE_FOUND ccache)
+-  if(CCACHE_EXE_FOUND)
++  if(CCACHE_EXE_FOUND AND CCACHE_ALLOWED)
+     message(STATUS "Found ccache: ${CCACHE_EXE_FOUND}")
+     set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)
+     set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ccache)
+-- 
+2.17.1
+

--- a/recipes-devtools/spirv-llvm-translator/spirv-llvm-translator_git.bb
+++ b/recipes-devtools/spirv-llvm-translator/spirv-llvm-translator_git.bb
@@ -4,6 +4,7 @@ LIC_FILES_CHKSUM = "file://LICENSE.TXT;md5=47e311aa9caedd1b3abf098bd7814d1d"
 BRANCH = "llvm_release_120"
 SRC_URI = "git://github.com/KhronosGroup/SPIRV-LLVM-Translator/;protocol=https;branch=${BRANCH} \
            file://0001-Use-12.0.0-for-base-llvm-version.patch \
+           file://0001-cmake-allow-to-enable-disable-ccache.patch \
           "
 
 PV = "12.0.0"
@@ -27,6 +28,7 @@ EXTRA_OECMAKE = "\
         -DLLVM_EXTERNAL_LIT=lit \
         -DLLVM_INCLUDE_TESTS=ON \
         -Wno-dev \
+        -DCCACHE_ALLOWED=FALSE \
 "
 
 do_compile_append() {


### PR DESCRIPTION
Native build is failing, error log:
~/build/tmp/work/x86_64-linux/spirv-llvm-translator-native/12.0.0-r0/git/lib/SPIRV/SPIRVLowerSPIRBlocks.cpp
| /bin/sh: 1: ccache: not found

Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
