### PR TITLE
clang: Install lld for target builds

### DIFF
--- a/recipes-devtools/clang/clang_git.bb
+++ b/recipes-devtools/clang/clang_git.bb
@@ -303,4 +303,7 @@ clang_sysroot_preprocess() {
 	install -d ${SYSROOT_DESTDIR}${bindir_crossscripts}/
 	install -m 0755 ${S}/../llvm-config ${SYSROOT_DESTDIR}${bindir_crossscripts}/
 	ln -sf llvm-config ${SYSROOT_DESTDIR}${bindir_crossscripts}/llvm-config${PV}
+	# LLDTargets.cmake references the lld executable(!) that some modules/plugins link to
+	install -d ${SYSROOT_DESTDIR}${bindir}
+	install -m 755 ${D}${bindir}/lld ${SYSROOT_DESTDIR}${bindir}/
 }


### PR DESCRIPTION
LLDTargets.cmake (generated and installed by the lld build)
references lld this way:

add_executable(lld IMPORTED)
set_property(TARGET lld PROPERTY ENABLE_EXPORTS 1)

This way lld can be used by plugins to get their symbols from,
pretty much like PHP modules that resolve their symbols from the
php executable during runtime linking.

At least https://github.com/RadeonOpenCompute/ROCm-CompilerSupport
uses lld's cmake files as opposed to using only llvm and previously
failed with:

|   The imported target "lld" references the file
|
|      ".../tmp-sicom-glibc/work/corei7-64-sicom-linux/amd-comgr/4.0.0-r0/recipe-sysroot/usr/bin/lld"
|
|   but this file does not exist.  Possible reasons include:
|
|   * The file was deleted, renamed, or moved to another location.
|
|   * An install or uninstall procedure did not complete successfully.
|
|   * The installation package was faulty and contained

Extending SYSROOT_DIRS with ${bindir} would break crosscompiling
since CMake found clang/clang++ from recipe-sysroot in this case.
Install lld into sysroot-destdir but nothing else.

Signed-off-by: Zoltán Böszörményi <zboszor@pr.hu>

Fixes: #439 

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
