### PR TITLE
bcc: link with dynamic libbpf

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-devtools/bcc/bcc/0001-cmake-link-dynamically-to-libclang-cpp-if-found-and-.patch
+++ b/dynamic-layers/openembedded-layer/recipes-devtools/bcc/bcc/0001-cmake-link-dynamically-to-libclang-cpp-if-found-and-.patch
@@ -1,0 +1,68 @@
+From f14f69d996ffc1c61dd523b839271d4a51328e4d Mon Sep 17 00:00:00 2001
+From: Luca Boccassi <bluca@debian.org>
+Date: Fri, 1 Jan 2021 19:04:37 +0000
+Subject: [PATCH 1/3] cmake: link dynamically to libclang-cpp if found and
+ ENABLE_LLVM_SHARED is set
+
+ENABLE_LLVM_SHARED allows to dynamically link against libLLVM, but
+libclang is still unconditionally linked statically.
+Search for libclang-cpp.so, and if it is found and ENABLE_LLVM_SHARED
+is set dynamically link against it.
+Also expand the libstdc++ static linking check to include this new
+condition.
+---
+ CMakeLists.txt               | 1 +
+ cmake/clang_libs.cmake       | 4 ++++
+ cmake/static_libstdc++.cmake | 2 +-
+ 3 files changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 74fe4f19..b2e334e9 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -76,6 +76,7 @@ find_library(libclangRewrite NAMES clangRewrite clang-cpp HINTS ${CLANG_SEARCH})
+ find_library(libclangSema NAMES clangSema clang-cpp HINTS ${CLANG_SEARCH})
+ find_library(libclangSerialization NAMES clangSerialization clang-cpp HINTS ${CLANG_SEARCH})
+ find_library(libclangASTMatchers NAMES clangASTMatchers clang-cpp HINTS ${CLANG_SEARCH})
++find_library(libclang-shared libclang-cpp.so HINTS ${CLANG_SEARCH})
+ if(libclangBasic STREQUAL "libclangBasic-NOTFOUND")
+   message(FATAL_ERROR "Unable to find clang libraries")
+ endif()
+diff --git a/cmake/clang_libs.cmake b/cmake/clang_libs.cmake
+index c33b635c..3f1523b7 100644
+--- a/cmake/clang_libs.cmake
++++ b/cmake/clang_libs.cmake
+@@ -26,6 +26,9 @@ llvm_map_components_to_libnames(_llvm_libs ${llvm_raw_libs})
+ llvm_expand_dependencies(llvm_libs ${_llvm_libs})
+ endif()
+ 
++if(ENABLE_LLVM_SHARED AND NOT libclang-shared STREQUAL "libclang-shared-NOTFOUND")
++set(clang_libs ${libclang-shared})
++else()
+ # order is important
+ set(clang_libs
+   ${libclangFrontend}
+@@ -46,6 +49,7 @@ list(APPEND clang_libs
+   ${libclangAST}
+   ${libclangLex}
+   ${libclangBasic})
++endif()
+ 
+ # prune unused llvm static library stuff when linking into the new .so
+ set(_exclude_flags)
+diff --git a/cmake/static_libstdc++.cmake b/cmake/static_libstdc++.cmake
+index 3c8ac179..787ed9ad 100644
+--- a/cmake/static_libstdc++.cmake
++++ b/cmake/static_libstdc++.cmake
+@@ -1,7 +1,7 @@
+ # only turn on static-libstdc++ if also linking statically against clang
+ string(REGEX MATCH ".*[.]a$" LIBCLANG_ISSTATIC "${libclangBasic}")
+ # if gcc 4.9 or higher is used, static libstdc++ is a good option
+-if (CMAKE_COMPILER_IS_GNUCC AND LIBCLANG_ISSTATIC)
++if (CMAKE_COMPILER_IS_GNUCC AND LIBCLANG_ISSTATIC AND (NOT ENABLE_LLVM_SHARED OR libclang-shared STREQUAL "libclang-shared-NOTFOUND"))
+   execute_process(COMMAND ${CMAKE_C_COMPILER} -dumpversion OUTPUT_VARIABLE GCC_VERSION)
+   if (GCC_VERSION VERSION_GREATER 4.9 OR GCC_VERSION VERSION_EQUAL 4.9)
+     execute_process(COMMAND ${CMAKE_C_COMPILER} -print-libgcc-file-name OUTPUT_VARIABLE GCC_LIB)
+-- 
+2.29.2
+

--- a/dynamic-layers/openembedded-layer/recipes-devtools/bcc/bcc/0002-cmake-always-link-to-packaged-libbpf-if-CMAKE_USE_LI.patch
+++ b/dynamic-layers/openembedded-layer/recipes-devtools/bcc/bcc/0002-cmake-always-link-to-packaged-libbpf-if-CMAKE_USE_LI.patch
@@ -1,0 +1,239 @@
+From ab9a9dadf294f69e024a8b58c983a6c2085c223a Mon Sep 17 00:00:00 2001
+From: Luca Boccassi <bluca@debian.org>
+Date: Fri, 8 Jan 2021 16:58:56 +0000
+Subject: [PATCH 2/3] cmake: always link to packaged libbpf if
+ CMAKE_USE_LIBBPF_PACKAGE is set (#3210)
+
+Some of the executables still link to the local static versions
+even if the user requested CMAKE_USE_LIBBPF_PACKAGE. Fix this by
+using bcc-shared-no-libbpf more widely if the variable is set.
+
+Skip the git submodule and the extraction commands if the user
+set CMAKE_USE_LIBBPF_PACKAGE
+---
+ CMakeLists.txt                     |  2 +-
+ examples/cpp/CMakeLists.txt        | 59 ++++++++----------------------
+ examples/cpp/pyperf/CMakeLists.txt |  5 +++
+ introspection/CMakeLists.txt       |  8 +++-
+ src/cc/CMakeLists.txt              | 29 ++++++++++-----
+ tests/cc/CMakeLists.txt            | 22 +++++++----
+ 6 files changed, 61 insertions(+), 64 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index b2e334e9..b68571ea 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -14,7 +14,7 @@ endif()
+ enable_testing()
+ 
+ # populate submodules (libbpf)
+-if(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/src/cc/libbpf/src)
++if(NOT CMAKE_USE_LIBBPF_PACKAGE AND NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/src/cc/libbpf/src)
+   execute_process(COMMAND git submodule update --init --recursive
+                   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+ endif()
+diff --git a/examples/cpp/CMakeLists.txt b/examples/cpp/CMakeLists.txt
+index dae0e9ce..dd343245 100644
+--- a/examples/cpp/CMakeLists.txt
++++ b/examples/cpp/CMakeLists.txt
+@@ -11,49 +11,20 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
+ 
+ option(INSTALL_CPP_EXAMPLES "Install C++ examples. Those binaries are statically linked and can take plenty of disk space" OFF)
+ 
+-add_executable(HelloWorld HelloWorld.cc)
+-target_link_libraries(HelloWorld bcc-static)
+-
+-add_executable(CPUDistribution CPUDistribution.cc)
+-target_link_libraries(CPUDistribution bcc-static)
+-
+-add_executable(RecordMySQLQuery RecordMySQLQuery.cc)
+-target_link_libraries(RecordMySQLQuery bcc-static)
+-
+-add_executable(TCPSendStack TCPSendStack.cc)
+-target_link_libraries(TCPSendStack bcc-static)
+-
+-add_executable(RandomRead RandomRead.cc)
+-target_link_libraries(RandomRead bcc-static)
+-
+-add_executable(LLCStat LLCStat.cc)
+-target_link_libraries(LLCStat bcc-static)
+-
+-add_executable(FollyRequestContextSwitch FollyRequestContextSwitch.cc)
+-target_link_libraries(FollyRequestContextSwitch bcc-static)
+-
+-add_executable(UseExternalMap UseExternalMap.cc)
+-target_link_libraries(UseExternalMap bcc-static)
+-
+-add_executable(CGroupTest CGroupTest.cc)
+-target_link_libraries(CGroupTest bcc-static)
+-
+-add_executable(TaskIterator TaskIterator.cc)
+-target_link_libraries(TaskIterator bcc-static)
+-
+-add_executable(SkLocalStorageIterator SkLocalStorageIterator.cc)
+-target_link_libraries(SkLocalStorageIterator bcc-static)
+-
+-if(INSTALL_CPP_EXAMPLES)
+-  install (TARGETS HelloWorld DESTINATION share/bcc/examples/cpp)
+-  install (TARGETS CPUDistribution DESTINATION share/bcc/examples/cpp)
+-  install (TARGETS RecordMySQLQuery DESTINATION share/bcc/examples/cpp)
+-  install (TARGETS TCPSendStack DESTINATION share/bcc/examples/cpp)
+-  install (TARGETS RandomRead DESTINATION share/bcc/examples/cpp)
+-  install (TARGETS LLCStat DESTINATION share/bcc/examples/cpp)
+-  install (TARGETS FollyRequestContextSwitch DESTINATION share/bcc/examples/cpp)
+-  install (TARGETS UseExternalMap DESTINATION share/bcc/examples/cpp)
+-  install (TARGETS CGroupTest DESTINATION share/bcc/examples/cpp)
+-endif(INSTALL_CPP_EXAMPLES)
++file(GLOB EXAMPLES *.cc)
++foreach(EXAMPLE ${EXAMPLES})
++  get_filename_component(NAME ${EXAMPLE} NAME_WE)
++  add_executable(${NAME} ${EXAMPLE})
++
++  if(NOT CMAKE_USE_LIBBPF_PACKAGE)
++    target_link_libraries(${NAME} bcc-static)
++  else()
++    target_link_libraries(${NAME} bcc-shared-no-libbpf)
++  endif()
++
++  if(INSTALL_CPP_EXAMPLES)
++    install (TARGETS ${NAME} DESTINATION share/bcc/examples/cpp)
++  endif(INSTALL_CPP_EXAMPLES)
++endforeach()
+ 
+ add_subdirectory(pyperf)
+diff --git a/examples/cpp/pyperf/CMakeLists.txt b/examples/cpp/pyperf/CMakeLists.txt
+index 6f963c66..97420806 100644
+--- a/examples/cpp/pyperf/CMakeLists.txt
++++ b/examples/cpp/pyperf/CMakeLists.txt
+@@ -7,6 +7,11 @@ include_directories(${CMAKE_SOURCE_DIR}/src/cc/libbpf/include/uapi)
+ 
+ add_executable(PyPerf PyPerf.cc PyPerfUtil.cc PyPerfBPFProgram.cc PyPerfLoggingHelper.cc PyPerfDefaultPrinter.cc Py36Offsets.cc)
+ target_link_libraries(PyPerf bcc-static)
++if(NOT CMAKE_USE_LIBBPF_PACKAGE)
++  target_link_libraries(PyPerf bcc-static)
++else()
++  target_link_libraries(PyPerf bcc-shared-no-libbpf)
++endif()
+ 
+ if(INSTALL_CPP_EXAMPLES)
+   install (TARGETS PyPerf DESTINATION share/bcc/examples/cpp)
+diff --git a/introspection/CMakeLists.txt b/introspection/CMakeLists.txt
+index 4328ee11..6c83f0c8 100644
+--- a/introspection/CMakeLists.txt
++++ b/introspection/CMakeLists.txt
+@@ -8,7 +8,13 @@ include_directories(${CMAKE_SOURCE_DIR}/src/cc/libbpf/include/uapi)
+ option(INSTALL_INTROSPECTION "Install BPF introspection tools" ON)
+ option(BPS_LINK_RT "Pass -lrt to linker when linking bps tool" ON)
+ 
+-set(bps_libs_to_link bpf-static elf z)
++# Note that the order matters! bpf-static first, the rest later
++if(CMAKE_USE_LIBBPF_PACKAGE AND LIBBPF_FOUND)
++set(bps_libs_to_link bpf-shared ${LIBBPF_LIBRARIES})
++else()
++set(bps_libs_to_link bpf-static)
++endif()
++list(APPEND bps_libs_to_link elf z)
+ if(BPS_LINK_RT)
+ list(APPEND bps_libs_to_link rt)
+ endif()
+diff --git a/src/cc/CMakeLists.txt b/src/cc/CMakeLists.txt
+index 4021c662..c8ea63aa 100644
+--- a/src/cc/CMakeLists.txt
++++ b/src/cc/CMakeLists.txt
+@@ -10,8 +10,12 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR}/frontends/clang)
+ include_directories(${LLVM_INCLUDE_DIRS})
+ include_directories(${LIBELF_INCLUDE_DIRS})
+ # todo: if check for kernel version
+-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/libbpf/include)
+-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/libbpf/include/uapi)
++if (CMAKE_USE_LIBBPF_PACKAGE AND LIBBPF_FOUND)
++  include_directories(${LIBBPF_INCLUDE_DIRS})
++else()
++  include_directories(${CMAKE_CURRENT_SOURCE_DIR}/libbpf/include)
++  include_directories(${CMAKE_CURRENT_SOURCE_DIR}/libbpf/include/uapi)
++endif()
+ 
+ # add_definitions has a problem parsing "-D_GLIBCXX_USE_CXX11_ABI=0", this is safer
+ separate_arguments(LLVM_DEFINITIONS)
+@@ -41,21 +45,26 @@ if(LIBBPF_INCLUDE_DIR)
+   add_definitions(-DHAVE_EXTERNAL_LIBBPF)
+ endif()
+ 
+-if(LIBBPF_FOUND)
+-  set(extract_dir ${CMAKE_CURRENT_BINARY_DIR}/libbpf_a_extract)
+-  execute_process(COMMAND sh -c "mkdir -p ${extract_dir} && cd ${extract_dir} && ${CMAKE_AR} x ${LIBBPF_STATIC_LIBRARIES}")
+-  file(GLOB libbpf_sources "${extract_dir}/*.o")
+-else()
+-  file(GLOB libbpf_sources "libbpf/src/*.c")
+-endif()
++if(NOT CMAKE_USE_LIBBPF_PACKAGE)
++  if(LIBBPF_FOUND)
++    set(extract_dir ${CMAKE_CURRENT_BINARY_DIR}/libbpf_a_extract)
++    execute_process(COMMAND sh -c "mkdir -p ${extract_dir} && cd ${extract_dir} && ${CMAKE_AR} x ${LIBBPF_STATIC_LIBRARIES}")
++    file(GLOB libbpf_sources "${extract_dir}/*.o")
++  else()
++    file(GLOB libbpf_sources "libbpf/src/*.c")
++  endif()
+ 
+-set(libbpf_uapi libbpf/include/uapi/linux/)
++  set(libbpf_uapi libbpf/include/uapi/linux/)
++endif()
+ 
+ add_library(bpf-static STATIC libbpf.c perf_reader.c ${libbpf_sources})
+ set_target_properties(bpf-static PROPERTIES OUTPUT_NAME bcc_bpf)
+ add_library(bpf-shared SHARED libbpf.c perf_reader.c ${libbpf_sources})
+ set_target_properties(bpf-shared PROPERTIES VERSION ${REVISION_LAST} SOVERSION 0)
+ set_target_properties(bpf-shared PROPERTIES OUTPUT_NAME bcc_bpf)
++if(CMAKE_USE_LIBBPF_PACKAGE AND LIBBPF_FOUND)
++  target_link_libraries(bpf-shared ${LIBBPF_LIBRARIES})
++endif()
+ 
+ set(bcc_common_sources bcc_common.cc bpf_module.cc bcc_btf.cc exported_files.cc)
+ if (${LLVM_PACKAGE_VERSION} VERSION_EQUAL 6 OR ${LLVM_PACKAGE_VERSION} VERSION_GREATER 6)
+diff --git a/tests/cc/CMakeLists.txt b/tests/cc/CMakeLists.txt
+index 528f1bda..b2fba5e3 100644
+--- a/tests/cc/CMakeLists.txt
++++ b/tests/cc/CMakeLists.txt
+@@ -7,7 +7,11 @@ include_directories(${CMAKE_SOURCE_DIR}/src/cc/libbpf/include/uapi)
+ include_directories(${CMAKE_SOURCE_DIR}/tests/python/include)
+ 
+ add_executable(test_static test_static.c)
+-target_link_libraries(test_static bcc-static)
++if(NOT CMAKE_USE_LIBBPF_PACKAGE)
++  target_link_libraries(test_static bcc-static)
++else()
++  target_link_libraries(test_static bcc-shared-no-libbpf)
++endif()
+ 
+ add_test(NAME c_test_static COMMAND ${TEST_WRAPPER} c_test_static sudo ${CMAKE_CURRENT_BINARY_DIR}/test_static)
+ 
+@@ -35,17 +39,19 @@ set(TEST_LIBBCC_SOURCES
+ 	utils.cc
+ 	test_parse_tracepoint.cc)
+ 
+-add_executable(test_libbcc ${TEST_LIBBCC_SOURCES})
+-
+ file(COPY dummy_proc_map.txt DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+ add_library(usdt_test_lib SHARED usdt_test_lib.cc)
+ 
+-add_dependencies(test_libbcc bcc-shared)
+-target_link_libraries(test_libbcc ${PROJECT_BINARY_DIR}/src/cc/libbcc.so dl usdt_test_lib)
+-set_target_properties(test_libbcc PROPERTIES INSTALL_RPATH ${PROJECT_BINARY_DIR}/src/cc)
+-target_compile_definitions(test_libbcc PRIVATE -DLIBBCC_NAME=\"libbcc.so\")
++if(NOT CMAKE_USE_LIBBPF_PACKAGE)
++  add_executable(test_libbcc ${TEST_LIBBCC_SOURCES})
++  add_dependencies(test_libbcc bcc-shared)
+ 
+-add_test(NAME test_libbcc COMMAND ${TEST_WRAPPER} c_test_all sudo ${CMAKE_CURRENT_BINARY_DIR}/test_libbcc)
++  target_link_libraries(test_libbcc ${PROJECT_BINARY_DIR}/src/cc/libbcc.so dl usdt_test_lib)
++  set_target_properties(test_libbcc PROPERTIES INSTALL_RPATH ${PROJECT_BINARY_DIR}/src/cc)
++  target_compile_definitions(test_libbcc PRIVATE -DLIBBCC_NAME=\"libbcc.so\")
++
++  add_test(NAME test_libbcc COMMAND ${TEST_WRAPPER} c_test_all sudo ${CMAKE_CURRENT_BINARY_DIR}/test_libbcc)
++endif()
+ 
+ if(LIBBPF_FOUND)
+   add_executable(test_libbcc_no_libbpf ${TEST_LIBBCC_SOURCES})
+-- 
+2.29.2
+

--- a/dynamic-layers/openembedded-layer/recipes-devtools/bcc/bcc/0003-Remove-libbcc-no-libbpf-shared-library-change-libbcc.patch
+++ b/dynamic-layers/openembedded-layer/recipes-devtools/bcc/bcc/0003-Remove-libbcc-no-libbpf-shared-library-change-libbcc.patch
@@ -1,0 +1,156 @@
+From c7509c9e6377a374ca28d73960d505e129aace7b Mon Sep 17 00:00:00 2001
+From: Luca Boccassi <bluca@debian.org>
+Date: Fri, 8 Jan 2021 17:04:03 +0000
+Subject: [PATCH 3/3] Remove libbcc-no-libbpf shared library, change libbcc
+ linkage instead
+
+The current upstream split does not work very well, as the SONAME is mangled so
+nothing recognises it. Applications link against libbcc, not libbcc_no_bpf.
+Remove it entirely, and switch the libbcc.so to dynamically
+link with libbpf if CMAKE_USE_LIBBPF_PACKAGE is set.
+---
+ examples/cpp/CMakeLists.txt        |  2 +-
+ examples/cpp/pyperf/CMakeLists.txt |  2 +-
+ src/cc/CMakeLists.txt              | 36 +++++++++++++-----------------
+ tests/cc/CMakeLists.txt            |  8 +++----
+ 4 files changed, 21 insertions(+), 27 deletions(-)
+
+diff --git a/examples/cpp/CMakeLists.txt b/examples/cpp/CMakeLists.txt
+index dd343245..45b30280 100644
+--- a/examples/cpp/CMakeLists.txt
++++ b/examples/cpp/CMakeLists.txt
+@@ -19,7 +19,7 @@ foreach(EXAMPLE ${EXAMPLES})
+   if(NOT CMAKE_USE_LIBBPF_PACKAGE)
+     target_link_libraries(${NAME} bcc-static)
+   else()
+-    target_link_libraries(${NAME} bcc-shared-no-libbpf)
++    target_link_libraries(${NAME} bcc-shared)
+   endif()
+ 
+   if(INSTALL_CPP_EXAMPLES)
+diff --git a/examples/cpp/pyperf/CMakeLists.txt b/examples/cpp/pyperf/CMakeLists.txt
+index 97420806..618b4e75 100644
+--- a/examples/cpp/pyperf/CMakeLists.txt
++++ b/examples/cpp/pyperf/CMakeLists.txt
+@@ -10,7 +10,7 @@ target_link_libraries(PyPerf bcc-static)
+ if(NOT CMAKE_USE_LIBBPF_PACKAGE)
+   target_link_libraries(PyPerf bcc-static)
+ else()
+-  target_link_libraries(PyPerf bcc-shared-no-libbpf)
++  target_link_libraries(PyPerf bcc-shared)
+ endif()
+ 
+ if(INSTALL_CPP_EXAMPLES)
+diff --git a/src/cc/CMakeLists.txt b/src/cc/CMakeLists.txt
+index c8ea63aa..931de2d9 100644
+--- a/src/cc/CMakeLists.txt
++++ b/src/cc/CMakeLists.txt
+@@ -83,6 +83,9 @@ set(bcc_sym_sources bcc_syms.cc bcc_elf.c bcc_perf_map.c bcc_proc.c)
+ set(bcc_common_headers libbpf.h perf_reader.h "${CMAKE_CURRENT_BINARY_DIR}/bcc_version.h")
+ set(bcc_table_headers file_desc.h table_desc.h table_storage.h)
+ set(bcc_api_headers bcc_common.h bpf_module.h bcc_exception.h bcc_syms.h bcc_proc.h bcc_elf.h)
++if(LIBBPF_FOUND)
++  set(bcc_common_sources ${bcc_common_sources} libbpf.c perf_reader.c)
++endif()
+ 
+ if(ENABLE_CLANG_JIT)
+ add_library(bcc-shared SHARED
+@@ -91,16 +94,6 @@ add_library(bcc-shared SHARED
+ set_target_properties(bcc-shared PROPERTIES VERSION ${REVISION_LAST} SOVERSION 0)
+ set_target_properties(bcc-shared PROPERTIES OUTPUT_NAME bcc)
+ 
+-# If there's libbpf detected we build the libbcc-no-libbpf.so library, that
+-# dynamicaly links libbpf.so, in comparison to static link in libbcc.so.
+-if(LIBBPF_FOUND)
+-  add_library(bcc-shared-no-libbpf SHARED
+-    link_all.cc ${bcc_common_sources} ${bcc_table_sources} ${bcc_sym_sources}
+-    ${bcc_util_sources} libbpf.c perf_reader.c)
+-  set_target_properties(bcc-shared-no-libbpf PROPERTIES VERSION ${REVISION_LAST} SOVERSION 0)
+-  set_target_properties(bcc-shared-no-libbpf PROPERTIES OUTPUT_NAME bcc-no-libbpf)
+-endif()
+-
+ if(ENABLE_USDT)
+   set(bcc_usdt_sources usdt/usdt.cc usdt/usdt_args.cc)
+   # else undefined
+@@ -123,18 +116,25 @@ set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${llvm_lib_exclude_f
+ set(bcc_common_libs b_frontend clang_frontend
+   -Wl,--whole-archive ${clang_libs} ${llvm_libs} -Wl,--no-whole-archive
+   ${LIBELF_LIBRARIES})
+-set(bcc_common_libs_for_a ${bcc_common_libs} bpf-static)
+-set(bcc_common_libs_for_s ${bcc_common_libs} bpf-static)
+-set(bcc_common_libs_for_n ${bcc_common_libs})
+-set(bcc_common_libs_for_lua b_frontend clang_frontend bpf-static
++set(bcc_common_libs_for_a ${bcc_common_libs})
++set(bcc_common_libs_for_s ${bcc_common_libs})
++set(bcc_common_libs_for_lua b_frontend clang_frontend
+   ${clang_libs} ${llvm_libs} ${LIBELF_LIBRARIES})
++if(LIBBPF_FOUND)
++  list(APPEND bcc_common_libs_for_a ${LIBBPF_LIBRARIES})
++  list(APPEND bcc_common_libs_for_s ${LIBBPF_LIBRARIES})
++  list(APPEND bcc_common_libs_for_lua ${LIBBPF_LIBRARIES})
++else()
++  list(APPEND bcc_common_libs_for_a bpf-static)
++  list(APPEND bcc_common_libs_for_s bpf-static)
++  list(APPEND bcc_common_libs_for_lua bpf-static)
++endif()
+ 
+ if(ENABLE_CPP_API)
+   add_subdirectory(api)
+   list(APPEND bcc_common_libs_for_a api-static)
+   # Keep all API functions
+   list(APPEND bcc_common_libs_for_s -Wl,--whole-archive api-static -Wl,--no-whole-archive)
+-  list(APPEND bcc_common_libs_for_n -Wl,--whole-archive api-static -Wl,--no-whole-archive)
+ endif()
+ 
+ if(ENABLE_USDT)
+@@ -142,7 +142,6 @@ if(ENABLE_USDT)
+   add_subdirectory(usdt)
+   list(APPEND bcc_common_libs_for_a usdt-static)
+   list(APPEND bcc_common_libs_for_s usdt-static)
+-  list(APPEND bcc_common_libs_for_n usdt-static)
+   list(APPEND bcc_common_libs_for_lua usdt-static)
+ endif()
+ 
+@@ -153,11 +152,6 @@ target_link_libraries(bcc-shared ${bcc_common_libs_for_s})
+ target_link_libraries(bcc-static ${bcc_common_libs_for_a} bcc-loader-static)
+ set(bcc-lua-static ${bcc-lua-static} ${bcc_common_libs_for_lua})
+ 
+-if(LIBBPF_FOUND)
+-  target_link_libraries(bcc-shared-no-libbpf ${bcc_common_libs_for_n} ${LIBBPF_LIBRARIES})
+-  install(TARGETS bcc-shared-no-libbpf LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+-endif()
+-
+ install(TARGETS bcc-shared bcc-static bcc-loader-static bpf-static LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+ install(FILES ${bcc_table_headers} DESTINATION include/bcc)
+ install(FILES ${bcc_api_headers} DESTINATION include/bcc)
+diff --git a/tests/cc/CMakeLists.txt b/tests/cc/CMakeLists.txt
+index b2fba5e3..58493248 100644
+--- a/tests/cc/CMakeLists.txt
++++ b/tests/cc/CMakeLists.txt
+@@ -10,7 +10,7 @@ add_executable(test_static test_static.c)
+ if(NOT CMAKE_USE_LIBBPF_PACKAGE)
+   target_link_libraries(test_static bcc-static)
+ else()
+-  target_link_libraries(test_static bcc-shared-no-libbpf)
++  target_link_libraries(test_static bcc-shared)
+ endif()
+ 
+ add_test(NAME c_test_static COMMAND ${TEST_WRAPPER} c_test_static sudo ${CMAKE_CURRENT_BINARY_DIR}/test_static)
+@@ -55,11 +55,11 @@ endif()
+ 
+ if(LIBBPF_FOUND)
+   add_executable(test_libbcc_no_libbpf ${TEST_LIBBCC_SOURCES})
+-  add_dependencies(test_libbcc_no_libbpf bcc-shared-no-libbpf)
++  add_dependencies(test_libbcc_no_libbpf bcc-shared)
+ 
+-  target_link_libraries(test_libbcc_no_libbpf ${PROJECT_BINARY_DIR}/src/cc/libbcc-no-libbpf.so dl usdt_test_lib ${LIBBPF_LIBRARIES})
++  target_link_libraries(test_libbcc_no_libbpf ${PROJECT_BINARY_DIR}/src/cc/libbcc.so dl usdt_test_lib ${LIBBPF_LIBRARIES})
+   set_target_properties(test_libbcc_no_libbpf PROPERTIES INSTALL_RPATH ${PROJECT_BINARY_DIR}/src/cc)
+-  target_compile_definitions(test_libbcc_no_libbpf PRIVATE -DLIBBCC_NAME=\"libbcc-no-libbpf.so\")
++  target_compile_definitions(test_libbcc_no_libbpf PRIVATE -DLIBBCC_NAME=\"libbcc.so\")
+ 
+   add_test(NAME test_libbcc_no_libbpf COMMAND ${TEST_WRAPPER} c_test_all_no_libbpf sudo ${CMAKE_CURRENT_BINARY_DIR}/test_libbcc_no_libbpf)
+ endif()
+-- 
+2.29.2
+

--- a/dynamic-layers/openembedded-layer/recipes-devtools/bcc/bcc/0004-cmake-look-for-either-static-or-dynamic-libraries.patch
+++ b/dynamic-layers/openembedded-layer/recipes-devtools/bcc/bcc/0004-cmake-look-for-either-static-or-dynamic-libraries.patch
@@ -1,0 +1,69 @@
+From 6b4222cd41b3f5e833307aeff2b10c6b084d3f4f Mon Sep 17 00:00:00 2001
+From: Matteo Croce <mcroce@microsoft.com>
+Date: Wed, 27 Jan 2021 00:26:39 +0100
+Subject: [PATCH] cmake: look for either static or dynamic libraries
+
+On some distro, static libraries are shipped in a separate package.
+Look for either a static or dynamic libbpf, and only fail if neither is found.
+---
+ cmake/FindLibBpf.cmake | 23 ++++++++++++++++-------
+ 1 file changed, 16 insertions(+), 7 deletions(-)
+
+diff --git a/cmake/FindLibBpf.cmake b/cmake/FindLibBpf.cmake
+index 75683ae3d..dc10dcee4 100644
+--- a/cmake/FindLibBpf.cmake
++++ b/cmake/FindLibBpf.cmake
+@@ -28,9 +28,9 @@ find_path (LIBBPF_INCLUDE_DIR
+     /sw/include
+     ENV CPATH)
+ 
+-find_library (LIBBPF_STATIC_LIBRARIES
++find_library (LIBBPF_LIBRARIES
+   NAMES
+-    libbpf.a
++    bpf
+   PATHS
+     /usr/lib
+     /usr/local/lib
+@@ -38,10 +38,13 @@ find_library (LIBBPF_STATIC_LIBRARIES
+     /sw/lib
+     ENV LIBRARY_PATH
+     ENV LD_LIBRARY_PATH)
++if(LIBBPF_LIBRARIES)
++list(APPEND PATHS LIBBPF_LIBRARIES)
++endif()
+ 
+-find_library (LIBBPF_LIBRARIES
++find_library (LIBBPF_STATIC_LIBRARIES
+   NAMES
+-    bpf
++    libbpf.a
+   PATHS
+     /usr/lib
+     /usr/local/lib
+@@ -49,13 +52,19 @@ find_library (LIBBPF_LIBRARIES
+     /sw/lib
+     ENV LIBRARY_PATH
+     ENV LD_LIBRARY_PATH)
++if(LIBBPF_STATIC_LIBRARIES)
++list(APPEND PATHS LIBBPF_STATIC_LIBRARIES)
++endif()
+ 
++if(LIBBPF_STATIC_LIBRARIES OR LIBBPF_LIBRARIES)
+ include (FindPackageHandleStandardArgs)
+ 
+ # handle the QUIETLY and REQUIRED arguments and set LIBBPF_FOUND to TRUE if all listed variables are TRUE
+ FIND_PACKAGE_HANDLE_STANDARD_ARGS(LibBpf "Please install the libbpf development package"
+-  LIBBPF_LIBRARIES
+-  LIBBPF_STATIC_LIBRARIES
++  ${PATHS}
+   LIBBPF_INCLUDE_DIR)
+ 
+-mark_as_advanced(LIBBPF_INCLUDE_DIR LIBBPF_STATIC_LIBRARIES LIBBPF_LIBRARIES)
++mark_as_advanced(LIBBPF_INCLUDE_DIR ${PATHS})
++else()
++message(Please install the libbpf development package)
++endif()
+-- 
+2.29.2
+

--- a/dynamic-layers/openembedded-layer/recipes-devtools/bcc/bcc_0.17.0.bb
+++ b/dynamic-layers/openembedded-layer/recipes-devtools/bcc/bcc_0.17.0.bb
@@ -18,13 +18,21 @@ LUAJIT_powerpc64 = ""
 
 RDEPENDS_${PN} += "bash python3 python3-core python3-setuptools xz"
 
-SRC_URI = "gitsm://github.com/iovisor/bcc \
+# Don't fetch submodules otherwise we fetch an older, vendored libbpf version
+# We use a dynamic libbpf library instead
+SRC_URI = "git://github.com/iovisor/bcc \
            file://0001-python-CMakeLists.txt-Remove-check-for-host-etc-debi.patch \
            file://0001-tools-trace.py-Fix-failing-to-exit.patch \
            file://0001-CMakeLists.txt-override-the-PY_CMD_ESCAPED.patch \
            file://0001-fix-compilation-issues-with-latest-llvm12-trunk.patch \
            file://0002-fix-compilation-error-with-latest-llvm12-trunk.patch \
+           file://0001-cmake-link-dynamically-to-libclang-cpp-if-found-and-.patch \
+           file://0002-cmake-always-link-to-packaged-libbpf-if-CMAKE_USE_LI.patch \
+           file://0003-Remove-libbcc-no-libbpf-shared-library-change-libbcc.patch \
+           file://0004-cmake-look-for-either-static-or-dynamic-libraries.patch \
            "
+
+DEPENDS += "libbpf"
 
 SRCREV = "ad5b82a5196b222ed2cdc738d8444e8c9546a77f"
 
@@ -39,6 +47,7 @@ EXTRA_OECMAKE = " \
     -DLLVM_PACKAGE_VERSION=${LLVMVERSION} \
     -DPYTHON_CMD=${PYTHON} \
     -DPYTHON_FLAGS=--install-lib=${PYTHON_SITEPACKAGES_DIR} \
+    -DCMAKE_USE_LIBBPF_PACKAGE=ON \
 "
 
 do_install_append() {


### PR DESCRIPTION
Link bcc dynamically against libbpf. This reduces the size of libbcc.so
from 68 MB to 3 MB.
Backport some patches from upstream which are needed for the actual
dynamic linking.

Depends on openembedded/meta-openembedded#320

Signed-off-by: Matteo Croce <mcroce@microsoft.com>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
