### PR TITLE
github/workflows: Set DISPLAY variable in environment

### DIFF
--- a/.github/workflows/yoe.yml
+++ b/.github/workflows/yoe.yml
@@ -66,6 +66,7 @@ jobs:
       - name: Test Image
         run: |
           cd yoe
+          export DISPLAY=":0"
           echo TESTIMAGE_AUTO_qemuall = \"1\" >> conf/local.conf
           /bin/bash -c ". ./qemuarm64-envsetup.sh && bitbake yoe-sdk-image"
       - name: Prepare results


### PR DESCRIPTION
This is needed for weston to launch since 'runqemu nograhic' no longer
specify right -vga option in OE-core after commit 9f8d049dbbe0b1760979d9f3b745124abfc54c90

Signed-off-by: Khem Raj <raj.khem@gmail.com>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
