### PR TITLE
bpftrace: Update to using master branch

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-devtools/bpftrace/bpftrace/0001-bpforc.h-Include-optional-header.patch
+++ b/dynamic-layers/openembedded-layer/recipes-devtools/bpftrace/bpftrace/0001-bpforc.h-Include-optional-header.patch
@@ -1,0 +1,31 @@
+From ec41ce71f8cd318ab3ca4ce727e7398289b5d7cf Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Tue, 30 Mar 2021 17:25:10 -0700
+Subject: [PATCH] bpforc.h: Include <optional> header
+
+This is required since this header had std::optional<std::tuple<uint8_t *, uintptr_t>>
+
+Fixes buiild errors with clang-12 with gcc11-runtime
+
+Upstream-Status: Submitted [https://github.com/iovisor/bpftrace/pull/1762]
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ src/bpforc.h | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/src/bpforc.h b/src/bpforc.h
+index da6345be..5634c544 100644
+--- a/src/bpforc.h
++++ b/src/bpforc.h
+@@ -22,6 +22,8 @@
+ #include <llvm/ExecutionEngine/Orc/JITTargetMachineBuilder.h>
+ #endif
+ 
++#include <optional>
++
+ namespace bpftrace {
+ 
+ const std::string LLVMTargetTriple = "bpf-pc-linux";
+-- 
+2.31.1
+

--- a/dynamic-layers/openembedded-layer/recipes-devtools/bpftrace/bpftrace_0.11.4.bb
+++ b/dynamic-layers/openembedded-layer/recipes-devtools/bpftrace/bpftrace_0.11.4.bb
@@ -10,11 +10,13 @@ DEPENDS += "bison-native \
             bcc \
             "
 
+PV .= "+git${SRCREV}"
 RDEPENDS_${PN} += "bash python3 xz"
 
-SRC_URI = "git://github.com/iovisor/bpftrace;branch=0.11_release \
+SRC_URI = "git://github.com/iovisor/bpftrace;branch=master \
+           file://0001-bpforc.h-Include-optional-header.patch \
            "
-SRCREV = "0cd90b8b91f67cae9f612a07498bf8d92306fab1"
+SRCREV = "6bfa61f505b6b4215328f90762776edd8a22fdb7"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
This is needed for fixing builds with master since clang 12 has dropped
ORCv1 APIs

Add a patch to fix build with clang-12

Signed-off-by: Khem Raj <raj.khem@gmail.com>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
