### PR TITLE
llvm-project-source: Add multilib vendor support

### DIFF
--- a/recipes-devtools/clang/llvm-project-source.inc
+++ b/recipes-devtools/clang/llvm-project-source.inc
@@ -28,13 +28,25 @@ python add_distro_vendor() {
     case = ""
     triple = ""
     vendors = d.getVar('CLANG_EXTRA_OE_VENDORS')
+    multilib_variants = d.getVar('MULTILIB_VARIANTS').split()
+    vendors_to_add = []
     for vendor in vendors.split():
         # convert -yoe into yoe
         vendor = vendor.lstrip('-')
-        if vendor == "oe":
-            continue
-        case += '\\n    .Case("' + vendor + '", Triple::OpenEmbedded)'
-        triple += ' "x86_64-' + vendor + '-linux",'
+        # generate possible multilib vendor names for yoe
+        # such as yoemllib32
+        vendors_to_add.extend([vendor + 'ml' + variant for variant in multilib_variants])
+        # skip oe since already part of the cpp file
+        if vendor != "oe":
+            vendors_to_add.append(vendor)
+
+    for vendor_to_add in vendors_to_add:
+        case += '\\n    .Case("' + vendor_to_add + '", Triple::OpenEmbedded)'
+        triple += ' "x86_64-' + vendor_to_add + '-linux",'
+
+    bb.note("Adding support following TARGET_VENDOR values")
+    bb.note(str(vendors_to_add))
+    bb.note("in llvm/lib/Support/Triple.cpp and ${S}/clang/lib/Driver/ToolChains/Gnu.cpp")
     cmd = d.expand("sed -i 's#//CLANG_EXTRA_OE_VENDORS_TRIPLES#%s#g' ${S}/clang/lib/Driver/ToolChains/Gnu.cpp" % (triple))
     subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True)
     cmd = d.expand("sed -i 's#//CLANG_EXTRA_OE_VENDORS_CASES#%s#g' -i ${S}/llvm/lib/Support/Triple.cpp" % (case))


### PR DESCRIPTION
Generate all possible vendor name that a multilib build could use
by using the variable MULTILIB_VARIANTS.

ex: {TARGET_VENDOR} {TARGET_VENDOR}mllib32

Fixes build issue when compiling lib32-compiler-rt
where clang has issue detecting gcc toolchain.

when clang --print-search-dirs:
lib32-recipe-sysroot//usr/lib/i686-wrsmllib32-linux
should be
lib32-recipe-sysroot//usr/lib/i686-wrsmllib32-linux/10.2.0/

Signed-off-by: Yi Fan Yu <yifan.yu@windriver.com>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ X] Changes have been tested
- [ X] `Signed-off-by` is present
- [ X] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
