### PR TITLE
layer.conf: Drop gatesgarth

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -7,7 +7,7 @@ BBFILES += "${LAYERDIR}/recipes*/*/*.bb ${LAYERDIR}/recipes*/*/*.bbappend"
 BBFILE_COLLECTIONS += "clang-layer"
 BBFILE_PATTERN_clang-layer := "^${LAYERDIR}/"
 BBFILE_PRIORITY_clang-layer = "7"
-LAYERSERIES_COMPAT_clang-layer = "gatesgarth hardknott"
+LAYERSERIES_COMPAT_clang-layer = "hardknott"
 LAYERDEPENDS_clang-layer = "core"
 
 BBFILES_DYNAMIC += " \


### PR DESCRIPTION
it has its own branch

Signed-off-by: Khem Raj <raj.khem@gmail.com>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
