### PR TITLE
clang: Add SDK_VENDOR string to CLANG_EXTRA_OE_VENDORS

### DIFF
--- a/recipes-devtools/clang/llvm-project-source.inc
+++ b/recipes-devtools/clang/llvm-project-source.inc
@@ -21,7 +21,7 @@ PACKAGES = ""
 
 # space separated list of additional distro vendor values we want to support e.g.
 # "yoe webos" or "-yoe -webos" '-' is optional
-CLANG_EXTRA_OE_VENDORS ?= "${TARGET_VENDOR}"
+CLANG_EXTRA_OE_VENDORS ?= "${TARGET_VENDOR} ${SDK_VENDOR}"
 
 python add_distro_vendor() {
     import subprocess


### PR DESCRIPTION
This helps in ensuring that SDK elements are built correctly as well,
at present we get right builds for cross/target/native clang but not for
nativesdk since it use SDK_VENDOR string for vendor eg. -yoesdk which
currently is not added to known OE vendors, as a result nativesdk-clang
does not build since crosssdk clang can not find runtime files e.g.
libgcc

Signed-off-by: Khem Raj <raj.khem@gmail.com>
Cc: Martin Jansa <Martin.Jansa@gmail.com>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
