### PR TITLE
clang: Enable dwarf-5 default debug info

### DIFF
--- a/recipes-devtools/clang/clang.inc
+++ b/recipes-devtools/clang/clang.inc
@@ -8,7 +8,7 @@ MAJOR_VER = "12"
 MINOR_VER = "0"
 PATCH_VER = "0"
 
-SRCREV ?= "d28af7c654d8db0b68c175db5ce212d74fb5e9bc"
+SRCREV ?= "fa0971b87fb2c9d14d1bba2551e61f02f18f329b"
 
 PV = "${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}"
 BRANCH = "release/${MAJOR_VER}.x"

--- a/recipes-devtools/clang/clang/0001-lldb-Add-lxml2-to-linker-cmdline-of-xml-is-found.patch
+++ b/recipes-devtools/clang/clang/0001-lldb-Add-lxml2-to-linker-cmdline-of-xml-is-found.patch
@@ -1,4 +1,4 @@
-From 6bf608a67654eaf3312d8ca4813a19526e35c8b1 Mon Sep 17 00:00:00 2001
+From 42e6673563ca1d0e433e16c3eefa20b98e280ebd Mon Sep 17 00:00:00 2001
 From: Khem Raj <raj.khem@gmail.com>
 Date: Mon, 22 May 2017 17:36:16 -0700
 Subject: [PATCH] lldb: Add -lxml2 to linker cmdline of xml is found

--- a/recipes-devtools/clang/clang/0002-libcxxabi-Find-libunwind-headers-when-LIBCXXABI_LIBU.patch
+++ b/recipes-devtools/clang/clang/0002-libcxxabi-Find-libunwind-headers-when-LIBCXXABI_LIBU.patch
@@ -1,4 +1,4 @@
-From 9e5acc06fe366c08a313bb033010f2e56c8cb65d Mon Sep 17 00:00:00 2001
+From da63df8f02b3a767b68d6de730bb63bba6c3ce33 Mon Sep 17 00:00:00 2001
 From: Khem Raj <raj.khem@gmail.com>
 Date: Sun, 27 Aug 2017 10:37:49 -0700
 Subject: [PATCH] libcxxabi: Find libunwind headers when

--- a/recipes-devtools/clang/clang/0003-compiler-rt-support-a-new-embedded-linux-target.patch
+++ b/recipes-devtools/clang/clang/0003-compiler-rt-support-a-new-embedded-linux-target.patch
@@ -1,4 +1,4 @@
-From f8ec4b59e6ad2a91ded1f05a9e711a68d9897608 Mon Sep 17 00:00:00 2001
+From cfeba7ac05c96abddfad1eeb827ba8d0c968ec94 Mon Sep 17 00:00:00 2001
 From: Khem Raj <raj.khem@gmail.com>
 Date: Sun, 19 Apr 2015 15:16:23 -0700
 Subject: [PATCH] compiler-rt: support a new embedded linux target

--- a/recipes-devtools/clang/clang/0004-compiler-rt-Simplify-cross-compilation.-Don-t-use-na.patch
+++ b/recipes-devtools/clang/clang/0004-compiler-rt-Simplify-cross-compilation.-Don-t-use-na.patch
@@ -1,4 +1,4 @@
-From 9aaf03ac32985430e5c08347ed4e5d2721d5db1b Mon Sep 17 00:00:00 2001
+From 6c786d55d560abca076b7c1b718cdcb31ef5b388 Mon Sep 17 00:00:00 2001
 From: Khem Raj <raj.khem@gmail.com>
 Date: Thu, 19 May 2016 23:11:45 -0700
 Subject: [PATCH] compiler-rt: Simplify cross-compilation. Don't use

--- a/recipes-devtools/clang/clang/0005-compiler-rt-Disable-tsan-on-OE-glibc.patch
+++ b/recipes-devtools/clang/clang/0005-compiler-rt-Disable-tsan-on-OE-glibc.patch
@@ -1,4 +1,4 @@
-From 0565a77f6bd5fdc7a440455fb31ee5f6fd42afff Mon Sep 17 00:00:00 2001
+From 121a71a3923dbace24dbb7bd25f9f286fb9f91fb Mon Sep 17 00:00:00 2001
 From: Khem Raj <raj.khem@gmail.com>
 Date: Mon, 18 Jul 2016 08:05:02 +0000
 Subject: [PATCH] compiler-rt: Disable tsan on OE/glibc

--- a/recipes-devtools/clang/clang/0006-llvm-TargetLibraryInfo-Undefine-libc-functions-if-th.patch
+++ b/recipes-devtools/clang/clang/0006-llvm-TargetLibraryInfo-Undefine-libc-functions-if-th.patch
@@ -1,4 +1,4 @@
-From 5152fffda4231ad41d81a8fe954adec3b2955ed5 Mon Sep 17 00:00:00 2001
+From 4afcffd0c4b3317b5b5e08e3372b2923ab471e4b Mon Sep 17 00:00:00 2001
 From: Khem Raj <raj.khem@gmail.com>
 Date: Sat, 21 May 2016 00:33:20 +0000
 Subject: [PATCH] llvm: TargetLibraryInfo: Undefine libc functions if they are

--- a/recipes-devtools/clang/clang/0007-llvm-allow-env-override-of-exe-path.patch
+++ b/recipes-devtools/clang/clang/0007-llvm-allow-env-override-of-exe-path.patch
@@ -1,4 +1,4 @@
-From d8875d549490e392fe432de259fb13c00b585598 Mon Sep 17 00:00:00 2001
+From 4ed6b8848edbe1c453ce0d23d33551ff023f4fb2 Mon Sep 17 00:00:00 2001
 From: Martin Kelly <mkelly@xevo.com>
 Date: Fri, 19 May 2017 00:22:57 -0700
 Subject: [PATCH] llvm: allow env override of exe path

--- a/recipes-devtools/clang/clang/0008-clang-driver-Check-sysroot-for-ldso-path.patch
+++ b/recipes-devtools/clang/clang/0008-clang-driver-Check-sysroot-for-ldso-path.patch
@@ -1,4 +1,4 @@
-From 09a0e9e8e39b31570f00ac70880e60377ce38973 Mon Sep 17 00:00:00 2001
+From 15008103e23b5e1cd65bcc32746aa41579583dc5 Mon Sep 17 00:00:00 2001
 From: Dan McGregor <dan.mcgregor@usask.ca>
 Date: Wed, 26 Apr 2017 20:29:41 -0600
 Subject: [PATCH] clang: driver: Check sysroot for ldso path
@@ -14,10 +14,10 @@ Signed-off-by: Khem Raj <raj.khem@gmail.com>
  1 file changed, 16 insertions(+)
 
 diff --git a/clang/lib/Driver/ToolChains/Linux.cpp b/clang/lib/Driver/ToolChains/Linux.cpp
-index e17a6bd4bdd2..199d9c867c96 100644
+index 9663a7390ada..06b92cc0bf5b 100644
 --- a/clang/lib/Driver/ToolChains/Linux.cpp
 +++ b/clang/lib/Driver/ToolChains/Linux.cpp
-@@ -516,11 +516,19 @@ std::string Linux::getDynamicLinker(const ArgList &Args) const {
+@@ -507,11 +507,19 @@ std::string Linux::getDynamicLinker(const ArgList &Args) const {
      LibDir = "lib64";
      Loader =
          (tools::ppc::hasPPCAbiArg(Args, "elfv2")) ? "ld64.so.2" : "ld64.so.1";
@@ -37,7 +37,7 @@ index e17a6bd4bdd2..199d9c867c96 100644
      break;
    case llvm::Triple::riscv32: {
      StringRef ABIName = tools::riscv::getRISCVABI(Args, Triple);
-@@ -542,6 +550,10 @@ std::string Linux::getDynamicLinker(const ArgList &Args) const {
+@@ -533,6 +541,10 @@ std::string Linux::getDynamicLinker(const ArgList &Args) const {
    case llvm::Triple::sparcv9:
      LibDir = "lib64";
      Loader = "ld-linux.so.2";
@@ -48,7 +48,7 @@ index e17a6bd4bdd2..199d9c867c96 100644
      break;
    case llvm::Triple::systemz:
      LibDir = "lib";
-@@ -556,6 +568,10 @@ std::string Linux::getDynamicLinker(const ArgList &Args) const {
+@@ -547,6 +559,10 @@ std::string Linux::getDynamicLinker(const ArgList &Args) const {
  
      LibDir = X32 ? "libx32" : "lib64";
      Loader = X32 ? "ld-linux-x32.so.2" : "ld-linux-x86-64.so.2";

--- a/recipes-devtools/clang/clang/0009-clang-Driver-tools.cpp-Add-lssp_nonshared-on-musl.patch
+++ b/recipes-devtools/clang/clang/0009-clang-Driver-tools.cpp-Add-lssp_nonshared-on-musl.patch
@@ -1,4 +1,4 @@
-From 88f44c237f409d091966cebfbeff6c089d212b20 Mon Sep 17 00:00:00 2001
+From 1b2f69bc1938d4d65dd88c2e43e1bd160312d074 Mon Sep 17 00:00:00 2001
 From: Khem Raj <raj.khem@gmail.com>
 Date: Thu, 19 May 2016 21:11:06 -0700
 Subject: [PATCH] clang: Driver/tools.cpp: Add -lssp_nonshared on musl

--- a/recipes-devtools/clang/clang/0010-clang-musl-ppc-does-not-support-128-bit-long-double.patch
+++ b/recipes-devtools/clang/clang/0010-clang-musl-ppc-does-not-support-128-bit-long-double.patch
@@ -1,4 +1,4 @@
-From 4c5c8ed9d14942e9c16cfdfb39257dc265a007c5 Mon Sep 17 00:00:00 2001
+From 7ab52935bc6bd89529a2478af1ea2cdf192eb0d9 Mon Sep 17 00:00:00 2001
 From: Khem Raj <raj.khem@gmail.com>
 Date: Tue, 10 May 2016 02:00:11 -0700
 Subject: [PATCH] clang: musl/ppc does not support 128-bit long double

--- a/recipes-devtools/clang/clang/0011-clang-Prepend-trailing-to-sysroot.patch
+++ b/recipes-devtools/clang/clang/0011-clang-Prepend-trailing-to-sysroot.patch
@@ -1,4 +1,4 @@
-From 20a2d20cb5c2eaa624a3ac514a663104c62786bf Mon Sep 17 00:00:00 2001
+From af7639bf4db497300060a22f2cc94b37145b8db5 Mon Sep 17 00:00:00 2001
 From: Khem Raj <raj.khem@gmail.com>
 Date: Thu, 16 Mar 2017 09:02:13 -0700
 Subject: [PATCH] clang: Prepend trailing '/' to sysroot
@@ -24,7 +24,7 @@ Signed-off-by: Khem Raj <raj.khem@gmail.com>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/clang/lib/Driver/ToolChains/Linux.cpp b/clang/lib/Driver/ToolChains/Linux.cpp
-index 199d9c867c96..520ae5a7d2cf 100644
+index 06b92cc0bf5b..726308413dc9 100644
 --- a/clang/lib/Driver/ToolChains/Linux.cpp
 +++ b/clang/lib/Driver/ToolChains/Linux.cpp
 @@ -218,7 +218,7 @@ Linux::Linux(const Driver &D, const llvm::Triple &Triple, const ArgList &Args)

--- a/recipes-devtools/clang/clang/0012-clang-Look-inside-the-target-sysroot-for-compiler-ru.patch
+++ b/recipes-devtools/clang/clang/0012-clang-Look-inside-the-target-sysroot-for-compiler-ru.patch
@@ -1,4 +1,4 @@
-From b1b677981b251e231b863dabbed938b7ece54eef Mon Sep 17 00:00:00 2001
+From f946307a70619c45919ac06fa37c267fd25c3ec8 Mon Sep 17 00:00:00 2001
 From: Khem Raj <raj.khem@gmail.com>
 Date: Thu, 16 Mar 2017 19:06:26 -0700
 Subject: [PATCH] clang: Look inside the target sysroot for compiler runtime

--- a/recipes-devtools/clang/clang/0013-clang-Define-releative-gcc-installation-dir.patch
+++ b/recipes-devtools/clang/clang/0013-clang-Define-releative-gcc-installation-dir.patch
@@ -1,4 +1,4 @@
-From 3658b52189bdbd9e742c0166d9bc919d4195b40e Mon Sep 17 00:00:00 2001
+From 9c61a33cec25c8f2e0a90d5109808131d2e51c2d Mon Sep 17 00:00:00 2001
 From: Khem Raj <raj.khem@gmail.com>
 Date: Sun, 21 May 2017 15:38:25 -0700
 Subject: [PATCH] clang: Define / releative gcc installation dir

--- a/recipes-devtools/clang/clang/0014-clang-Fix-ldso-for-musl-on-x86-and-x32-architectures.patch
+++ b/recipes-devtools/clang/clang/0014-clang-Fix-ldso-for-musl-on-x86-and-x32-architectures.patch
@@ -1,4 +1,4 @@
-From 7b8ad95e1e5953234df3e06d5d01cbdd1a8c051d Mon Sep 17 00:00:00 2001
+From 3166a3b59f406de57f04a0b6fd0f3f1eabfaaa37 Mon Sep 17 00:00:00 2001
 From: Khem Raj <raj.khem@gmail.com>
 Date: Wed, 16 Aug 2017 15:16:15 -0700
 Subject: [PATCH] clang: Fix ldso for musl on x86 and x32 architectures
@@ -14,10 +14,10 @@ Signed-off-by: Khem Raj <raj.khem@gmail.com>
  1 file changed, 8 insertions(+)
 
 diff --git a/clang/lib/Driver/ToolChains/Linux.cpp b/clang/lib/Driver/ToolChains/Linux.cpp
-index 520ae5a7d2cf..8b72e8f505fe 100644
+index 726308413dc9..b64396647882 100644
 --- a/clang/lib/Driver/ToolChains/Linux.cpp
 +++ b/clang/lib/Driver/ToolChains/Linux.cpp
-@@ -435,6 +435,7 @@ std::string Linux::getDynamicLinker(const ArgList &Args) const {
+@@ -426,6 +426,7 @@ std::string Linux::getDynamicLinker(const ArgList &Args) const {
    if (Triple.isMusl()) {
      std::string ArchName;
      bool IsArm = false;
@@ -25,7 +25,7 @@ index 520ae5a7d2cf..8b72e8f505fe 100644
  
      switch (Arch) {
      case llvm::Triple::arm:
-@@ -447,6 +448,13 @@ std::string Linux::getDynamicLinker(const ArgList &Args) const {
+@@ -438,6 +439,13 @@ std::string Linux::getDynamicLinker(const ArgList &Args) const {
        ArchName = "armeb";
        IsArm = true;
        break;

--- a/recipes-devtools/clang/clang/0015-clang-scan-view-needs-python-2.x.patch
+++ b/recipes-devtools/clang/clang/0015-clang-scan-view-needs-python-2.x.patch
@@ -1,4 +1,4 @@
-From 330f45191d4e73ac50131d278fa201b56c173880 Mon Sep 17 00:00:00 2001
+From bd42395fa181d5821f0d756d12c534f2cda525c0 Mon Sep 17 00:00:00 2001
 From: Khem Raj <raj.khem@gmail.com>
 Date: Tue, 15 May 2018 10:28:43 -0700
 Subject: [PATCH] clang: scan-view needs python 2.x

--- a/recipes-devtools/clang/clang/0016-clang-Add-lpthread-and-ldl-along-with-lunwind-for-st.patch
+++ b/recipes-devtools/clang/clang/0016-clang-Add-lpthread-and-ldl-along-with-lunwind-for-st.patch
@@ -1,4 +1,4 @@
-From e5457a0d477d7a0f7fffef56670450744881554f Mon Sep 17 00:00:00 2001
+From c309e121d6aca050119084e3e98371cd8e44ecca Mon Sep 17 00:00:00 2001
 From: Khem Raj <raj.khem@gmail.com>
 Date: Wed, 31 Jul 2019 22:51:39 -0700
 Subject: [PATCH] clang: Add -lpthread and -ldl along with -lunwind for static

--- a/recipes-devtools/clang/clang/0017-Pass-PYTHON_EXECUTABLE-when-cross-compiling-for-nati.patch
+++ b/recipes-devtools/clang/clang/0017-Pass-PYTHON_EXECUTABLE-when-cross-compiling-for-nati.patch
@@ -1,4 +1,4 @@
-From 20ad7e5562772d10d5edaafc1a054a26e91ccdb5 Mon Sep 17 00:00:00 2001
+From 00449fb89e8ab3b34f03d3a09a4d859e5d0a8245 Mon Sep 17 00:00:00 2001
 From: Anuj Mittal <anuj.mittal@intel.com>
 Date: Thu, 26 Dec 2019 12:56:16 -0800
 Subject: [PATCH] Pass PYTHON_EXECUTABLE when cross compiling for native build

--- a/recipes-devtools/clang/clang/0018-Check-for-atomic-double-intrinsics.patch
+++ b/recipes-devtools/clang/clang/0018-Check-for-atomic-double-intrinsics.patch
@@ -1,4 +1,4 @@
-From 1fbeaabbc22e1f665889a0f3fec5bb435207649b Mon Sep 17 00:00:00 2001
+From 761be2d8d20d9ebe93fa33719bdd0d25396d812d Mon Sep 17 00:00:00 2001
 From: Khem Raj <raj.khem@gmail.com>
 Date: Mon, 18 Nov 2019 17:00:29 -0800
 Subject: [PATCH] Check for atomic<double> intrinsics

--- a/recipes-devtools/clang/clang/0019-clang-Enable-SSP-and-PIE-by-default.patch
+++ b/recipes-devtools/clang/clang/0019-clang-Enable-SSP-and-PIE-by-default.patch
@@ -1,4 +1,4 @@
-From 460c9c3c8d6384613f3a12af6f27513d1a2222f0 Mon Sep 17 00:00:00 2001
+From d0f788c1fb3d00350c51e88302ecbcf3506e4b53 Mon Sep 17 00:00:00 2001
 From: Evangelos Foutras <evangelos@foutrelis.com>
 Date: Thu, 26 Dec 2019 15:46:19 -0800
 Subject: [PATCH] clang: Enable SSP and PIE by default
@@ -37,10 +37,10 @@ Signed-off-by: Khem Raj <raj.khem@gmail.com>
  13 files changed, 42 insertions(+), 30 deletions(-)
 
 diff --git a/clang/lib/Driver/ToolChains/Linux.cpp b/clang/lib/Driver/ToolChains/Linux.cpp
-index 8b72e8f505fe..98f54a935465 100644
+index b64396647882..604024bb3df4 100644
 --- a/clang/lib/Driver/ToolChains/Linux.cpp
 +++ b/clang/lib/Driver/ToolChains/Linux.cpp
-@@ -865,8 +865,14 @@ void Linux::AddIAMCUIncludeArgs(const ArgList &DriverArgs,
+@@ -856,8 +856,14 @@ void Linux::AddIAMCUIncludeArgs(const ArgList &DriverArgs,
  }
  
  bool Linux::isPIEDefault() const {
@@ -221,7 +221,7 @@ index 0959bd7ba0a1..4056a672b6f9 100644
  // CHECK-SPARCV9PIC: as
  // CHECK-SPARCV9PIC: -64
 diff --git a/clang/test/Driver/linux-ld.c b/clang/test/Driver/linux-ld.c
-index 0b788ffcb852..0ee504cd00e3 100644
+index 24d3c78643f8..9ea22e6e0f64 100644
 --- a/clang/test/Driver/linux-ld.c
 +++ b/clang/test/Driver/linux-ld.c
 @@ -1,3 +1,5 @@

--- a/recipes-devtools/clang/clang/0020-libcxx-Add-compiler-runtime-library-to-link-step-for.patch
+++ b/recipes-devtools/clang/clang/0020-libcxx-Add-compiler-runtime-library-to-link-step-for.patch
@@ -1,4 +1,4 @@
-From 81ece1b8e6762676679106f2c17c5fdd2aad3035 Mon Sep 17 00:00:00 2001
+From 5c0a4264ad87c880ade430022e0f128da86bbf6d Mon Sep 17 00:00:00 2001
 From: Jeremy Puhlman <jpuhlman@mvista.com>
 Date: Thu, 16 Jan 2020 21:16:10 +0000
 Subject: [PATCH] libcxx: Add compiler runtime library to link step for libcxx

--- a/recipes-devtools/clang/clang/0021-clang-llvm-cmake-Fix-configure-for-packages-using-fi.patch
+++ b/recipes-devtools/clang/clang/0021-clang-llvm-cmake-Fix-configure-for-packages-using-fi.patch
@@ -1,4 +1,4 @@
-From 62e0614c52cc2b084d993914451b5290759a1187 Mon Sep 17 00:00:00 2001
+From 12fe6e45d18add7da95fe637f9e21425330666f9 Mon Sep 17 00:00:00 2001
 From: Ovidiu Panait <ovidiu.panait@windriver.com>
 Date: Fri, 31 Jan 2020 10:56:11 +0200
 Subject: [PATCH] clang,llvm: cmake: Fix configure for packages using

--- a/recipes-devtools/clang/clang/0022-clang-Fix-resource-dir-location-for-cross-toolchains.patch
+++ b/recipes-devtools/clang/clang/0022-clang-Fix-resource-dir-location-for-cross-toolchains.patch
@@ -1,4 +1,4 @@
-From 1dcf3b4cd50bfd75f7530a463f818ff2705fdb60 Mon Sep 17 00:00:00 2001
+From 6ad331a0e464ee28eac7d0a1c658cd007e831297 Mon Sep 17 00:00:00 2001
 From: Jim Broadus <jbroadus@xevo.com>
 Date: Thu, 26 Mar 2020 16:05:53 -0700
 Subject: [PATCH] clang: Fix resource dir location for cross toolchains

--- a/recipes-devtools/clang/clang/0023-fix-path-to-libffi.patch
+++ b/recipes-devtools/clang/clang/0023-fix-path-to-libffi.patch
@@ -1,4 +1,4 @@
-From d45e47dd0d7fe5e8b179557822292fc312a55cfc Mon Sep 17 00:00:00 2001
+From cbcfe7d13dfc5644c9b8a48e951b43bc15d9f4cf Mon Sep 17 00:00:00 2001
 From: Anuj Mittal <anuj.mittal@intel.com>
 Date: Fri, 3 Apr 2020 15:10:37 +0800
 Subject: [PATCH] fix path to libffi

--- a/recipes-devtools/clang/clang/0024-clang-driver-Add-dyld-prefix-when-checking-sysroot-f.patch
+++ b/recipes-devtools/clang/clang/0024-clang-driver-Add-dyld-prefix-when-checking-sysroot-f.patch
@@ -1,4 +1,4 @@
-From 6c2721a8ee7f15f3035592dfd0d7983369ffd12a Mon Sep 17 00:00:00 2001
+From 5f3d1b71c3e87017dfa471f1561f6c28f34a77f8 Mon Sep 17 00:00:00 2001
 From: Oleksandr Ocheretnyi <oocheret@cisco.com>
 Date: Wed, 15 Apr 2020 00:08:39 +0300
 Subject: [PATCH] clang: driver: Add dyld-prefix when checking sysroot for ldso
@@ -18,10 +18,10 @@ Signed-off-by: Khem Raj <raj.khem@gmail.com>
  1 file changed, 8 insertions(+), 8 deletions(-)
 
 diff --git a/clang/lib/Driver/ToolChains/Linux.cpp b/clang/lib/Driver/ToolChains/Linux.cpp
-index 98f54a935465..cab25988e81a 100644
+index 604024bb3df4..812599cdaf84 100644
 --- a/clang/lib/Driver/ToolChains/Linux.cpp
 +++ b/clang/lib/Driver/ToolChains/Linux.cpp
-@@ -524,8 +524,8 @@ std::string Linux::getDynamicLinker(const ArgList &Args) const {
+@@ -515,8 +515,8 @@ std::string Linux::getDynamicLinker(const ArgList &Args) const {
      LibDir = "lib64";
      Loader =
          (tools::ppc::hasPPCAbiArg(Args, "elfv2")) ? "ld64.so.2" : "ld64.so.1";
@@ -32,7 +32,7 @@ index 98f54a935465..cab25988e81a 100644
          LibDir = "lib";
      }
      break;
-@@ -533,8 +533,8 @@ std::string Linux::getDynamicLinker(const ArgList &Args) const {
+@@ -524,8 +524,8 @@ std::string Linux::getDynamicLinker(const ArgList &Args) const {
      LibDir = "lib64";
      Loader =
          (tools::ppc::hasPPCAbiArg(Args, "elfv1")) ? "ld64.so.1" : "ld64.so.2";
@@ -43,7 +43,7 @@ index 98f54a935465..cab25988e81a 100644
          LibDir = "lib";
      }
      break;
-@@ -558,8 +558,8 @@ std::string Linux::getDynamicLinker(const ArgList &Args) const {
+@@ -549,8 +549,8 @@ std::string Linux::getDynamicLinker(const ArgList &Args) const {
    case llvm::Triple::sparcv9:
      LibDir = "lib64";
      Loader = "ld-linux.so.2";
@@ -54,7 +54,7 @@ index 98f54a935465..cab25988e81a 100644
          LibDir = "lib";
      }
      break;
-@@ -576,8 +576,8 @@ std::string Linux::getDynamicLinker(const ArgList &Args) const {
+@@ -567,8 +567,8 @@ std::string Linux::getDynamicLinker(const ArgList &Args) const {
  
      LibDir = X32 ? "libx32" : "lib64";
      Loader = X32 ? "ld-linux-x32.so.2" : "ld-linux-x86-64.so.2";

--- a/recipes-devtools/clang/clang/0025-clang-Use-python3-in-python-scripts.patch
+++ b/recipes-devtools/clang/clang/0025-clang-Use-python3-in-python-scripts.patch
@@ -1,4 +1,4 @@
-From c308a31dc960830c7c325f85e0840c3f26b01a34 Mon Sep 17 00:00:00 2001
+From fd3696213eed77e8c217be0ded0e220c0b597f1e Mon Sep 17 00:00:00 2001
 From: Khem Raj <raj.khem@gmail.com>
 Date: Wed, 14 Oct 2020 22:19:57 -0700
 Subject: [PATCH] clang: Use python3 in python scripts

--- a/recipes-devtools/clang/clang/0026-For-x86_64-set-Yocto-based-GCC-install-search-path.patch
+++ b/recipes-devtools/clang/clang/0026-For-x86_64-set-Yocto-based-GCC-install-search-path.patch
@@ -1,4 +1,4 @@
-From 386cec2c3000b398cb0afe9bf9e9d57f7cdfd4eb Mon Sep 17 00:00:00 2001
+From 13dedb0bbf780f7d66ddad8b1b33b3a1e0de2d25 Mon Sep 17 00:00:00 2001
 From: Hongxu Jia <hongxu.jia@windriver.com>
 Date: Mon, 25 Jan 2021 16:14:35 +0800
 Subject: [PATCH] For x86_64, set Yocto based GCC install search path
@@ -56,9 +56,11 @@ Signed-off-by: Khem Raj <raj.khem@gmail.com>
  clang/lib/Driver/ToolChains/Gnu.cpp | 1 +
  1 file changed, 1 insertion(+)
 
+diff --git a/clang/lib/Driver/ToolChains/Gnu.cpp b/clang/lib/Driver/ToolChains/Gnu.cpp
+index 05d1d3003881..33b1d7fb7061 100644
 --- a/clang/lib/Driver/ToolChains/Gnu.cpp
 +++ b/clang/lib/Driver/ToolChains/Gnu.cpp
-@@ -2109,6 +2109,7 @@ void Generic_GCC::GCCInstallationDetecto
+@@ -2109,6 +2109,7 @@ void Generic_GCC::GCCInstallationDetector::AddDefaultGCCPrefixes(
        "x86_64-redhat-linux",    "x86_64-suse-linux",
        "x86_64-manbo-linux-gnu", "x86_64-linux-gnu",
        "x86_64-slackware-linux", "x86_64-unknown-linux",

--- a/recipes-devtools/clang/clang/0027-compiler-rt-Include-stddef.h.patch
+++ b/recipes-devtools/clang/clang/0027-compiler-rt-Include-stddef.h.patch
@@ -1,4 +1,4 @@
-From cea47d9b88c94d1daf7d4c579e6ca4f9c72dc874 Mon Sep 17 00:00:00 2001
+From f5367ee64b6e74039c0957e1f7d81dc8d597804d Mon Sep 17 00:00:00 2001
 From: Khem Raj <raj.khem@gmail.com>
 Date: Sat, 6 Feb 2021 12:44:30 -0800
 Subject: [PATCH] compiler-rt: Include stddef.h

--- a/recipes-devtools/clang/clang/0028-llvm-Do-not-use-find_library-for-ncurses.patch
+++ b/recipes-devtools/clang/clang/0028-llvm-Do-not-use-find_library-for-ncurses.patch
@@ -1,4 +1,4 @@
-From dcb04ae498c16f90b3a4376ad5674156c3ec0dc6 Mon Sep 17 00:00:00 2001
+From 6660c7d48601df4276fb3f51156c96fff103fb79 Mon Sep 17 00:00:00 2001
 From: Khem Raj <raj.khem@gmail.com>
 Date: Sun, 7 Feb 2021 23:58:41 -0800
 Subject: [PATCH] llvm: Do not use find_library for ncurses

--- a/recipes-devtools/clang/clang/0029-llvm-Insert-anchor-for-adding-OE-distro-vendor-names.patch
+++ b/recipes-devtools/clang/clang/0029-llvm-Insert-anchor-for-adding-OE-distro-vendor-names.patch
@@ -1,7 +1,7 @@
-From 74beba7c8edee65e123b034cb2a28515f8e22eb8 Mon Sep 17 00:00:00 2001
+From 7bc8252aff944f2efeaad92c431b1f1c5cf606b1 Mon Sep 17 00:00:00 2001
 From: Khem Raj <raj.khem@gmail.com>
 Date: Thu, 11 Feb 2021 16:42:49 -0800
-Subject: [PATCH] llvm: Recognize yoe and poky as OE distro
+Subject: [PATCH] llvm: Insert anchor for adding OE distro vendor names
 
 This helps in making right detection for OE built gcc toolchains
 
@@ -9,20 +9,20 @@ The //CLANG_EXTRA_OE_VENDORS_CASES string is replaced with list of
 additional Ceses based on CLANG_EXTRA_OE_VENDORS variable in
 recipes-devtools/clang/llvm-project-source.inc:add_more_target_vendors()
 
+Upstream-Status: Inappropriate [OE-specific]
+
 Signed-off-by: Khem Raj <raj.khem@gmail.com>
 Signed-off-by: Martin Jansa <martin.jansa@gmail.com>
-
-Add wrs
-Signed-off-by: Yi Fan Yu <yifan.yu@windriver.com>
 ---
- llvm/lib/Support/Triple.cpp | 3 +++
- 1 file changed, 3 insertions(+)
+ llvm/lib/Support/Triple.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/llvm/lib/Support/Triple.cpp b/llvm/lib/Support/Triple.cpp
-index 4f483c965282..abd181759786 100644
+index 4f483c965282..ffd20d223133 100644
 --- a/llvm/lib/Support/Triple.cpp
 +++ b/llvm/lib/Support/Triple.cpp
-@@ -490,6 +490,6 @@ static Triple::VendorType parseVendor(StringRef VendorName) {
+@@ -489,7 +489,7 @@ static Triple::VendorType parseVendor(StringRef VendorName) {
+     .Case("amd", Triple::AMD)
      .Case("mesa", Triple::Mesa)
      .Case("suse", Triple::SUSE)
 -    .Case("oe", Triple::OpenEmbedded)

--- a/recipes-devtools/clang/clang/0030-AsmMatcherEmitter-sort-ClassInfo-lists-by-name-as-we.patch
+++ b/recipes-devtools/clang/clang/0030-AsmMatcherEmitter-sort-ClassInfo-lists-by-name-as-we.patch
@@ -1,0 +1,32 @@
+From 4d51447a11ee6796594fd55718ea62575ecebc78 Mon Sep 17 00:00:00 2001
+From: Alexander Kanavin <alex.kanavin@gmail.com>
+Date: Fri, 27 Nov 2020 10:11:08 +0000
+Subject: [PATCH] AsmMatcherEmitter: sort ClassInfo lists by name as well
+
+Otherwise, there are instances which are identical in
+every other field and therefore sort non-reproducibly
+(which breaks binary and source reproducibiliy).
+
+Upstream-Status: Pending
+Signed-off-by: Alexander Kanavin <alex.kanavin@gmail.com>
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ llvm/utils/TableGen/AsmMatcherEmitter.cpp | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/llvm/utils/TableGen/AsmMatcherEmitter.cpp b/llvm/utils/TableGen/AsmMatcherEmitter.cpp
+index 9d304910ba4e..d1b50b04fc71 100644
+--- a/llvm/utils/TableGen/AsmMatcherEmitter.cpp
++++ b/llvm/utils/TableGen/AsmMatcherEmitter.cpp
+@@ -359,7 +359,10 @@ public:
+     // name of a class shouldn't be significant. However, some of the backends
+     // accidentally rely on this behaviour, so it will have to stay like this
+     // until they are fixed.
+-    return ValueName < RHS.ValueName;
++    if (ValueName != RHS.ValueName)
++        return ValueName < RHS.ValueName;
++    // All else being equal, we should sort by name, for source and binary reproducibility
++    return Name < RHS.Name;
+   }
+ };
+ 

--- a/recipes-devtools/clang/clang/0031-compiler-rt-Use-mcr-based-barrier-on-armv6.patch
+++ b/recipes-devtools/clang/clang/0031-compiler-rt-Use-mcr-based-barrier-on-armv6.patch
@@ -1,4 +1,4 @@
-From 97123bf7bc7cc2a55c3dfb5006be5dd66c46d790 Mon Sep 17 00:00:00 2001
+From 4f45514fb8841a08d8d3bb68d9cb84b607e652f2 Mon Sep 17 00:00:00 2001
 From: Khem Raj <raj.khem@gmail.com>
 Date: Wed, 24 Mar 2021 00:32:09 -0700
 Subject: [PATCH] compiler-rt: Use mcr based barrier on armv6
@@ -69,6 +69,3 @@ index f6ce6a9fccff..5c6cd9376ac4 100644
  #if defined(USE_THUMB_2)
  #define WIDE(op) op.w
  #else
--- 
-2.31.0
-

--- a/recipes-devtools/clang/clang/0032-clang-Switch-defaults-to-dwarf-5-debug-info-on-Linux.patch
+++ b/recipes-devtools/clang/clang/0032-clang-Switch-defaults-to-dwarf-5-debug-info-on-Linux.patch
@@ -1,0 +1,28 @@
+From 1d07b3e71bf073da0a25b30efb135adaa876e3df Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Thu, 15 Apr 2021 18:58:07 -0700
+Subject: [PATCH] clang: Switch defaults to dwarf-5 debug info on Linux
+
+GCC 11 has defaulted to DWARF-5 as well, this matches
+debug info formats,  so mix and match of components with GCC 11
+works.
+
+Upstream-Status: Pending
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ clang/lib/Driver/ToolChains/Linux.h | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/clang/lib/Driver/ToolChains/Linux.h b/clang/lib/Driver/ToolChains/Linux.h
+index 582d4bef81df..82c9494c744e 100644
+--- a/clang/lib/Driver/ToolChains/Linux.h
++++ b/clang/lib/Driver/ToolChains/Linux.h
+@@ -58,6 +58,8 @@ public:
+       const llvm::opt::ArgList &DriverArgs, const JobAction &JA,
+       const llvm::fltSemantics *FPType = nullptr) const override;
+ 
++  unsigned GetDefaultDwarfVersion() const override { return 5; }
++
+ protected:
+   Tool *buildAssembler() const override;
+   Tool *buildLinker() const override;

--- a/recipes-devtools/clang/common.inc
+++ b/recipes-devtools/clang/common.inc
@@ -37,8 +37,10 @@ SRC_URI = "\
     file://0026-For-x86_64-set-Yocto-based-GCC-install-search-path.patch \
     file://0027-compiler-rt-Include-stddef.h.patch \
     file://0028-llvm-Do-not-use-find_library-for-ncurses.patch \
-    file://0029-llvm-Recognize-yoe-and-poky-as-OE-distro.patch \
-    file://0030-compiler-rt-Use-mcr-based-barrier-on-armv6.patch \
+    file://0029-llvm-Insert-anchor-for-adding-OE-distro-vendor-names.patch \
+    file://0030-AsmMatcherEmitter-sort-ClassInfo-lists-by-name-as-we.patch \
+    file://0031-compiler-rt-Use-mcr-based-barrier-on-armv6.patch \
+    file://0032-clang-Switch-defaults-to-dwarf-5-debug-info-on-Linux.patch \
 "
 # Fallback to no-PIE if not set
 GCCPIE ??= ""


### PR DESCRIPTION
This matches with GCC 11 which is also defaulting to DWARF-5

Signed-off-by: Khem Raj <raj.khem@gmail.com>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
