### PR TITLE
Fix x86 packages with RUNTIME=llvm and do not force libgcc unwinder on RISCV

### DIFF
--- a/classes/clang.bbclass
+++ b/classes/clang.bbclass
@@ -17,8 +17,6 @@ COMPILER_RT_powerpc = "-rtlib=libgcc ${UNWINDLIB}"
 COMPILER_RT_armeb = "-rtlib=libgcc ${UNWINDLIB}"
 
 UNWINDLIB ??= ""
-UNWINDLIB_riscv64 = "--unwindlib=libgcc"
-UNWINDLIB_riscv32 = "--unwindlib=libgcc"
 UNWINDLIB_powerpc = "--unwindlib=libgcc"
 UNWINDLIB_armeb = "--unwindlib=libgcc"
 

--- a/conf/nonclangable.conf
+++ b/conf/nonclangable.conf
@@ -292,23 +292,25 @@ COMPILER_RT_pn-qtbase_toolchain-clang_riscv32 = "-rtlib=compiler-rt ${UNWINDLIB}
 LDFLAGS_append_pn-gnutls_toolchain-clang_riscv64 = " -latomic"
 LDFLAGS_append_pn-harfbuzz_toolchain-clang_riscv64 = " -latomic"
 LDFLAGS_append_pn-qtwebengine_toolchain-clang_runtime-gnu_x86 = " -latomic"
-LDFLAGS_append_pn-qemu_toolchain-clang_runtime-gnu_x86 = " -latomic"
+LDFLAGS_append_pn-qemu_toolchain-clang_x86 = " -latomic"
 
 # glibc is built with gcc and hence encodes some libgcc specific builtins which are not found
 # when doing static linking with clang using compiler-rt, so use libgcc
 # undefined reference to `__unordtf2'
-COMPILER_RT_pn-aufs-util_libc-glibc_toolchain-clang_x86 = "-rtlib=libgcc"
-COMPILER_RT_pn-libhugetlbfs_libc-glibc_toolchain-clang_x86 = "-rtlib=libgcc"
-COMPILER_RT_pn-tsocks_libc-glibc_toolchain-clang_x86 = "-rtlib=libgcc"
-COMPILER_RT_pn-aufs-util_libc-glibc_toolchain-clang_x86-64 = "-rtlib=libgcc"
-COMPILER_RT_pn-libhugetlbfs_libc-glibc_toolchain-clang_x86-64 = "-rtlib=libgcc"
-COMPILER_RT_pn-tsocks_libc-glibc_toolchain-clang_x86-64 = "-rtlib=libgcc"
+COMPILER_RT_pn-aufs-util_libc-glibc_toolchain-clang_x86 = "-rtlib=libgcc --unwindlib=libgcc"
+COMPILER_RT_pn-libhugetlbfs_libc-glibc_toolchain-clang_x86 = "-rtlib=libgcc --unwindlib=libgcc"
+COMPILER_RT_pn-tsocks_libc-glibc_toolchain-clang_x86 = "-rtlib=libgcc --unwindlib=libgcc"
+COMPILER_RT_pn-libc-bench_libc-glibc_toolchain-clang_x86 = "-rtlib=libgcc --unwindlib=libgcc"
+COMPILER_RT_pn-mpich_libc-glibc_toolchain-clang_x86 = "-rtlib=libgcc --unwindlib=libgcc"
+COMPILER_RT_pn-aufs-util_libc-glibc_toolchain-clang_x86-64 = "-rtlib=libgcc --unwindlib=libgcc"
+COMPILER_RT_pn-libhugetlbfs_libc-glibc_toolchain-clang_x86-64 = "-rtlib=libgcc --unwindlib=libgcc"
+COMPILER_RT_pn-tsocks_libc-glibc_toolchain-clang_x86-64 = "-rtlib=libgcc --unwindlib=libgcc"
 
 #(unwind.o): in function `__pthread_unwind':
 #/usr/src/debug/glibc/2.29-r0/git/nptl/unwind.c:121: undefined reference to `_Unwind_ForcedUnwind'
 #clang-8: error: linker command failed with exit code 1 (use -v to see invocation)
-COMPILER_RT_pn-aufs-util_libc-glibc_toolchain-clang_arm = "-rtlib=libgcc"
-COMPILER_RT_pn-libhugetlbfs_libc-glibc_toolchain-clang_arm = "-rtlib=libgcc"
+COMPILER_RT_pn-aufs-util_libc-glibc_toolchain-clang_arm = "-rtlib=libgcc --unwindlib=libgcc"
+COMPILER_RT_pn-libhugetlbfs_libc-glibc_toolchain-clang_arm = "-rtlib=libgcc --unwindlib=libgcc"
 
 # Uses gcc for native tools, e.g. nsinstall and passes clang options which fails so
 # let same compiler ( gcc or clang) be native/cross compiler


### PR DESCRIPTION
---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
