### PR TITLE
spirv-llvm-translator: Remove a trailing slash from SRC_URI

### DIFF
--- a/recipes-devtools/spirv-llvm-translator/spirv-llvm-translator_git.bb
+++ b/recipes-devtools/spirv-llvm-translator/spirv-llvm-translator_git.bb
@@ -2,7 +2,7 @@ LICENSE = "NCSA"
 LIC_FILES_CHKSUM = "file://LICENSE.TXT;md5=47e311aa9caedd1b3abf098bd7814d1d"
 
 BRANCH = "master"
-SRC_URI = "git://github.com/KhronosGroup/SPIRV-LLVM-Translator/;protocol=https;branch=${BRANCH} \
+SRC_URI = "git://github.com/KhronosGroup/SPIRV-LLVM-Translator;protocol=https;branch=${BRANCH} \
           "
 
 PV = "13.0.0"


### PR DESCRIPTION
The trailing slash caused the mirror name endswith a dot which looks strange:
github.com.KhronosGroup.SPIRV-LLVM-Translator.

The slash is not needed, so remove it.

Signed-off-by: Robert Yang <liezhi.yang@windriver.com>
Signed-off-by: Changqing Li <changqing.li@windriver.com>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
