### PR TITLE
clang: drop git suffix from version variables

### DIFF
--- a/recipes-devtools/clang/clang/0036-Drop-the-git-suffix-from-various-version-variables.patch
+++ b/recipes-devtools/clang/clang/0036-Drop-the-git-suffix-from-various-version-variables.patch
@@ -1,0 +1,70 @@
+From f25f79545c919543e182f629f7101f4b35faaac6 Mon Sep 17 00:00:00 2001
+From: Changqing Li <changqing.li@windriver.com>
+Date: Wed, 23 Jun 2021 16:25:06 +0800
+Subject: [PATCH] Drop the 'git' suffix from various version variables
+
+Upstream-Status: Backport [cherry-picked from branch 12.0.0]
+
+Signed-off-by: Changqing Li <changqing.li@windriver.com>
+---
+ libcxx/CMakeLists.txt    | 2 +-
+ libcxxabi/CMakeLists.txt | 2 +-
+ libunwind/CMakeLists.txt | 2 +-
+ llvm/CMakeLists.txt      | 2 +-
+ 4 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/libcxx/CMakeLists.txt b/libcxx/CMakeLists.txt
+index 06ee1d74a03e..1ead84c19fcb 100644
+--- a/libcxx/CMakeLists.txt
++++ b/libcxx/CMakeLists.txt
+@@ -29,7 +29,7 @@ if (CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR OR LIBCXX_STANDALONE_BUIL
+   project(libcxx CXX C)
+ 
+   set(PACKAGE_NAME libcxx)
+-  set(PACKAGE_VERSION 13.0.0git)
++  set(PACKAGE_VERSION 13.0.0)
+   set(PACKAGE_STRING "${PACKAGE_NAME} ${PACKAGE_VERSION}")
+   set(PACKAGE_BUGREPORT "llvm-bugs@lists.llvm.org")
+ 
+diff --git a/libcxxabi/CMakeLists.txt b/libcxxabi/CMakeLists.txt
+index fb656e7db9fb..405bc3ceeaa7 100644
+--- a/libcxxabi/CMakeLists.txt
++++ b/libcxxabi/CMakeLists.txt
+@@ -28,7 +28,7 @@ if (CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR OR LIBCXXABI_STANDALONE_B
+   project(libcxxabi CXX C)
+ 
+   set(PACKAGE_NAME libcxxabi)
+-  set(PACKAGE_VERSION 11.0.0git)
++  set(PACKAGE_VERSION 11.0.0)
+   set(PACKAGE_STRING "${PACKAGE_NAME} ${PACKAGE_VERSION}")
+   set(PACKAGE_BUGREPORT "llvm-bugs@lists.llvm.org")
+ 
+diff --git a/libunwind/CMakeLists.txt b/libunwind/CMakeLists.txt
+index a2c03fd3f8aa..82424253c8da 100644
+--- a/libunwind/CMakeLists.txt
++++ b/libunwind/CMakeLists.txt
+@@ -24,7 +24,7 @@ if (CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR OR LIBUNWIND_STANDALONE_B
+   project(libunwind LANGUAGES C CXX ASM)
+ 
+   set(PACKAGE_NAME libunwind)
+-  set(PACKAGE_VERSION 13.0.0git)
++  set(PACKAGE_VERSION 13.0.0)
+   set(PACKAGE_STRING "${PACKAGE_NAME} ${PACKAGE_VERSION}")
+   set(PACKAGE_BUGREPORT "llvm-bugs@lists.llvm.org")
+ 
+diff --git a/llvm/CMakeLists.txt b/llvm/CMakeLists.txt
+index 135036f509d2..c28bc3f8d19d 100644
+--- a/llvm/CMakeLists.txt
++++ b/llvm/CMakeLists.txt
+@@ -20,7 +20,7 @@ if(NOT DEFINED LLVM_VERSION_PATCH)
+   set(LLVM_VERSION_PATCH 0)
+ endif()
+ if(NOT DEFINED LLVM_VERSION_SUFFIX)
+-  set(LLVM_VERSION_SUFFIX git)
++  set(LLVM_VERSION_SUFFIX "")
+ endif()
+ 
+ if (NOT PACKAGE_VERSION)
+-- 
+2.17.1
+

--- a/recipes-devtools/clang/common.inc
+++ b/recipes-devtools/clang/common.inc
@@ -45,6 +45,7 @@ SRC_URI = "\
     file://0033-compiler-rt-Use-uintptr_t-instead-of-_Unwind_Word.patch \
     file://0034-compiler-rt-Do-not-force-thumb-mode-directive.patch \
     file://0035-openmp-Fix-build-on-non-x86-targets.patch \
+    file://0036-Drop-the-git-suffix-from-various-version-variables.patch \
 "
 # Fallback to no-PIE if not set
 GCCPIE ??= ""


### PR DESCRIPTION
other recipe like intel-graphics-compiler, config failed with
below error:
[IGC] Could not find the LLVM dylib.  Aborting.

with a suffix in library name make other recipe cannot found it.
Backport a patch from 12.0.0 to fix this.

Signed-off-by: Changqing Li <changqing.li@windriver.com>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
