### PR TITLE
clang_git.bb: class-nativesdk add dependency to gcc-crosssdk

### DIFF
--- a/recipes-devtools/clang/clang_git.bb
+++ b/recipes-devtools/clang/clang_git.bb
@@ -175,7 +175,7 @@ EXTRA_OECMAKE_append_class-target = "\
 "
 
 DEPENDS = "binutils zlib libffi libxml2 libxml2-native ninja-native swig-native"
-DEPENDS_append_class-nativesdk = " clang-crosssdk-${SDK_ARCH} virtual/${TARGET_PREFIX}binutils-crosssdk nativesdk-python3"
+DEPENDS_append_class-nativesdk = " clang-crosssdk-${SDK_ARCH} virtual/${TARGET_PREFIX}binutils-crosssdk nativesdk-python3 gcc-crosssdk-${SDK_SYS}"
 DEPENDS_append_class-target = " clang-cross-${TARGET_ARCH} python3"
 
 RRECOMMENDS_${PN} = "binutils"


### PR DESCRIPTION
For class-nativesdk OECMAKE_(C|CXX)_COMPILER is set to gcc-crosssdk without depending on it. This results in cmake configure errors not finding the compiler. Adding a dependency to cc-crosssdk-${SDK_SYS} fixes that problem.

Signed-off-by: Bernhard Guillon <Bernhard.Guillon@begu.org>
---
### Contributor checklistgcc-crosssdk 
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
