### PR TITLE
clang: fix do_package error when multilib enabled

### DIFF
--- a/recipes-devtools/clang/clang_git.bb
+++ b/recipes-devtools/clang/clang_git.bb
@@ -252,7 +252,7 @@ FILES_${PN} += "\
   ${libdir}/${BPN} \
   ${nonarch_libdir}/${BPN}/*/include/ \
   ${datadir}/scan-* \
-  ${libdir}/libscanbuild \
+  ${nonarch_libdir}/libscanbuild \
   ${datadir}/opt-viewer/ \
 "
 
@@ -283,7 +283,7 @@ FILES_libclang = "\
 FILES_${PN}-dev += "\
   ${datadir}/llvm/cmake \
   ${libdir}/cmake \
-  ${libdir}/libear \
+  ${nonarch_libdir}/libear \
   ${nonarch_libdir}/${BPN}/*.la \
 "
 


### PR DESCRIPTION
After enable multilib, libdir is /usr/lib64, but in llvm's
CMakelist.txt, the install path is hardcode as /usr/lib
eg:
${CMAKE_BINARY_DIR}/lib/libscanbuild/resources/${resource}

Signed-off-by: Changqing Li <changqing.li@windriver.com>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
