### PR TITLE
clang: Depend on clang runtime when using RUNTIME = "llvm" for native…

### DIFF
--- a/classes/clang.bbclass
+++ b/classes/clang.bbclass
@@ -109,6 +109,7 @@ def clang_base_deps(d):
     return ""
 
 BASE_DEFAULT_DEPS_toolchain-clang_class-target = "${@clang_base_deps(d)}"
+BASE_DEFAULT_DEPS_append_class-native_toolchain-clang_runtime-llvm = " libcxx-native compiler-rt-native"
 
 cmake_do_generate_toolchain_file_append_toolchain-clang () {
     cat >> ${WORKDIR}/toolchain.cmake <<EOF


### PR DESCRIPTION
… packages

Signed-off-by: Khem Raj <raj.khem@gmail.com>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
