### PR TITLE
clang: support android runtime

### DIFF
--- a/classes/clang.bbclass
+++ b/classes/clang.bbclass
@@ -91,15 +91,16 @@ def clang_base_deps(d):
     if not d.getVar('INHIBIT_DEFAULT_DEPS', False):
         if not oe.utils.inherits(d, 'allarch') :
             ret = " clang-cross-${TARGET_ARCH} virtual/libc "
+            if (d.getVar('RUNTIME').find('android') != -1):
+                ret += " libcxx"
+                return ret
             if (d.getVar('RUNTIME').find('llvm') != -1):
                 ret += " compiler-rt libcxx"
             elif (d.getVar('COMPILER_RT').find('-rtlib=compiler-rt') != -1):
                 ret += " compiler-rt "
             else:
                 ret += " libgcc "
-            if (d.getVar('RUNTIME').find('llvm') != -1):
-                ret += " libcxx"
-            elif (d.getVar('COMPILER_RT').find('--unwindlib=libunwind') != -1):
+            if (d.getVar('COMPILER_RT').find('--unwindlib=libunwind') != -1):
                 ret += " libcxx "
             elif (d.getVar('LIBCPLUSPLUS').find('-stdlib=libc++') != -1):
                 ret += " libcxx "

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -25,7 +25,7 @@ PREFERRED_PROVIDER_libgcc-initial = "libgcc-initial"
 PREFERRED_PROVIDER_llvm = "clang"
 PREFERRED_PROVIDER_llvm-native = "clang-native"
 PREFERRED_PROVIDER_nativesdk-llvm = "nativesdk-clang"
-PREFERRED_PROVIDER_libunwind = "${@bb.utils.contains("RUNTIME", "llvm", "libcxx", "libunwind", d)}"
+PREFERRED_PROVIDER_libunwind = "${@bb.utils.contains_any("RUNTIME", "llvm android", "libcxx", "libunwind", d)}"
 INHERIT += "clang"
 
 # Do not include clang in SDK unless user wants to


### PR DESCRIPTION
Or I should set up a new RUNTIME condition? Because in Android, only the C++ environment comes from LLVM but the libc is not .
Signed-off-by: Hsia-Jun(Randy) Li <randy.li@synaptics.com>

---
