### PR TITLE
upgrade of android-tools to 10.0.0.r36

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -17,6 +17,7 @@ BBFILES_DYNAMIC += " \
     openembedded-layer:${LAYERDIR}/dynamic-layers/openembedded-layer/*/*/*.bbappend \
     networking-layer:${LAYERDIR}/dynamic-layers/networking-layer/*/*/*.bb \
     networking-layer:${LAYERDIR}/dynamic-layers/networking-layer/*/*/*.bbappend \
+    selinux:${LAYERDIR}/dynamic-layers/selinux/*/*.bb \
 "
 
 PREFERRED_PROVIDER_libgcc-initial = "libgcc-initial"

--- a/dynamic-layers/selinux/android-tools/android-tools-conf-configfs/10-adbd-configfs.conf
+++ b/dynamic-layers/selinux/android-tools/android-tools-conf-configfs/10-adbd-configfs.conf
@@ -1,0 +1,4 @@
+[Service]
+ExecStartPre=/usr/bin/android-gadget-setup
+ExecStartPost=/usr/bin/android-gadget-start
+ExecStopPost=/usr/bin/android-gadget-cleanup

--- a/dynamic-layers/selinux/android-tools/android-tools-conf-configfs/android-gadget-cleanup
+++ b/dynamic-layers/selinux/android-tools/android-tools-conf-configfs/android-gadget-cleanup
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+[ -d /sys/kernel/config/usb_gadget ] || exit 0
+
+cd /sys/kernel/config/usb_gadget
+
+cd adb
+
+echo "" > UDC || true
+
+killall adbd || true
+
+umount /dev/usb-ffs/adb
+
+rm configs/c.1/ffs.usb0
+
+rmdir configs/c.1/strings/0x409
+rmdir configs/c.1
+
+rmdir functions/ffs.usb0
+rmdir strings/0x409
+
+cd ..
+rmdir adb

--- a/dynamic-layers/selinux/android-tools/android-tools-conf-configfs/android-gadget-setup
+++ b/dynamic-layers/selinux/android-tools/android-tools-conf-configfs/android-gadget-setup
@@ -1,0 +1,35 @@
+#!/bin/sh
+
+set -e
+
+manufacturer=RPB
+model="Android device"
+serial=0123456789ABCDEF
+
+if [ -r /etc/android-gadget-setup.machine ] ; then
+	. /etc/android-gadget-setup.machine
+fi
+
+[ -d /sys/kernel/config/usb_gadget ] || modprobe libcomposite
+
+cd /sys/kernel/config/usb_gadget
+
+[ -d adb ] && /usr/bin/android-gadget-cleanup || true
+
+mkdir adb
+cd adb
+
+mkdir configs/c.1
+mkdir functions/ffs.usb0
+mkdir strings/0x409
+mkdir configs/c.1/strings/0x409
+echo 0x18d1 > idVendor
+echo 0xd002 > idProduct
+echo "$serial" > strings/0x409/serialnumber
+echo "$manufacturer" > strings/0x409/manufacturer
+echo "$model" > strings/0x409/product
+echo "Conf 1" > configs/c.1/strings/0x409/configuration
+ln -s functions/ffs.usb0 configs/c.1
+
+mkdir -p /dev/usb-ffs/adb
+mount -t functionfs usb0 /dev/usb-ffs/adb

--- a/dynamic-layers/selinux/android-tools/android-tools-conf-configfs/android-gadget-start
+++ b/dynamic-layers/selinux/android-tools/android-tools-conf-configfs/android-gadget-start
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+set -e
+
+sleep 3
+
+ls /sys/class/udc/ > /sys/kernel/config/usb_gadget/adb/UDC

--- a/dynamic-layers/selinux/android-tools/android-tools-conf-configfs_1.0.bb
+++ b/dynamic-layers/selinux/android-tools/android-tools-conf-configfs_1.0.bb
@@ -1,0 +1,35 @@
+DESCRIPTION = "Different utilities from Android - corressponding configuration files for using ConfigFS"
+SECTION = "console/utils"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+SRC_URI = " \
+    file://android-gadget-setup \
+    file://android-gadget-start \
+    file://android-gadget-cleanup \
+    file://10-adbd-configfs.conf \
+"
+
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+do_install() {
+    install -d ${D}${bindir}
+    install -m 0755 ${WORKDIR}/android-gadget-setup ${D}${bindir}
+    install -m 0755 ${WORKDIR}/android-gadget-start ${D}${bindir}
+    install -m 0755 ${WORKDIR}/android-gadget-cleanup ${D}${bindir}
+
+    if [ -r ${WORKDIR}/android-gadget-setup.machine ] ; then
+	install -d ${D}${sysconfdir}
+	install -m 0644 ${WORKDIR}/android-gadget-setup.machine ${D}${sysconfdir}
+    fi
+
+    install -d ${D}${systemd_unitdir}/system/android-tools-adbd.service.d
+    install -m 0644 ${WORKDIR}/10-adbd-configfs.conf ${D}${systemd_unitdir}/system/android-tools-adbd.service.d
+}
+
+FILES_${PN} += " \
+    ${systemd_unitdir}/system/ \
+"
+
+PROVIDES += "android-tools-conf"
+RPROVIDES_${PN} = "android-tools-conf"

--- a/dynamic-layers/selinux/android-tools/android-tools-conf/android-gadget-setup
+++ b/dynamic-layers/selinux/android-tools/android-tools-conf/android-gadget-setup
@@ -1,0 +1,37 @@
+#!/bin/sh
+
+[ ! -e /dev/pts ] && mkdir -p /dev/pts
+[ ! -e /dev/pts/0 ] && mount devpts /dev/pts -t devpts
+
+# TODO enable the lines below once we have support for getprop
+# retrieve the product info from Android
+# manufacturer=$(getprop ro.product.manufacturer Android)
+# model=$(getprop ro.product.model Android)
+# serial=$(getprop ro.serialno 0123456789ABCDEF)
+
+#below are now needed in order to use FunctionFS for ADB, tested to work with 3.4+ kernels
+if grep -q functionfs /proc/filesystems; then
+    mkdir -p /dev/usb-ffs/adb
+    mount -t functionfs adb /dev/usb-ffs/adb
+    #android-gadget-setup doesn't provide below 2 and without them it won't work, so we provide them here.
+    echo adb > /sys/class/android_usb/android0/f_ffs/aliases
+    echo ffs > /sys/class/android_usb/android0/functions
+fi
+
+manufacturer="$(cat /system/build.prop | grep -o 'ro.product.manufacturer=.*' | cut -d'=' -f 2)"
+model="$(cat /system/build.prop | grep -o 'ro.product.model=.*' | cut -d'=' -f 2)"
+# get the device serial number from /proc/cmdline directly(since we have no getprop on
+# GNU/Linux)
+serial="$(cat /proc/cmdline | sed 's/.*androidboot.serialno=//' | sed 's/ .*//')"
+
+echo $serial > /sys/class/android_usb/android0/iSerial
+echo $manufacturer > /sys/class/android_usb/android0/iManufacturer
+echo $model > /sys/class/android_usb/android0/iProduct
+
+echo "0" > /sys/class/android_usb/android0/enable
+echo "18d1" > /sys/class/android_usb/android0/idVendor
+echo "D002" > /sys/class/android_usb/android0/idProduct
+echo "adb" > /sys/class/android_usb/android0/functions
+echo "1" >  /sys/class/android_usb/android0/enable
+
+sleep 4

--- a/dynamic-layers/selinux/android-tools/android-tools-conf_1.0.bb
+++ b/dynamic-layers/selinux/android-tools/android-tools-conf_1.0.bb
@@ -1,0 +1,20 @@
+DESCRIPTION = "Different utilities from Android - corressponding configuration files"
+SECTION = "console/utils"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+SRC_URI = "file://android-gadget-setup"
+
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+do_install() {
+    install -d ${D}${bindir}
+    install -m 0755 ${WORKDIR}/android-gadget-setup ${D}${bindir}
+}
+
+python () {
+    pn = d.getVar('PN')
+    profprov = d.getVar("PREFERRED_PROVIDER_" + pn)
+    if profprov and pn != profprov:
+        raise bb.parse.SkipRecipe("PREFERRED_PROVIDER_%s set to %s, not %s" % (pn, profprov, pn))
+}

--- a/dynamic-layers/selinux/android-tools/android-tools/adb_mk_change_out_dir.patch
+++ b/dynamic-layers/selinux/android-tools/android-tools/adb_mk_change_out_dir.patch
@@ -1,0 +1,50 @@
+patching adb.mk to build in yocto environment.
+
+Changes include:
+Introduced an output folder which will keep all the outputs from the
+android-tools.
+
+Adding an include file that is setting the common flags.
+Changed the cppflag to include the headers from other components
+of android-tools
+
+Modified LDflags so that the libraries that are coming from other android-tools
+are searched in the output folder.
+
+Modified the build rule so that it outputs the binary to the OUT_DIR
+
+Signed-off-by: Nisha Parrakat <Nisha.Parrakat@kpit.com>
+
+Upstream-Status: Pending 
+--- git/system/core/debian/adb.mk	2021-04-29 21:11:00.617892503 +0200
++++ git/system/core/debian/adb.mk	2021-04-29 21:17:33.256016600 +0200
+@@ -1,3 +1,4 @@
++include ../../rules_yocto.mk
+ NAME = adb
+ 
+ SOURCES = client/adb_client.cpp \
+@@ -12,10 +13,10 @@
+ 
+ SOURCES := $(foreach source, $(SOURCES), adb/$(source))
+ CXXFLAGS += -std=gnu++2a
+-CPPFLAGS += -Iinclude -Iadb -Ibase/include \
++CPPFLAGS += -Iinclude -Iadb -Ibase/include  -I$(OUT_DIR)/usr/include/ \
+             -DADB_VERSION='"$(DEB_VERSION)"' -DADB_HOST=1 -D_GNU_SOURCE
+-LDFLAGS += -Wl,-rpath=/usr/lib/$(DEB_HOST_MULTIARCH)/android -Wl,-rpath-link=. \
+-           -lpthread -L. -ladb -lbase
++LDFLAGS += -Wl,-rpath=/usr/lib/$(DEB_HOST_MULTIARCH)/android -Wl,-rpath-link=$(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android/ \
++           -lpthread -L$(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android/ -ladb -lbase
+ 
+ # -latomic should be the last library specified
+ # https://github.com/android/ndk/issues/589
+@@ -24,7 +25,8 @@
+ endif
+ 
+ build: $(SOURCES)
+-	$(CXX) $^ -o adb/$(NAME) $(CXXFLAGS) $(CPPFLAGS) $(LDFLAGS)
++	mkdir --parents $(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android/adb
++	$(CXX) $^ -o $(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android/adb/$(NAME) $(CXXFLAGS) $(CPPFLAGS) $(LDFLAGS)
+ 
+ clean:
+-	$(RM) adb/$(NAME)
++	$(RM) $(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android/adb/$(NAME)

--- a/dynamic-layers/selinux/android-tools/android-tools/android-tools-adbd.service
+++ b/dynamic-layers/selinux/android-tools/android-tools/android-tools-adbd.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Android Debug Bridge
+ConditionPathExists=/var/usb-debugging-enabled
+Before=android-system.service
+
+[Service]
+Type=simple
+Restart=on-failure
+ExecStartPre=-/usr/bin/android-gadget-setup adb
+ExecStart=/usr/bin/adbd
+
+[Install]
+WantedBy=basic.target

--- a/dynamic-layers/selinux/android-tools/android-tools/fastboot_compile_remove_gtest.patch
+++ b/dynamic-layers/selinux/android-tools/android-tools/fastboot_compile_remove_gtest.patch
@@ -1,0 +1,51 @@
+socket.h: removing dependency of gtest
+
+Removed the dependency of gtest on the build of fastboot binary.
+Fixes below error
+
+In file included from fastboot/fastboot.cpp:70:
+| In file included from fastboot/tcp.h:36:
+| fastboot/socket.h:43:10: fatal error: 'gtest/gtest_prod.h' file not found
+| #include <gtest/gtest_prod.h>
+|          ^~~~~~~~~~~~~~~~~~~~
+| 1 error generated.
+| In file included from fastboot/socket.cpp:29:
+| fastboot/socket.h:43:10: fatal error: 'gtest/gtest_prod.h' file not found
+| #include <gtest/gtest_prod.h>
+|          ^~~~~~~~~~~~~~~~~~~~
+| 1 error generated.
+| In file included from fastboot/tcp.cpp:29:
+| In file included from fastboot/tcp.h:36:
+| fastboot/socket.h:43:10: fatal error: 'gtest/gtest_prod.h' file not found
+| #include <gtest/gtest_prod.h>
+|          ^~~~~~~~~~~~~~~~~~~~
+| 1 error generated.
+| In file included from fastboot/udp.cpp:31:
+| In file included from fastboot/udp.h:34:
+| fastboot/socket.h:43:10: fatal error: 'gtest/gtest_prod.h' file not found
+| #include <gtest/gtest_prod.h>
+|          ^~~~~~~~~~~~~~~~~~~~
+| 1 error generated.
+
+
+Signed-off-by: Nisha Parrakat <Nisha.Parrakat@kpit.com>
+
+--- a/system/core/fastboot/socket.h       2021-04-14 21:14:00.355973915 +0000
++++ b/system/core/fastboot/socket.h   2021-04-14 21:14:21.879680699 +0000
+@@ -40,7 +40,6 @@
+
+ #include <android-base/macros.h>
+ #include <cutils/sockets.h>
+-#include <gtest/gtest_prod.h>
+
+ // Socket interface to be implemented for each platform.
+ class Socket {
+@@ -119,8 +118,6 @@
+             socket_send_buffers_function_ = &socket_send_buffers;
+
+   private:
+-    FRIEND_TEST(SocketTest, TestTcpSendBuffers);
+-    FRIEND_TEST(SocketTest, TestUdpSendBuffers);
+
+     DISALLOW_COPY_AND_ASSIGN(Socket);
+ };

--- a/dynamic-layers/selinux/android-tools/android-tools/fastboot_dont_use_sparse_file_import_auto_in_load_buf_fd.patch
+++ b/dynamic-layers/selinux/android-tools/android-tools/fastboot_dont_use_sparse_file_import_auto_in_load_buf_fd.patch
@@ -1,0 +1,42 @@
+upstream commit taken as below
+Original Issue link
+https://android-review.googlesource.com/c/platform/system/core/+/1123485
+
+Commit taken below:
+
+fastboot: don't use sparse_file_import_auto() in load_buf_fd()
+
+load_buf_fd() attempts to find the size of the file that it is about
+to load by first calling sparse_file_import_auto() then using
+sparse_file_len() upon success or falling back to the file size on the
+filesystem on failure.
+
+This is problematic however as sparse_file_import_auto() creates a
+sparse_file out of the normal file, but does not resparse it, so an
+assertion fails during the sparse_file_len() call.
+
+This is fixed by using sparse_file_import() instead.  This will fail
+in the case that the file is not sparse and the call to
+sparse_file_len() will be properly skipped.
+
+Bug: 140538105
+Test: flash blueline factory image with assertions enabled in
+      libsparse/sparse.cpp
+
+Change-Id: I0283be33563a3301ce5b09bde41105a20f91086c
+
+https://android.googlesource.com/platform/system/core/+/fbb9535aaea5ae4011f3c3edf4c00b27452f57ec
+Upstream-Status: Backport(commit fbb9535aaea5ae4011f3c3edf4c00b27452f57ec)
+Signed-off-by: Nisha Parrakat <Nisha.Parrakat@kpit.com>
+
+--- git/system/core/fastboot/fastboot.cpp	2021-05-28 09:24:15.583963227 +0000
++++ git/system/core/fastboot/fastboot.cpp	2021-05-28 09:25:09.948974990 +0000
+@@ -869,7 +869,7 @@
+         return false;
+     }
+ 
+-    if (sparse_file* s = sparse_file_import_auto(fd, false, false)) {
++    if (sparse_file* s = sparse_file_import(fd, false, false)) {
+         buf->image_size = sparse_file_len(s, false, false);
+         sparse_file_destroy(s);
+     } else {

--- a/dynamic-layers/selinux/android-tools/android-tools/fastboot_mk_change_out_dir.patch
+++ b/dynamic-layers/selinux/android-tools/android-tools/fastboot_mk_change_out_dir.patch
@@ -1,0 +1,52 @@
+patching fastboot.mk to build in yocto environment.
+
+Changes include:
+Introduced an output folder which will keep all the outputs from the
+android-tools.
+
+Adding an include file that is setting the common flags.
+Changed the cppflag to include the headers from other components
+of android-tools
+
+Modified LDflags so that the libraries that are coming from other android-tools
+are searched in the output folder.
+
+Modified the build rule so that it outputs the binary to the OUT_DIR
+
+Signed-off-by: Nisha Parrakat <Nisha.Parrakat@kpit.com>
+
+Upstream-Status: Pending
+
+--- git/system/core/debian/fastboot.mk	2021-05-17 07:47:56.800224043 +0000
++++ git/system/core/debian/fastboot.mk	2021-05-17 07:49:40.130383096 +0000
+@@ -1,3 +1,4 @@
++include ../../rules_yocto.mk
+ NAME = fastboot
+ fastboot_SOURCES = \
+           bootimg_utils.cpp \
+@@ -38,11 +39,11 @@
+             -Ifs_mgr/liblp/include \
+             -I/usr/include/android/openssl \
+             -Ilibsparse/include \
+-            -Ilibziparchive/include
++            -Ilibziparchive/include -I$(OUT_DIR)/usr/include/ 
+ LDFLAGS += -Wl,-rpath=/usr/lib/$(DEB_HOST_MULTIARCH)/android \
+            -fuse-ld=gold \
+-           -Wl,-rpath-link=. \
+-           -L. -lziparchive -lsparse -lbase -lcutils -ladb -lcrypto -lext4_utils \
++           -Wl,-rpath-link=$(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android \
++           -L$(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android -lziparchive -lsparse -lbase -lcutils -ladb -lcrypto -lext4_utils \
+            -L/usr/lib/$(DEB_HOST_MULTIARCH)/android \
+            -l7z \
+ 
+@@ -53,7 +54,8 @@
+ endif
+ 
+ build: $(SOURCES)
+-	$(CXX) $^ -o fastboot/$(NAME) $(CXXFLAGS) $(CPPFLAGS) $(LDFLAGS)
++	mkdir --parents $(OUT_DIR)/usr/bin/fastboot
++	$(CXX) $^ -o $(OUT_DIR)/usr/bin/fastboot/$(NAME) $(CXXFLAGS) $(CPPFLAGS) $(LDFLAGS)
+ 
+ clean:
+-	$(RM) fastboot/$(NAME)
++	$(RM) $(OUT_DIR)/usr/bin/fastboot/$(NAME)

--- a/dynamic-layers/selinux/android-tools/android-tools/img2simg_change_out_dir.patch
+++ b/dynamic-layers/selinux/android-tools/android-tools/img2simg_change_out_dir.patch
@@ -1,0 +1,41 @@
+patching img2simg.mk to build in yocto environment.
+
+Changes include:
+Introduced an output folder which will keep all the outputs from the
+android-tools.
+
+Adding an include file that is setting the common flags.
+Changed the cppflag to include the headers from other components
+of android-tools
+
+Modified LDflags so that the libraries that are coming from other android-tools
+are searched in the output folder.
+
+Modified the build rule so that it outputs the binary to the OUT_DIR
+
+Signed-off-by: Nisha Parrakat <Nisha.Parrakat@kpit.com>
+
+Upstream-Status: Pending
+
+--- git/system/core/debian/img2simg.mk	2021-05-12 09:05:38.580607289 +0000
++++ git/system/core/debian/img2simg.mk	2021-05-12 09:09:04.331908253 +0000
+@@ -1,13 +1,14 @@
++include ../../rules_yocto.mk
+ NAME = img2simg
+ SOURCES = img2simg.cpp
+ SOURCES := $(foreach source, $(SOURCES), libsparse/$(source))
+ CPPFLAGS += -Ilibsparse/include -Iinclude -std=gnu++17
+-LDFLAGS += -Wl,-rpath=/usr/lib/$(DEB_HOST_MULTIARCH)/android \
+-           -Wl,-rpath-link=. \
+-           -L. -lsparse
++LDFLAGS += -Wl,-rpath=$(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android \
++           -Wl,-rpath-link=$(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android/ \
++           -L$(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android/ -lsparse
+ 
+ build: $(SOURCES)
+-	$(CXX) $^ -o libsparse/$(NAME) $(CPPFLAGS) $(LDFLAGS)
++	$(CXX) $^ -o $(OUT_DIR)/usr/bin/$(NAME) $(CPPFLAGS) $(LDFLAGS)
+ 
+ clean:
+-	$(RM) libsparse/$(NAME)
++	$(RM) $(OUT_DIR)/usr/bin/$(NAME)

--- a/dynamic-layers/selinux/android-tools/android-tools/libadb_mk_change_out_dir.patch
+++ b/dynamic-layers/selinux/android-tools/android-tools/libadb_mk_change_out_dir.patch
@@ -1,0 +1,44 @@
+libadb.mk: modifications to make it build in yocto environment
+
+Adding an include file that is setting the common flags.
+Changed the cppflag to include the headers from other components
+of android-tools
+
+Modified LDflags so that the libraries that are coming from other android-tools
+are searched in the output folder.
+
+Modified the build rule so that it outputs the binary to the OUT_DIR
+
+Signed-off-by: Nisha Parrakat <Nisha.Parrakat@kpit.com>
+
+--- git/system/core/debian/libadb.mk	2021-04-30 16:29:34.596618862 +0200
++++ git/system/core/debian/libadb.mk	2021-04-30 16:36:53.932837490 +0200
+@@ -1,3 +1,4 @@
++include ../../rules_yocto.mk
+ NAME := libadb
+ 
+ LIBADB_SRC_FILES := \
+@@ -43,18 +44,18 @@
+             -Ibase/include \
+             -Idiagnose_usb/include \
+             -Ilibcrypto_utils/include \
+-            -Iinclude \
++            -Iinclude -I$(OUT_DIR)/usr/include \
+             -DPLATFORM_TOOLS_VERSION='"$(PLATFORM_TOOLS_VERSION)"' \
+             -DADB_HOST=1 -DADB_VERSION='"$(DEB_VERSION)"'
+ 
+ LDFLAGS += -shared -Wl,-soname,$(NAME).so.0 \
+            -Wl,-rpath=/usr/lib/$(DEB_HOST_MULTIARCH)/android \
+-           -L/usr/lib/$(DEB_HOST_MULTIARCH)/android -lcrypto \
+-           -lpthread -L. -lbase -lcutils -lcrypto_utils -lusb-1.0
++           -L$(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android -lcrypto \
++           -lpthread -lbase -lcutils -lcrypto_utils -lusb-1.0
+ 
+ $(NAME).so: $(SOURCES)
+-	$(CXX) $^ -o $(NAME).so.0 $(CXXFLAGS) $(CPPFLAGS) $(LDFLAGS)
+-	ln -s $(NAME).so.0 $(NAME).so
++	$(CXX) $^ -o $(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android/$(NAME).so.0 $(CXXFLAGS) $(CPPFLAGS) $(LDFLAGS)
++	ln -s $(NAME).so.0 $(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android/$(NAME).so
+ 
+ transport_mdns_unsupported.cpp:
+ 	echo 'void init_mdns_transport_discovery(void) {}' > transport_mdns_unsupported.cpp

--- a/dynamic-layers/selinux/android-tools/android-tools/libbacktrace_mk_change_out_dir.patch
+++ b/dynamic-layers/selinux/android-tools/android-tools/libbacktrace_mk_change_out_dir.patch
@@ -1,0 +1,60 @@
+patching libbacktrace.mk to build in yocto environment.
+
+Changes include:
+Introduced an output folder which will keep all the outputs from the
+android-tools.
+
+Adding an include file that is setting the common flags.
+Changed the cppflag to include the headers from other components
+of android-tools
+
+Modified LDflags so that the libraries that are coming from other android-tools
+are searched in the output folder.
+
+Modified the build rule so that it outputs the binary to the OUT_DIR
+
+Signed-off-by: Nisha Parrakat <Nisha.Parrakat@kpit.com>
+
+Upstream-Status: Pending
+
+--- git/system/core/debian/libbacktrace.mk	2021-05-21 23:51:55.022408433 +0000
++++ git/system/core/debian/libbacktrace.mk	2021-05-21 23:53:07.487543521 +0000
+@@ -1,5 +1,6 @@
+-
+-include /usr/share/dpkg/architecture.mk
++include ../../rules_yocto.mk
++#pass architecture specific info to makefile
++DEB_HOST_ARCH=${deb_host_arch}
+ 
+ NAME = libbacktrace
+ 
+@@ -88,11 +89,11 @@
+             -Ilibprocinfo/include \
+             -Ilibunwindstack/include \
+             -I/usr/include/android/lzma \
+-            -I/usr/include/android/unwind
++            -I$(OUT_DIR)/usr/include/android/libunwind
+ LDFLAGS += -shared -Wl,-soname,$(NAME).so.0 \
+            -Wl,-rpath=/usr/lib/$(DEB_HOST_MULTIARCH)/android \
+-           -L/usr/lib/$(DEB_HOST_MULTIARCH)/android -lunwind \
+-           -L. -lbase -llog -lpthread -l7z
++           -L$(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android -lunwind \
++           -lbase -llog -lpthread -l7z
+ 
+ # -latomic should be the last library specified
+ # https://github.com/android/ndk/issues/589
+@@ -104,11 +105,11 @@
+ endif
+ 
+ build: $(COBJECTS) $(CXXOBJECTS) $(OBJECTS_ASSEMBLY)
+-	$(CXX) $^ -o $(NAME).so.0 $(LDFLAGS)
+-	ln -s $(NAME).so.0 $(NAME).so
++	$(CXX) $^ -o $(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android/$(NAME).so.0 $(LDFLAGS)
++	ln -s $(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android/$(NAME).so.0 $(NAME).so
+ 
+ clean:
+-	$(RM) $(COBJECTS) $(CXXOBJECTS) $(NAME).so*
++	$(RM) $(COBJECTS) $(CXXOBJECTS) $(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android/$(NAME).so*
+ 
+ $(CXXOBJECTS): %.o: %.cpp
+ 	$(CXX) $< -o $@ $(CXXFLAGS) $(CPPFLAGS)

--- a/dynamic-layers/selinux/android-tools/android-tools/libbase_mk_change_out_dir.patch
+++ b/dynamic-layers/selinux/android-tools/android-tools/libbase_mk_change_out_dir.patch
@@ -1,0 +1,33 @@
+libbase.mk: modifications to make it build in yocto environment
+
+Adding an include file that is setting the common flags.
+Changed the cppflag to include the headers from other components
+of android-tools
+
+Modified LDflags so that the libraries that are coming from other android-tools
+are searched in the output folder.
+
+Modified the build rule so that it outputs the binary to the OUT_DIR
+
+Signed-off-by: Nisha Parrakat <Nisha.Parrakat@kpit.com>
+
+--- git/system/core/debian/libbase.mk	2021-04-29 22:01:13.664181133 +0200
++++ git/system/core/debian/libbase.mk	2021-04-29 22:04:52.328123833 +0200
+@@ -1,3 +1,4 @@
++include ../../rules_yocto.mk
+ NAME = libbase
+ SOURCES = \
+           chrono_utils.cpp \
+@@ -20,8 +21,9 @@
+ LDFLAGS += -shared -Wl,-soname,$(NAME).so.0
+ 
+ build: $(SOURCES)
+-	$(CXX) $^ -o $(NAME).so.0 $(CXXFLAGS) $(CPPFLAGS) $(LDFLAGS)
+-	ln -s $(NAME).so.0 $(NAME).so
++	$(CXX) $^ -o $(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android/$(NAME).so.0 $(CXXFLAGS) $(CPPFLAGS) $(LDFLAGS)
++	ln -s $(NAME).so.0 $(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android/$(NAME).so
++	cp -r base/include/* $(OUT_DIR)/usr/include/
+ 
+ clean:
+-	$(RM) $(NAME).so*
++	$(RM) $(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android/$(NAME).so*

--- a/dynamic-layers/selinux/android-tools/android-tools/libcrypto_mk_change_out_dir.patch
+++ b/dynamic-layers/selinux/android-tools/android-tools/libcrypto_mk_change_out_dir.patch
@@ -1,0 +1,30 @@
+libcrypto.mk: modifications to make it build in yocto environment
+
+Adding an include file that is setting the common flags.
+
+Modified the build rule so that it outputs the binary and include
+to the OUT_DIR
+
+
+Signed-off-by: Nisha Parrakat <Nisha.Parrakat@kpit.com>
+
+--- git/external/boringssl/debian/libcrypto.mk	2021-04-30 11:32:40.610312307 +0000
++++ git/external/boringssl/debian/libcrypto.mk	2021-04-30 11:36:47.738318880 +0000
+@@ -1,3 +1,4 @@
++include ../../rules_yocto.mk
+ include sources.mk
+ 
+ NAME = libcrypto
+@@ -26,6 +27,8 @@
+ LDFLAGS += -shared -Wl,-soname,$(NAME).so.0 -lpthread
+ 
+ build: $(SOURCES)
+-	mkdir --parents debian/out
+-	$(CC) $^ -o debian/out/$(NAME).so.0 $(CFLAGS) $(CPPFLAGS) $(LDFLAGS)
+-	ln -s $(NAME).so.0 debian/out/$(NAME).so
+\ No newline at end of file
++	mkdir --parents $(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android/ 
++	mkdir --parents $(OUT_DIR)/usr/include
++	$(CC) $^ -o $(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android/$(NAME).so.0 $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) -DOPENSSL_NO_ASM
++	ln -s $(NAME).so.0 $(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android/$(NAME).so
++	cp -r include/openssl $(OUT_DIR)/usr/include

--- a/dynamic-layers/selinux/android-tools/android-tools/libcrypto_utils_mk_change_out_dir.patch
+++ b/dynamic-layers/selinux/android-tools/android-tools/libcrypto_utils_mk_change_out_dir.patch
@@ -1,0 +1,38 @@
+libcrypto_utils.mk: modifications to make it build in yocto environment
+
+Adding an include file that is setting the common flags.
+Changed the cppflag to include the headers from other components
+of android-tools
+
+Modified LDflags so that the libraries that are coming from other android-tools
+are searched in the output folder.
+
+Modified the build rule so that it outputs the binary and header to the OUT_DIR
+
+Signed-off-by: Nisha Parrakat <Nisha.Parrakat@kpit.com>
+
+--- git/system/core/debian/libcrypto_utils.mk	2021-04-30 14:18:54.071379767 +0200
++++ git/system/core/debian/libcrypto_utils.mk	2021-04-30 14:22:46.179047308 +0200
+@@ -1,15 +1,17 @@
++include ../../rules_yocto.mk
+ NAME:= libcrypto_utils
+ SOURCES := android_pubkey.c
+ SOURCES := $(foreach source, $(SOURCES), libcrypto_utils/$(source))
+-CPPFLAGS += -Ilibcrypto_utils/include -Iinclude
++CPPFLAGS += -Ilibcrypto_utils/include -Iinclude -I$(OUT_DIR)/usr/include
+ LDFLAGS += -shared -Wl,-soname,$(NAME).so.0 \
+ 	-Wl,-rpath=/usr/lib/$(DEB_HOST_MULTIARCH)/android \
+-	-L/usr/lib/$(DEB_HOST_MULTIARCH)/android \
++	-L$(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android \
+ 	-lcrypto -Wl,-z,defs
+ 
+ build: $(SOURCES)
+-	$(CC) $^ -o $(NAME).so.0  $(CPPFLAGS) $(LDFLAGS)
+-	ln -s $(NAME).so.0 $(NAME).so
++	$(CC) $^ -o $(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android/$(NAME).so.0  $(CPPFLAGS) $(LDFLAGS)
++	ln -s $(NAME).so.0 $(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android/$(NAME).so
++	cp -r libcrypto_utils/include/* $(OUT_DIR)/usr/include/
+ 
+ clean:
+-	$(RM) $(NAME).so*
++	$(RM) $(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android/$(NAME).so*

--- a/dynamic-layers/selinux/android-tools/android-tools/libcutils_mk_change_out_dir.patch
+++ b/dynamic-layers/selinux/android-tools/android-tools/libcutils_mk_change_out_dir.patch
@@ -1,0 +1,27 @@
+--- git/system/core/debian/libcutils.mk	2021-05-17 06:38:40.105161629 +0000
++++ git/system/core/debian/libcutils.mk	2021-05-17 06:42:37.141912366 +0000
+@@ -1,3 +1,4 @@
++include ../../rules_yocto.mk
+ NAME = libcutils
+ 
+ # copied from libcutils/Android.bp
+@@ -50,14 +51,15 @@
+             -Iinclude \
+ 
+ LDFLAGS += -shared -Wl,-soname,$(NAME).so.0 \
+-           -Wl,-rpath=/usr/lib/$(DEB_HOST_MULTIARCH)/android -lpthread -L. -llog -lbase
++           -Wl,-rpath=/usr/lib/$(DEB_HOST_MULTIARCH)/android -lpthread -L$(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android/ -llog -lbase 
+ 
+ build: $(COBJECTS) $(CXXOBJECTS)
+-	$(CXX) $^ -o $(NAME).so.0 $(LDFLAGS)
+-	ln -s $(NAME).so.0 $(NAME).so
++	$(CXX) $^ -o $(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android/$(NAME).so.0 $(LDFLAGS)	
++	ln -s $(NAME).so.0 $(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android/$(NAME).so
++	cp -r libcutils/include/cutils $(OUT_DIR)/usr/include/	
+ 
+ clean:
+-	$(RM) $(CXXOBJECTS) $(COBJECTS) $(NAME).so*
++	$(RM) $(CXXOBJECTS) $(COBJECTS) $(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android/$(NAME).so*
+ 
+ $(COBJECTS): %.o: %.c
+ 	$(CC) $< -o $@ $(CFLAGS) $(CPPFLAGS)

--- a/dynamic-layers/selinux/android-tools/android-tools/libext4_utils_mk_change_out_dir.patch
+++ b/dynamic-layers/selinux/android-tools/android-tools/libext4_utils_mk_change_out_dir.patch
@@ -1,0 +1,42 @@
+libext4_utils.mk: modifications to make it build in yocto environment
+
+Adding an include file that is setting the common flags.
+Changed the cppflag to include the headers from other components
+of android-tools
+
+Modified LDflags so that the libraries that are coming from other android-tools
+are searched in the output folder.
+
+Modified the build rule so that it outputs the binary and header to the OUT_DIR
+
+Signed-off-by: Nisha Parrakat <Nisha.Parrakat@kpit.com>
+
+--- git/system/extras/debian/libext4_utils.mk	2021-04-29 21:46:39.384394114 +0000
++++ git/system/extras/debian/libext4_utils.mk	2021-04-29 21:49:53.808605543 +0000
+@@ -1,3 +1,4 @@
++include ../../rules_yocto.mk
+ NAME = libext4_utils
+ 
+ ext4_utils_SOURCES := \
+@@ -17,14 +18,16 @@
+             -Iext4_utils/include \
+             -Ilibfec/include \
+             -Isquashfs_utils \
+-            -I/usr/include/android \
++            -I/usr/include/android -I$(OUT_DIR)/usr/include \
+             -D_GNU_SOURCE -DFEC_NO_KLOG -DSQUASHFS_NO_KLOG -D_LARGEFILE64_SOURCE
+ LDFLAGS += -shared -Wl,-soname,$(NAME).so.0 \
+            -Wl,-rpath=/usr/lib/$(DEB_HOST_MULTIARCH)/android \
+-           -L/usr/lib/$(DEB_HOST_MULTIARCH)/android \
++           -L$(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android/ \
+            -lbase -lsparse -lselinux
+ 
+ build: $(SOURCES)
+-	mkdir --parents $(OUT_DIR)
+-	$(CC) $^ -o $(OUT_DIR)/$(NAME).so.0 $(CFLAGS) $(CPPFLAGS) $(LDFLAGS)
+-	ln -s $(NAME).so.0 $(OUT_DIR)/$(NAME).so
++	mkdir --parents $(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android/	
++	$(CC) $^ -o $(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android/$(NAME).so.0 $(CFLAGS) $(CPPFLAGS) $(LDFLAGS)
++	ln -s $(NAME).so.0 $(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android/$(NAME).so
++	cp -r ext4_utils/include/* $(OUT_DIR)/usr/include/
++

--- a/dynamic-layers/selinux/android-tools/android-tools/libfec_mk_change_out_dir.patch
+++ b/dynamic-layers/selinux/android-tools/android-tools/libfec_mk_change_out_dir.patch
@@ -1,0 +1,35 @@
+--- git/system/extras/debian/libfec.mk	2021-05-17 06:55:51.973044031 +0000
++++ git/system/extras/debian/libfec.mk	2021-05-17 06:56:41.940185413 +0000
+@@ -1,3 +1,4 @@
++include ../../rules_yocto.mk
+ NAME = libfec
+ 
+ # copied from libfec/Android.bp
+@@ -12,20 +13,21 @@
+ CXXFLAGS += -fno-strict-aliasing -std=g++17
+ CPPFLAGS += \
+             -Iext4_utils/include \
+-            -Ilibfec/include \
++            -Ilibfec/include -I $(OUT_DIR)/usr/include \
+             -D_GNU_SOURCE -DFEC_NO_KLOG -D_LARGEFILE64_SOURCE
+ LDFLAGS += -shared -Wl,-soname,$(NAME).so.0 \
+            -Wl,-rpath=/usr/lib/$(DEB_HOST_MULTIARCH)/android \
+-           -L/usr/lib/$(DEB_HOST_MULTIARCH)/android \
++           -L$(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android \
+            -lbase -lsparse -lselinux
+ 
+ build: $(COBJECTS) $(CXXOBJECTS)
+-	mkdir -p $(OUT_DIR)
+-	$(CXX) $^ -o $(OUT_DIR)/$(NAME).so.0 $(LDFLAGS)
+-	ln -s $(NAME).so.0 $(OUT_DIR)/$(NAME).so
++	mkdir -p $(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android
++	$(CXX) $^ -o $(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android/$(NAME).so.0 $(LDFLAGS)
++	ln -s $(NAME).so.0 $(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android/$(NAME).so
++	cp -r libfec/include/* $(OUT_DIR)/usr/include/
+ 
+ clean:
+-	$(RM) $(CXXOBJECTS) $(COBJECTS) $(NAME).so*
++	$(RM) $(CXXOBJECTS) $(COBJECTS) $(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android/$(NAME).so*
+ 
+ $(COBJECTS): %.o: %.c
+ 	$(CC) $< -o $@ $(CFLAGS) $(CPPFLAGS)

--- a/dynamic-layers/selinux/android-tools/android-tools/liblog_mk_change_out_dir.patch
+++ b/dynamic-layers/selinux/android-tools/android-tools/liblog_mk_change_out_dir.patch
@@ -1,0 +1,42 @@
+patching liblog.mk to build in yocto environment.
+
+Changes include:
+Introduced an output folder which will keep all the outputs from the
+android-tools.
+
+Adding an include file that is setting the common flags.
+Changed the cppflag to include the headers from other components
+of android-tools
+
+Modified LDflags so that the libraries that are coming from other android-tools
+are searched in the output folder.
+
+Modified the build rule so that it outputs the binary to the OUT_DIR
+
+Signed-off-by: Nisha Parrakat <Nisha.Parrakat@kpit.com>
+
+Upstream-Status: Pending
+
+--- git/system/core/debian/liblog.mk	2021-05-17 08:13:28.304700936 +0000
++++ git/system/core/debian/liblog.mk	2021-05-17 08:15:59.590064282 +0000
+@@ -1,3 +1,4 @@
++include ../../rules_yocto.mk
+ NAME = liblog
+ 
+ # copied from liblog/Android.bp
+@@ -39,11 +40,12 @@
+ LDFLAGS += -shared -Wl,-soname,$(NAME).so.0 -lpthread
+ 
+ build: $(COBJECTS) $(CXXOBJECTS)
+-	$(CXX) $^ -o $(NAME).so.0 $(LDFLAGS)
+-	ln -s $(NAME).so.0 $(NAME).so
++	$(CXX) $^ -o $(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android/$(NAME).so.0 $(LDFLAGS)	
++	ln -s $(NAME).so.0 $(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android/$(NAME).so
++	cp -r liblog/include/* $(OUT_DIR)/usr/include/	
+ 
+ clean:
+-	$(RM) $(COBJECTS) $(CXXOBJECTS) $(NAME).so*
++	$(RM) $(COBJECTS) $(CXXOBJECTS) $(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android/$(NAME).so*
+ 
+ $(COBJECTS): %.o: %.c
+ 	$(CC) $< -o $@ $(CFLAGS) $(CPPFLAGS)

--- a/dynamic-layers/selinux/android-tools/android-tools/libsparse_mk_change_out_dir.patch
+++ b/dynamic-layers/selinux/android-tools/android-tools/libsparse_mk_change_out_dir.patch
@@ -1,0 +1,47 @@
+patching libsparse.mk to build in yocto environment.
+
+Changes include:
+Introduced an output folder which will keep all the outputs from the
+android-tools.
+
+Adding an include file that is setting the common flags.
+Changed the cppflag to include the headers from other components
+of android-tools
+
+Modified LDflags so that the libraries that are coming from other android-tools
+are searched in the output folder.
+
+Modified the build rule so that it outputs the binary to the OUT_DIR
+
+Signed-off-by: Nisha Parrakat <Nisha.Parrakat@kpit.com>
+
+Upstream-Status: Pending
+
+--- git/system/core/debian/libsparse.mk	2021-05-17 08:13:34.764584388 +0000
++++ git/system/core/debian/libsparse.mk	2021-05-17 08:15:34.850492654 +0000
+@@ -1,3 +1,4 @@
++include ../../rules_yocto.mk
+ NAME = libsparse
+ SOURCES = \
+         backed_block.cpp \
+@@ -18,16 +19,16 @@
+   -shared -Wl,-soname,$(NAME).so.0 \
+   -lz \
+   -Wl,-rpath=/usr/lib/$(DEB_HOST_MULTIARCH)/android \
+-  -L. \
++  -L$(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android/ \
+   -lbase
+ 
+ 
+ build: $(COBJECTS) $(CXXOBJECTS)
+-	$(CXX) $^ -o $(NAME).so.0 $(LDFLAGS)
+-	ln -s $(NAME).so.0 $(NAME).so
++	$(CXX) $^ -o $(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android/$(NAME).so.0 $(LDFLAGS)
++	ln -s $(NAME).so.0 $(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android/$(NAME).so	
+ 
+ clean:
+-	$(RM) $(CXXOBJECTS) $(COBJECTS) $(NAME).so*
++	$(RM) $(CXXOBJECTS) $(COBJECTS) $(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android/$(NAME).so*
+ 
+ $(COBJECTS): %.o: %.c
+ 	$(CC) $< -o $@ $(CFLAGS) $(CPPFLAGS)

--- a/dynamic-layers/selinux/android-tools/android-tools/libunwind_mk_change_out_dir.patch
+++ b/dynamic-layers/selinux/android-tools/android-tools/libunwind_mk_change_out_dir.patch
@@ -1,0 +1,47 @@
+patching libundwind to build in yocto environment.
+
+Changes include:
+Introduced an output folder which will keep all the outputs from the
+android-tools.
+
+Adding an include file that is setting the common flags.
+Changed the cppflag to include the headers from other components
+of android-tools
+
+Modified LDflags so that the libraries that are coming from other android-tools
+are searched in the output folder.
+
+Modified the build rule so that it outputs the binary to the OUT_DIR
+
+Passing the architecture details($CPU)from the recipe.
+
+Signed-off-by: Nisha Parrakat <Nisha.Parrakat@kpit.com>
+
+Upstream-Status: Pending
+
+--- git/external/libunwind/debian/libunwind.mk	2021-05-22 02:29:52.950324653 +0000
++++ git/external/libunwind/debian/libunwind.mk	2021-05-22 02:30:48.535322846 +0000
+@@ -1,4 +1,4 @@
+-include debian/detect_arch.mk
++include ../../rules_yocto.mk 
+ 
+ ARCH_SOURCES = is_fpreg.c \
+                regname.c \
+@@ -131,10 +131,12 @@
+ CPPFLAGS += -Iinclude -Isrc $($(CPU)_INCLUDES) -Idebian/include
+ LDFLAGS += -shared -Wl,-soname,$(NAME).so.0 \
+            -Wl,-rpath=/usr/lib/$(DEB_HOST_MULTIARCH)/android \
+-           -lpthread -nostdlib -lc -lgcc -Ldebian/out -l7z
++           -lpthread -nostdlib -lc -lgcc -l7z
+ 
+ build: $(SOURCES)
+-	mkdir --parents debian/out
+-	ln -s /usr/lib/p7zip/7z.so debian/out/lib7z.so
+-	$(CC) $^ -o debian/out/$(NAME).so.0 $(CFLAGS) $(CPPFLAGS) $(LDFLAGS)
+-	ln -s $(NAME).so.0 debian/out/$(NAME).so
++	mkdir --parents $(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android/ 
++	mkdir --parents $(OUT_DIR)/usr/include/android/libunwind
++	$(CC) $^ -o $(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android/$(NAME).so.0 $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) -Wno-header-guard -Wno-absolute-value
++	ln -s $(NAME).so.0 $(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android/$(NAME).so
++	cp -r include/* debian/include/* $(OUT_DIR)/usr/include/android/libunwind/
++

--- a/dynamic-layers/selinux/android-tools/android-tools/libziparchive_mk_change_out_dir.patch
+++ b/dynamic-layers/selinux/android-tools/android-tools/libziparchive_mk_change_out_dir.patch
@@ -1,0 +1,47 @@
+patching libziparchive.mk to build in yocto environment.
+
+Changes include:
+Introduced an output folder which will keep all the outputs from the
+android-tools.
+
+Adding an include file that is setting the common flags.
+Changed the cppflag to include the headers from other components
+of android-tools
+
+Modified LDflags so that the libraries that are coming from other android-tools
+are searched in the output folder.
+
+Modified the build rule so that it outputs the binary to the OUT_DIR
+
+Signed-off-by: Nisha Parrakat <Nisha.Parrakat@kpit.com>
+
+Upstream-Status: Pending
+
+--- git/system/core/debian/libziparchive.mk	2021-05-17 08:13:41.684459540 +0000
++++ git/system/core/debian/libziparchive.mk	2021-05-17 08:16:19.293722572 +0000
+@@ -1,3 +1,4 @@
++include ../../rules_yocto.mk
+ NAME = libziparchive
+ SOURCES = zip_archive.cc \
+           zip_archive_stream_entry.cc\
+@@ -5,14 +6,15 @@
+ SOURCES := $(foreach source, $(SOURCES), libziparchive/$(source))
+ CXXFLAGS += -std=gnu++17
+ CPPFLAGS += -DZLIB_CONST -D_FILE_OFFSET_BITS=64 \
+-            -Iinclude -Ibase/include -Ilibziparchive/include
++            -Iinclude -Ibase/include -Ilibziparchive/include -I$(OUT_DIR)/usr/include/
+ LDFLAGS += -shared -Wl,-soname,$(NAME).so.0 \
+            -Wl,-rpath=/usr/lib/$(DEB_HOST_MULTIARCH)/android \
+-           -lz -L. -llog -lbase
++           -lz -L$(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android -llog -lbase 
+ 
+ build: $(SOURCES)
+-	$(CXX) $^ -o $(NAME).so.0 $(CXXFLAGS) $(CPPFLAGS) $(LDFLAGS)
+-	ln -s $(NAME).so.0 $(NAME).so
++	$(CXX) $^ -o $(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android/$(NAME).so.0 $(CXXFLAGS) $(CPPFLAGS) $(LDFLAGS)	
++	ln -s $(NAME).so.0 $(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android/$(NAME).so
++	cp -r libziparchive/include/* $(OUT_DIR)/usr/include/
+ 
+ clean:
+-	$(RM) $(NAME).so*
++	$(RM) $(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android/$(NAME).so*

--- a/dynamic-layers/selinux/android-tools/android-tools/rules_yocto.mk
+++ b/dynamic-layers/selinux/android-tools/android-tools/rules_yocto.mk
@@ -1,0 +1,4 @@
+CPPFLAGS += -fPIC
+ifndef OUT_DIR
+OUT_DIR = ../../debian/out
+endif

--- a/dynamic-layers/selinux/android-tools/android-tools/simg2img_change_out_dir.patch
+++ b/dynamic-layers/selinux/android-tools/android-tools/simg2img_change_out_dir.patch
@@ -1,0 +1,41 @@
+patching simg2img.mk to build in yocto environment.
+
+Changes include:
+Introduced an output folder which will keep all the outputs from the
+android-tools.
+
+Adding an include file that is setting the common flags.
+Changed the cppflag to include the headers from other components
+of android-tools
+
+Modified LDflags so that the libraries that are coming from other android-tools
+are searched in the output folder.
+
+Modified the build rule so that it outputs the binary to the OUT_DIR
+
+Signed-off-by: Nisha Parrakat <Nisha.Parrakat@kpit.com>
+
+Upstream-Status: Pending
+
+--- git/system/core/debian/simg2img.mk	2021-05-12 09:47:52.577840520 +0000
++++ git/system/core/debian/simg2img.mk	2021-05-12 09:51:43.525678276 +0000
+@@ -1,13 +1,14 @@
++include ../../rules_yocto.mk
+ NAME = simg2img
+ SOURCES = simg2img.cpp sparse_crc32.cpp
+ SOURCES := $(foreach source, $(SOURCES), libsparse/$(source))
+ CPPFLAGS += -Ilibsparse/include -Iinclude -std=gnu++17
+-LDFLAGS += -Wl,-rpath=/usr/lib/$(DEB_HOST_MULTIARCH)/android \
+-           -Wl,-rpath-link=. \
+-           -L. -lsparse
++LDFLAGS += -Wl,-rpath=$(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android \
++           -Wl,-rpath-link=$(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android \
++           -L$(OUT_DIR)/usr/lib/$(DEB_HOST_MULTIARCH)/android -lsparse
+ 
+ build: $(SOURCES)
+-	$(CXX) $^ -o libsparse/$(NAME) $(CPPFLAGS) $(LDFLAGS)
++	$(CXX) $^ -o $(OUT_DIR)/usr/bin/$(NAME) $(CPPFLAGS) $(LDFLAGS)
+ 
+ clean:
+-	$(RM) libsparse/$(NAME)
++	$(RM) $(OUT_DIR)/usr/bin/$(NAME)

--- a/dynamic-layers/selinux/android-tools/android-tools/use_name_space_std_to_compile_libbacktrace.patch
+++ b/dynamic-layers/selinux/android-tools/android-tools/use_name_space_std_to_compile_libbacktrace.patch
@@ -1,0 +1,19 @@
+To Fix the below error
+
+ In file included from libunwindstack/DwarfSection.cpp:21:
+| libunwindstack/include/unwindstack/DwarfMemory.h:32:29: error: unknown type name 'size_t'; did you mean 'std::size_t'?
+|   bool ReadBytes(void* dst, size_t num_bytes);
+|                             ^~~~~~
+|                             std::size_t
+
+--- ./system/core/libunwindstack/include/unwindstack/DwarfMemory.h	2021-05-22 00:52:15.132452862 +0000
++++ ./system/core/libunwindstack/include/unwindstack/DwarfMemory.h	2021-05-22 00:53:09.793416724 +0000
+@@ -23,7 +23,7 @@
+ 
+ // Forward declarations.
+ class Memory;
+-
++using namespace std;
+ class DwarfMemory {
+  public:
+   DwarfMemory(Memory* memory) : memory_(memory) {}

--- a/dynamic-layers/selinux/android-tools/android-tools_10.0.0.r36.bb
+++ b/dynamic-layers/selinux/android-tools/android-tools_10.0.0.r36.bb
@@ -1,0 +1,205 @@
+DESCRIPTION = "Different utilities from Android"
+SECTION = "console/utils"
+LICENSE = "Apache-2.0 & GPL-2.0 & BSD-2-Clause & BSD-3-Clause"
+LIC_FILES_CHKSUM = " \
+    file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10 \
+    file://${COMMON_LICENSE_DIR}/GPL-2.0-only;md5=801f80980d171dd6425610833a22dbe6 \
+    file://${COMMON_LICENSE_DIR}/BSD-2-Clause;md5=cb641bc04cda31daea161b1bc15da69f \
+    file://${COMMON_LICENSE_DIR}/BSD-3-Clause;md5=550794465ba0ec5312d6919e203a55f9 \
+"
+DEPENDS = "libbsd libpcre zlib libcap libusb squashfs-tools p7zip libselinux"
+
+ANDROID_MIRROR = "android.googlesource.com"
+
+# matches with 10.0.0+r36
+SRCREV_boringssl = "ae2dd49c7cb74d04bdba7c1c9bd62c1e9cdf98f6"
+SRCREV_core = "5aa13b053182b758d7a19db0c83e1b9b5bf1ec2e"
+SRCREV_extras = "d31740f9d0399f8b938e88e58843d966e1cccab6"
+SRCREV_libhardware = "c6925520342a7d37758f85eb1cf3baa20a7b7a18"
+SRCREV_build = "28768b3120f751583a2743101b892f210d4715cf"
+SRCREV_libunwind = "03a963ecf6ea836b38b3537cbcda0ecfd7a77393"
+
+SRC_URI = " \
+    git://salsa.debian.org/android-tools-team/android-platform-external-boringssl;name=boringssl;protocol=https;nobranch=1;destsuffix=git/external/boringssl \
+    git://salsa.debian.org/android-tools-team/android-platform-system-core;name=core;protocol=https;nobranch=1;destsuffix=git/system/core \
+    git://salsa.debian.org/android-tools-team/android-platform-system-extras;name=extras;protocol=https;nobranch=1;destsuffix=git/system/extras \
+    git://${ANDROID_MIRROR}/platform/hardware/libhardware;name=libhardware;protocol=https;nobranch=1;destsuffix=git/hardware/libhardware \
+    git://salsa.debian.org/android-tools-team/android-platform-build.git;name=build;protocol=https;nobranch=1;destsuffix=git/build \
+    git://salsa.debian.org/android-tools-team/android-platform-external-libunwind.git;protocol=https;name=libunwind;nobranch=1;destsuffix=git/external/libunwind \
+    file://adb_mk_change_out_dir.patch \
+    file://libadb_mk_change_out_dir.patch \
+    file://fastboot_compile_remove_gtest.patch \
+    file://fastboot_mk_change_out_dir.patch \
+    file://fastboot_dont_use_sparse_file_import_auto_in_load_buf_fd.patch \
+    file://libbase_mk_change_out_dir.patch \
+    file://libext4_utils_mk_change_out_dir.patch \
+    file://libcrypto_mk_change_out_dir.patch \
+    file://libcrypto_utils_mk_change_out_dir.patch \
+    file://libcutils_mk_change_out_dir.patch \
+    file://libfec_mk_change_out_dir.patch \
+    file://img2simg_change_out_dir.patch \
+    file://simg2img_change_out_dir.patch \
+    file://liblog_mk_change_out_dir.patch \
+    file://libsparse_mk_change_out_dir.patch \
+    file://libziparchive_mk_change_out_dir.patch \
+    file://libbacktrace_mk_change_out_dir.patch \
+    file://libunwind_mk_change_out_dir.patch \
+    file://use_name_space_std_to_compile_libbacktrace.patch \
+    file://rules_yocto.mk;subdir=git \
+    file://android-tools-adbd.service \
+"
+
+S = "${WORKDIR}/git"
+B = "${WORKDIR}/${BPN}"
+
+#apply all the patches maintained in the debian version.
+do_unpack_and_patch_debian() {
+    cd ${S}/system/core
+    for i in `find ${S}/system/core/debian/patches -name "*.patch"`; do
+        patch -p1 < $i
+    done
+    #a patch with no .patch extention, lets apply that
+    patch -p1 < ${S}/system/core/debian/patches/Added-missing-headers
+    cd ${S}/external/libunwind
+    for i in `find ${S}/external/libunwind/debian/patches -name "*.patch"`; do
+        patch -p1 < $i
+    done
+}
+addtask unpack_and_patch_debian after do_unpack before do_patch
+
+# http://errors.yoctoproject.org/Errors/Details/1debian881/
+ARM_INSTRUCTION_SET_armv4 = "arm"
+ARM_INSTRUCTION_SET_armv5 = "arm"
+
+COMPATIBLE_HOST_powerpc = "(null)"
+COMPATIBLE_HOST_powerpc64 = "(null)"
+COMPATIBLE_HOST_powerpc64le = "(null)"
+
+inherit systemd clang
+
+TOOLCHAIN = "clang"
+DEPENDS += "\
+    clang-cross-${TARGET_ARCH} \
+"
+
+SYSTEMD_SERVICE_${PN} = "android-tools-adbd.service"
+
+# Find libbsd headers during native builds
+CC:append_class-native = " -I${STAGING_INCDIR}"
+CC:append_class-nativesdk = " -I${STAGING_INCDIR}"
+
+PREREQUISITE_core = "libbase libsparse liblog libcutils"
+TOOLS_TO_BUILD = "libcrypto_utils libadb libziparchive fastboot adb img2simg simg2img libbacktrace"
+
+# Adb needs sys/capability.h, which is not available for native*
+TOOLS_class-native = "boringssl fastboot ext4_utils mkbootimg"
+TOOLS_class-nativesdk = "boringssl fastboot ext4_utils mkbootimg"
+
+do_compile() {
+
+    case "${HOST_ARCH}" in
+      arm)
+        export android_arch=linux-arm
+        cpu=arm
+        deb_host_arch=arm
+      ;;
+      aarch64)
+        export android_arch=linux-arm64
+        cpu=arm64
+        deb_host_arch=arm64
+      ;;
+      riscv64)
+        export android_arch=linux-riscv64
+      ;;
+      mips|mipsel)
+        export android_arch=linux-mips
+        cpu=mips
+        deb_host_arch=mips
+      ;;
+      mips64|mips64el)
+        export android_arch=linux-mips64
+        cpu=mips64
+        deb_host_arch=mips64
+      ;;
+      powerpc|powerpc64)
+        export android_arch=linux-ppc
+      ;;
+      i586|i686|x86_64)
+        export android_arch=linux-x86
+        cpu=x86_64
+        deb_host_arch=amd64
+      ;;
+    esac
+
+    export SRCDIR=${S}
+
+    oe_runmake -f ${S}/external/boringssl/debian/libcrypto.mk -C ${S}/external/boringssl
+    oe_runmake -f ${S}/external/libunwind/debian/libunwind.mk -C ${S}/external/libunwind CPU=${cpu}
+
+    for tool in ${PREREQUISITE_core}; do
+      oe_runmake -f ${S}/system/core/debian/${tool}.mk -C ${S}/system/core
+    done
+
+    for i in `find ${S}/system/extras/debian/ -name "*.mk"`; do
+        oe_runmake -f $i -C ${S}/system/extras
+    done
+
+    for tool in ${TOOLS_TO_BUILD}; do
+        if tool == "libbacktrace"; then
+            oe_runmake -f ${S}/system/core/debian/${tool}.mk -C ${S}/system/core DEB_HOST_ARCH=${deb_host_arch}
+        else
+            oe_runmake -f ${S}/system/core/debian/${tool}.mk -C ${S}/system/core
+        fi
+    done
+
+}
+
+do_install() {
+    if echo ${TOOLS_TO_BUILD} | grep -q "ext4_utils" ; then
+        install -D -p -m0755 ${S}/system/core/libsparse/simg_dump.py ${D}${bindir}/simg_dump
+    fi
+
+    if echo ${TOOLS_TO_BUILD} | grep -q "adb " ; then
+        install -d ${D}${bindir}
+        install -m0755 ${S}/debian/out/usr/lib/android/adb/adb ${D}${bindir}
+    fi
+
+    if echo ${TOOLS_TO_BUILD} | grep -q "adbd" ; then
+        install -d ${D}${bindir}
+        install -m0755 ${B}/adbd/adbd ${D}${bindir}
+    fi
+
+    # Outside the if statement to avoid errors during do_package
+    install -D -p -m0644 ${WORKDIR}/android-tools-adbd.service \
+      ${D}${systemd_unitdir}/system/android-tools-adbd.service
+
+    if echo ${TOOLS_TO_BUILD} | grep -q "fastboot" ; then
+        install -d ${D}${bindir}
+        install -m0755 ${S}/debian/out/usr/bin/fastboot/fastboot ${D}${bindir}
+    fi
+
+    install -d  ${D}${libdir}/android/
+    install -m0755 ${S}/debian/out/usr/lib/android/*.so.* ${D}${libdir}/android/
+    if echo ${TOOLS_TO_BUILD} | grep -q "mkbootimg" ; then
+        install -d ${D}${bindir}
+        install -m0755 ${B}/mkbootimg/mkbootimg ${D}${bindir}
+    fi
+}
+
+PACKAGES += "${PN}-fstools"
+
+RDEPENDS_${BPN} = "${BPN}-conf p7zip"
+
+FILES_${PN}-fstools = "\
+    ${bindir}/ext2simg \
+    ${bindir}/ext4fixup \
+    ${bindir}/img2simg \
+    ${bindir}/make_ext4fs \
+    ${bindir}/simg2img \
+    ${bindir}/simg2simg \
+    ${bindir}/simg_dump \
+    ${bindir}/mkuserimg \
+"
+FILES:${PN} += "${libdir}/android ${libdir}/android/*"
+
+BBCLASSEXTEND = "native"


### PR DESCRIPTION
An older version is present in the meta-oe layer.
Took the old recipe and adapted it in the following way:

--Deleted all the old patches that were applicable for
old version.

--Used all the makefiles that come with the new version
directly from the source code, just modifying them
to install output to a specific folder as below

a)added rules_yocto.mk that will mimic the debian/rules
b)modified the makefiles of the components to output to
a common dir.
c)
Built boringssl crypto with the option -DOPENSSL_NO_ASM
to solve the below errors

 libcrypto.so.0: undefined reference to `aes_hw_encrypt'
 libcrypto.so.0: undefined reference to `aes_hw_set_encrypt_key'
 libcrypto.so.0: undefined reference to `gcm_gmult_v8'
 libcrypto.so.0: undefined reference to `gcm_init_v8'
 libcrypto.so.0: undefined reference to `sha256_block_data_order'
 libcrypto.so.0: undefined reference to `aes_hw_ctr32_encrypt_blocks'
 libcrypto.so.0: undefined reference to `aes_hw_cbc_encrypt'
 libcrypto.so.0: undefined reference to `vpaes_decrypt'
 libcrypto.so.0: undefined reference to `vpaes_encrypt'
 libcrypto.so.0: undefined reference to `gcm_gmult_neon'
 libcrypto.so.0: undefined reference to `sha1_block_data_order'
 libcrypto.so.0: undefined reference to `sha512_block_data_order'
 libcrypto.so.0: undefined reference to `gcm_init_neon'
 libcrypto.so.0: undefined reference to `aes_hw_set_decrypt_key'
 libcrypto.so.0: undefined reference to `vpaes_set_decrypt_key'
 libcrypto.so.0: undefined reference to `gcm_ghash_neon'
 libcrypto.so.0: undefined reference to `bn_mul_mont'
 libcrypto.so.0: undefined reference to `aes_hw_decrypt'
 libcrypto.so.0: undefined reference to `gcm_ghash_v8'
 libcrypto.so.0: undefined reference to `vpaes_cbc_encrypt'
 libcrypto.so.0: undefined reference to `ChaCha20_ctr32'
 libcrypto.so.0: undefined reference to `vpaes_ctr32_encrypt_blocks'
 libcrypto.so.0: undefined reference to `vpaes_set_encrypt_key'

 Attention : https://github.com/grpc/grpc/issues/9440

d) compiled android compatible version of libunwind to be used
to build libbacktrace
e) REQUIRES meta-selinux for libselinux, thus added it to
BBFILES_DYNAMIC of this layer.
f) checked compilation and packaging for for x86_64 and aarch64
g) UNTESTED android-tools-adbd.service , couldn't find how to build adbd
that is needed by the service with the new version of android-tools. At
present the service is still packaged but may not work.
h) tested the adb and fastboot on the core-image-minimal by including
the android-tools in the image and ran the commands with 'help'

Signed-off-by: Nisha Parrakat <Nisha.Parrakat@kpit.com>
Signed-off-by: Nisha Parrakat <nishaparrakat@gmail.com>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
