### PR TITLE
spirv-llvm-translator: switch to release llvm_release_130 branch

### DIFF
--- a/recipes-devtools/spirv-llvm-translator/spirv-llvm-translator_git.bb
+++ b/recipes-devtools/spirv-llvm-translator/spirv-llvm-translator_git.bb
@@ -1,12 +1,14 @@
 LICENSE = "NCSA"
 LIC_FILES_CHKSUM = "file://LICENSE.TXT;md5=47e311aa9caedd1b3abf098bd7814d1d"
 
-BRANCH = "master"
+BRANCH = "llvm_release_130"
 SRC_URI = "git://github.com/KhronosGroup/SPIRV-LLVM-Translator;protocol=https;branch=${BRANCH} \
+            git://github.com/KhronosGroup/SPIRV-Headers.git;protocol=https;destsuffix=git/SPIRV-Headers;name=headers \
           "
 
 PV = "13.0.0"
-SRCREV = "ddb5c962f0a11dc3dcc03e1e1840d2d826b95af9"
+SRCREV = "7d3a83f6e81be9e13254e73edd4272fa96ed0d44"
+SRCREV_headers = "ddf3230c14c71e81fc0eae9b781cc4bcc2d1f0f5"
 
 S = "${WORKDIR}/git"
 
@@ -27,6 +29,7 @@ EXTRA_OECMAKE = "\
         -DLLVM_INCLUDE_TESTS=ON \
         -Wno-dev \
         -DCCACHE_ALLOWED=FALSE \
+        -DLLVM_EXTERNAL_SPIRV_HEADERS_SOURCE_DIR=${S}/SPIRV-Headers \
 "
 
 do_compile:append() {


### PR DESCRIPTION
Fetching SPIRV-Headers, which provides required spirv.hpp headers

https://github.com/KhronosGroup/SPIRV-Headers.git

Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
