### PR TITLE
spirv-llvm-translator: Define explicit SRCREV_FORMAT

### DIFF
--- a/recipes-devtools/spirv-llvm-translator/spirv-llvm-translator_git.bb
+++ b/recipes-devtools/spirv-llvm-translator/spirv-llvm-translator_git.bb
@@ -10,6 +10,8 @@ PV = "13.0.0"
 SRCREV = "7d3a83f6e81be9e13254e73edd4272fa96ed0d44"
 SRCREV_headers = "ddf3230c14c71e81fc0eae9b781cc4bcc2d1f0f5"
 
+SRCREV_FORMAT = "default_headers"
+
 S = "${WORKDIR}/git"
 
 DEPENDS = "spirv-tools clang"


### PR DESCRIPTION
Since it uses multiple fetch URIs make it explicit to define SRCREV_FORMAT

Signed-off-by: Khem Raj <raj.khem@gmail.com>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
