### PR TITLE
clang: use global multilib variants

### DIFF
--- a/recipes-devtools/clang/llvm-project-source.inc
+++ b/recipes-devtools/clang/llvm-project-source.inc
@@ -28,7 +28,7 @@ python add_distro_vendor() {
     case = ""
     triple = ""
     vendors = d.getVar('CLANG_EXTRA_OE_VENDORS')
-    multilib_variants = d.getVar('MULTILIB_VARIANTS').split()
+    multilib_variants = (d.getVar("MULTILIB_GLOBAL_VARIANTS") or "").split()
     vendors_to_add = []
     for vendor in vendors.split():
         # convert -yoe into yoe


### PR DESCRIPTION
Using regular multilib variants prevents sharing state between machines
with dissimilar multilibs, or non-multilib machines. Since there's no
harm in having extra multilib triples, use the full set for all builds.

Signed-off-by: Dan McGregor <dan.mcgregor@usask.ca>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
