### PR TITLE
clang: Update to 13.0.0-rc4

### DIFF
--- a/recipes-devtools/clang/clang.inc
+++ b/recipes-devtools/clang/clang.inc
@@ -8,7 +8,7 @@ MAJOR_VER = "13"
 MINOR_VER = "0"
 PATCH_VER = "0"
 
-SRCREV ?= "f6b09e394a5fad4b33f8746195377f4f638e2c8d"
+SRCREV ?= "d7b669b3a30345cfcdb2fde2af6f48aa4b94845d"
 
 PV = "${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}"
 BRANCH = "release/13.x"


### PR DESCRIPTION
Changes in this set

  * d7b669b3a303 [clang] don't mark as Elidable CXXConstruct expressions used in NRVO
  * ee6913cc8317 [analyzer] Add 13.0.0 release notes
  * d0f0b5b99262 Thread safety analysis: Warn when demoting locks on back edges
  * 80f974e40f81 [AArch64][GlobalISel] Use ZExtValue for zext(xor) when invert tb(n)z
  * 5b95eb0b442e [debuginfo-test][cross-project-tests] Release note for new project name
  * b96ee8f581f6 [X86] combineX86ShuffleChain - ensure we only peek through bitcasts to vectors (PR51858)
  * dda88bfc06b5 [clang][scan-build] Use cc/c++ instead of gcc/g++ on OpenBSD.
  * 08642a395f23 Fix syntax error in Clang release notes
  * 6a5ccb2ec438 [compiler-rt] Implement __clear_cache() on OpenBSD/riscv64
  * 6aa054242d60 [LLD] Add required `ppc` target to the test cases. NFC
  * 8d78ac26f475 [OpenMP]Fix PR51349: Remove AlwaysInline for if regions.
  * d811546f803c [compiler-rt] Move -fno-omit-frame-pointer check to common config-ix
  * 89f2c0c63c22 [clang] disable implicit moves when not in CPlusPLus
  * 635b7871de93 [clang-repl] Install clang-repl
  * 1f27fe612876 -Wunused-but-set-parameter/-Wunused-but-set-variable Add to the release notes

Signed-off-by: Khem Raj <raj.khem@gmail.com>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
