### PR TITLE
nativesdk-clang: Fix build when using RUNTIME = llvm

### DIFF
--- a/classes/clang.bbclass
+++ b/classes/clang.bbclass
@@ -110,6 +110,7 @@ def clang_base_deps(d):
 
 BASE_DEFAULT_DEPS:toolchain-clang:class-target = "${@clang_base_deps(d)}"
 BASE_DEFAULT_DEPS:append:class-native:toolchain-clang:runtime-llvm = " libcxx-native compiler-rt-native"
+BASE_DEFAULT_DEPS:append:class-nativesdk:toolchain-clang:runtime-llvm = " clang-native nativesdk-libcxx nativesdk-compiler-rt"
 
 cmake_do_generate_toolchain_file:append:toolchain-clang () {
     cat >> ${WORKDIR}/toolchain.cmake <<EOF

--- a/recipes-devtools/clang/clang_git.bb
+++ b/recipes-devtools/clang/clang_git.bb
@@ -305,6 +305,8 @@ SSTATE_SCAN_FILES:remove = "*-config"
 TOOLCHAIN = "clang"
 TOOLCHAIN:class-native = "gcc"
 TOOLCHAIN:class-nativesdk = "clang"
+COMPILER_RT:class-nativesdk:toolchain-clang:runtime-llvm = "-rtlib=libgcc --unwindlib=libgcc"
+LIBCPLUSPLUS:class-nativesdk:toolchain-clang:runtime-llvm = "-stdlib=libstdc++"
 
 SYSROOT_DIRS:append:class-target = " ${nonarch_libdir}"
 


### PR DESCRIPTION
We can not use nativesdk variants of libcxx and compiler-rt yet when
compiling nativesdk-clang because, it will need this compiler to build
them, so solve this catch-22, since we do not use the runtime built
during compiler builds, use libgcc/libstdc++ to pass cmake tests
during configure, this should be fine as it will be not needed for final
builds where nativesdk-clang will be used, it can still default to llvm
runtime on SDK host

Signed-off-by: Khem Raj <raj.khem@gmail.com>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
