### PR TITLE
DEPENDS on virtual/${TARGET_PREFIX}binutils

### DIFF
--- a/recipes-devtools/clang/clang-cross_git.bb
+++ b/recipes-devtools/clang/clang-cross_git.bb
@@ -11,7 +11,7 @@ PN = "clang-cross-${TARGET_ARCH}"
 require clang.inc
 require common-source.inc
 inherit cross
-DEPENDS += "clang-native binutils-cross-${TARGET_ARCH}"
+DEPENDS += "clang-native virtual/${TARGET_PREFIX}binutils"
 
 do_install() {
         install -d ${D}${bindir}


### PR DESCRIPTION
```virtual/${TARGET_PREFIX}binutils``` shall be used and not ```binutils-cross-${TARGET_ARCH}```
In the case of an external arm toolchain, ```binutils-cross-aarch64``` does not exist and creates following error:
```
Missing or unbuildable dependency chain was: ['tisdk-base-image', 'packagegroup-core-standalone-sdk-target', 'libcxx-dev', 'compiler-rt', 'clang-cross-aarch64', 'binutils-cross-aarch64']
```
Signed-off-by: Guillaume Pais <guillaume.pais@siemens.com>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
