### PR TITLE
clang: Backport missing include fix from upstream.

### DIFF
--- a/recipes-devtools/clang/clang/0028-nfc-Fix-missing-include.patch
+++ b/recipes-devtools/clang/clang/0028-nfc-Fix-missing-include.patch
@@ -1,0 +1,28 @@
+From b498303066a63a203d24f739b2d2e0e56dca70d1 Mon Sep 17 00:00:00 2001
+From: serge-sans-paille <sguelton@redhat.com>
+Date: Tue, 10 Nov 2020 14:55:25 +0100
+Subject: [PATCH] [nfc] Fix missing include
+
+Upstream-Status: Backport [https://github.com/llvm/llvm-project/commit/b498303066a63a203d24f739b2d2e0e56dca70d1]
+
+Signed-off-by: Raphael Kubo da Costa <raphael.kubo.da.costa@intel.com>
+
+---
+ llvm/utils/benchmark/src/benchmark_register.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/llvm/utils/benchmark/src/benchmark_register.h b/llvm/utils/benchmark/src/benchmark_register.h
+index 0705e219f2fa..4caa5ad4da07 100644
+--- a/llvm/utils/benchmark/src/benchmark_register.h
++++ b/llvm/utils/benchmark/src/benchmark_register.h
+@@ -1,6 +1,7 @@
+ #ifndef BENCHMARK_REGISTER_H
+ #define BENCHMARK_REGISTER_H
+ 
++#include <limits>
+ #include <vector>
+ 
+ #include "check.h"
+-- 
+2.31.1
+

--- a/recipes-devtools/clang/common.inc
+++ b/recipes-devtools/clang/common.inc
@@ -35,6 +35,7 @@ SRC_URI = "\
     file://0025-clang-driver-Add-dyld-prefix-when-checking-sysroot-f.patch \
     file://0026-OpenCL-Fix-support-for-cl_khr_mipmap_image_writes.patch \
     file://0027-InstCombine-visitBitCast-do-not-crash-on-weird-bitca.patch;patchdir=llvm \
+    file://0028-nfc-Fix-missing-include.patch \
 "
 
 # Fallback to no-PIE if not set


### PR DESCRIPTION
This affects LLVM < 12, so backport directly to dunfell. This adds a missing
include that was breaking the build with recent libstdc++ releases on the
host system (versions 11 and above).