### PR TITLE
clang: don't use lnr

### DIFF
--- a/recipes-devtools/clang/clang_git.bb
+++ b/recipes-devtools/clang/clang_git.bb
@@ -201,7 +201,7 @@ endif()\n" ${D}${libdir}/cmake/llvm/LLVMExports-release.cmake
     if [ -n "${LLVM_LIBDIR_SUFFIX}" ]; then
         mkdir -p ${D}${nonarch_libdir}
         mv ${D}${libdir}/clang ${D}${nonarch_libdir}/clang
-        lnr ${D}${nonarch_libdir}/clang ${D}${libdir}/clang
+        ln -rs ${D}${nonarch_libdir}/clang ${D}${libdir}/clang
         rmdir --ignore-fail-on-non-empty ${D}${libdir}
     fi
     for t in clang clang++ llvm-nm llvm-ar llvm-as llvm-ranlib llvm-strip; do


### PR DESCRIPTION
lnr is deprecated, simply use ln -rs instead.

Signed-off-by: Ross Burton <ross.burton@arm.com>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
