### PR TITLE
clang: Update to 13.0.1-rc1

### DIFF
--- a/recipes-devtools/clang/clang.inc
+++ b/recipes-devtools/clang/clang.inc
@@ -8,7 +8,7 @@ MAJOR_VER = "13"
 MINOR_VER = "0"
 PATCH_VER = "1"
 
-SRCREV ?= "08e3a5ccd952edee36b3c002e3a29c6b1b5153de"
+SRCREV ?= "19b8368225dc9ec5a0da547eae48c10dae13522d"
 
 PV = "${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}"
 BRANCH = "release/13.x"


### PR DESCRIPTION
Changes in this bump

  * 19b8368225dc [X86][VARARG] Assign MMO earlier to   avoid prolog insert point been sunk across VASTART_SAVE_XMM_REGS
  * 41c85bbb43e4 [X86][NFC] Pre-commit test to show prolog insert problem
  * 9dc7d6d5e326 [SystemZ] Give the EXRL_Pseudo a size value of 6 bytes.
  * 32bb956916e3 Bad SLPVectorization shufflevector replacement, resulting in write to wrong memory location
  * 93edfb23b18b [SLP][NFC]Add a test to show an issue with incorrectly extracted pointers.
  * 162f3f18c945 [Aarch64] Correct register class for pseudo instructions
  * 8be24d19fefa [MergeICmps] Don't merge icmps derived from pointers with addressspaces
  * 9e084f4194e6 Fix building with GCC 12:
  * d5159b99105d MLIR can't support -Bsymbolic link option, fail at CMake time with a helpful message instead of broken ru  ntime
  * ff2cb6e400c3 [clang] Partially revert d8cd7806310c51af912a647a6ca46de62ff13214.
  * ed38280d006c [ARM] Use hardware TLS register in Thumb2 mode when -mtp=cp15 is passed
  * 216200aff268 [libc++] Fix hang in counting_semaphore::try_acquire
  * 00f64ccb49d9 [libc++] Remove non-atomic "platform" semaphore implementations.
  * 6cf25deec7d0 [libc++] counting_semaphore should not be default-constructible.
  * d218ef07a072 Re-apply the fix on DwarfEHPrepare and add a test

Signed-off-by: Khem Raj <raj.khem@gmail.com>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
