### PR TITLE
clang: for x86_64, correct GCC install search path for OpenEmbedded Host

### DIFF
--- a/recipes-devtools/clang/clang/0037-Fix-lib-paths-for-OpenEmbedded-Host.patch
+++ b/recipes-devtools/clang/clang/0037-Fix-lib-paths-for-OpenEmbedded-Host.patch
@@ -1,0 +1,81 @@
+From 76e66abe135908b9d987e9a96aab0176391ee38a Mon Sep 17 00:00:00 2001
+From: Changqing Li <changqing.li@windriver.com>
+Date: Tue, 7 Dec 2021 04:08:22 +0000
+Subject: [PATCH] Fix lib paths for OpenEmbedded Host
+
+Under OpenEmbedded Host, while building with clang-native, it cannot find
+the GCCInstallPath, which causing following error:
+[snip]
+compiler-rt-native/13.0.1-r0/recipe-sysroot-native/usr/bin/clang
+-target x86_64-linux
+-isystem/path/to/x86_64-linux/compiler-rt-native/13.0.1-r0/recipe-sysroot-native/usr/include
+-O2 -pipe
+/path/to/compiler-rt-native/13.0.1-r0/recipe-sysroot-native/usr/share/cmake-3.21/Modules/CMakeCCompilerABI.c`
+hosttools/ld: cannot find crtbeginS.o: No such file or directory
+[snip]
+
+Before this patch:
+compiler-rt-native/13.0.1-r0/recipe-sysroot-native/usr/bin/clang
+clang version 13.0.1 (https://github.com/llvm/llvm-project 08e3a5ccd952edee36b3c002e3a29c6b1b5153de)
+Target: x86_64-unknown-linux-gnu
+Thread model: posix
+InstalledDir: /build/tmp-glibc/work/x86_64-linux/compiler-rt-native/13.0.1-r0/recipe-sysroot-native/usr/bin
+Found candidate GCC installation: /usr/lib/gcc/x86_64-wrs-linux/10.2.0
+
+After this patch:
+compiler-rt-native/13.0.1-r0/recipe-sysroot-native/usr/bin/clang
+clang version 13.0.1 (https://github.com/llvm/llvm-project 08e3a5ccd952edee36b3c002e3a29c6b1b5153de)
+Thread model: posix
+InstalledDir: /build/tmp-glibc/work/x86_64-linux/compiler-rt-native/13.0.1-r0/recipe-sysroot-native/usr/bin
+Found candidate GCC installation: /usr/lib/gcc/x86_64-wrs-linux/10.2.0
+Found candidate GCC installation: /usr/lib/x86_64-wrs-linux/10.2.0
+Selected GCC installation: /usr/lib/x86_64-wrs-linux/10.2.0
+Candidate multilib: .;@m64
+Selected multilib: .;@m64
+
+Summary:
+For OpenEmbedded Host, sysroots are of the form<sysroot>/usr/lib/<triple>/x.y.z.
+Take x86-64 as example, the default triple is x86_64-unknown-linux-gnu.
+For clang-native, the target vendor is '-unknown', need to test current distro
+to follow above form.
+
+Upstream-Status: Inappropriate [oe specific]
+
+Signed-off-by: Changqing Li <changqing.li@windriver.com>
+---
+ clang/lib/Driver/ToolChains/Gnu.cpp | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/clang/lib/Driver/ToolChains/Gnu.cpp b/clang/lib/Driver/ToolChains/Gnu.cpp
+index 3350bda709f5..c03a839d1c72 100644
+--- a/clang/lib/Driver/ToolChains/Gnu.cpp
++++ b/clang/lib/Driver/ToolChains/Gnu.cpp
+@@ -22,6 +22,7 @@
+ #include "clang/Driver/Options.h"
+ #include "clang/Driver/Tool.h"
+ #include "clang/Driver/ToolChain.h"
++#include "clang/Driver/Distro.h"
+ #include "llvm/Option/ArgList.h"
+ #include "llvm/Support/CodeGen.h"
+ #include "llvm/Support/Path.h"
+@@ -2530,6 +2531,7 @@ void Generic_GCC::GCCInstallationDetector::ScanLibDirForGCCTriple(
+     const llvm::Triple &TargetTriple, const ArgList &Args,
+     const std::string &LibDir, StringRef CandidateTriple,
+     bool NeedsBiarchSuffix, bool GCCDirExists, bool GCCCrossDirExists) {
++  Distro Distro(D.getVFS(), TargetTriple);
+   // Locations relative to the system lib directory where GCC's triple-specific
+   // directories might reside.
+   struct GCCLibSuffix {
+@@ -2547,7 +2549,8 @@ void Generic_GCC::GCCInstallationDetector::ScanLibDirForGCCTriple(
+       // files in that location, not just GCC installation data.
+       {CandidateTriple.str(), "..",
+        TargetTriple.getVendor() == llvm::Triple::Freescale ||
+-           TargetTriple.getVendor() == llvm::Triple::OpenEmbedded},
++           TargetTriple.getVendor() == llvm::Triple::OpenEmbedded ||
++           Distro.IsOpenEmbedded()},
+ 
+       // This is the normal place.
+       {"gcc/" + CandidateTriple.str(), "../..", GCCDirExists},
+-- 
+2.32.0
+

--- a/recipes-devtools/clang/clang/0038-Correct-library-search-path-for-OpenEmbedded-Host.patch
+++ b/recipes-devtools/clang/clang/0038-Correct-library-search-path-for-OpenEmbedded-Host.patch
@@ -1,0 +1,86 @@
+From f790cf664e6d7ac2da4bf24caa82e7f166d592d8 Mon Sep 17 00:00:00 2001
+From: Changqing Li <changqing.li@windriver.com>
+Date: Tue, 7 Dec 2021 04:55:48 +0000
+Subject: [PATCH] Correct library search path for OpenEmbedded Host
+
+For OpenEmbedded Host, the gcc install path is
+/usr/lib/x86_64-[distroname]-linux/[gcc-version].
+So the library search path is not found with default triple
+'x86_64-linux-gnu' for x86_64. Causing following error:
+[snip]
+compiler-rt-native/13.0.1-r0/recipe-sysroot-native/usr/bin/clang
+-target x86_64-linux
+-isystem/path/to/x86_64-linux/compiler-rt-native/13.0.1-r0/recipe-sysroot-native/usr/include
+-O2 -pipe
+/path/to/compiler-rt-native/13.0.1-r0/recipe-sysroot-native/usr/share/cmake-3.21/Modules/CMakeCCompilerABI.c`
+|     /build/tmp-glibc/hosttools/ld: cannot find -lgcc
+|     /build/tmp-glibc/hosttools/ld: cannot find -lgcc
+|     clang-13: error: linker command failed with exit code 1 (use -v to see invocation)
+[snip]
+
+before this patch:
+b59da142f2b0:$ /path/to/x86_64-linux/compiler-rt-native/13.0.1-r0/recipe-sysroot-native/usr/bin/clang --print-search-dirs
+programs: =/build/tmp-glibc/work/x86_64-linux/compiler-rt-native/13.0.1-r0/recipe-sysroot-native/usr/bin
+libraries: =/build/tmp-glibc/work/x86_64-linux/compiler-rt-native/13.0.1-r0/recipe-sysroot-native/usr/lib/clang/13.0.1:/build/tmp-glibc/work/x86_64-linux/compiler-rt-native/13.0.1-r0/recipe-sysroot-native/usr/bin/../lib://lib://usr/lib
+
+after this patch:
+b59da142f2b0:$ /path/to/x86_64-linux/compiler-rt-native/13.0.1-r0/recipe-sysroot-native/usr/bin/clang --print-search-dirs
+programs: =/build/tmp-glibc/work/x86_64-linux/compiler-rt-native/13.0.1-r0/recipe-sysroot-native/usr/bin
+libraries: =/build/tmp-glibc/work/x84_64-linux/compiler-rt-native/13.0.1-r0/recipe-sysroot-native/usr/lib/clang/13.0.1:/usr/lib/x86_64-wrs-linux/10.2.0://lib/x86_64-wrs-linux://usr/lib/x86_64-wrs-linux:/build/tmp-glibc/work/x86_64-linux/compiler-rt-native/13.0.1-r0/recipe-sysroot-native/usr/bin/../lib://lib://usr/lib
+
+Upstream-Status: Inappropriate [oe specific]
+
+Signed-off-by: Changqing Li <changqing.li@windriver.com>
+---
+ clang/include/clang/Driver/Distro.h   | 2 ++
+ clang/lib/Driver/Distro.cpp           | 1 +
+ clang/lib/Driver/ToolChains/Linux.cpp | 1 +
+ 3 files changed, 4 insertions(+)
+
+diff --git a/clang/include/clang/Driver/Distro.h b/clang/include/clang/Driver/Distro.h
+index 0d2a0939639e..5556f473899f 100644
+--- a/clang/include/clang/Driver/Distro.h
++++ b/clang/include/clang/Driver/Distro.h
+@@ -43,6 +43,7 @@ public:
+     RHEL7,
+     Fedora,
+     Gentoo,
++    //CLANG_EXTRA_OE_DISTRO_NAME
+     OpenSUSE,
+     UbuntuHardy,
+     UbuntuIntrepid,
+@@ -130,6 +131,7 @@ public:
+ 
+   bool IsGentoo() const { return DistroVal == Gentoo; }
+ 
++  //CLANG_EXTRA_OE_DISTRO_CHECK
+   /// @}
+ };
+ 
+diff --git a/clang/lib/Driver/Distro.cpp b/clang/lib/Driver/Distro.cpp
+index c4cf4e48b5b8..2695c0ab85c2 100644
+--- a/clang/lib/Driver/Distro.cpp
++++ b/clang/lib/Driver/Distro.cpp
+@@ -44,6 +44,7 @@ static Distro::DistroType DetectOsRelease(llvm::vfs::FileSystem &VFS) {
+                     .Case("sles", Distro::OpenSUSE)
+                     .Case("opensuse", Distro::OpenSUSE)
+                     .Case("exherbo", Distro::Exherbo)
++                    //CLANG_EXTRA_OE_DISTRO_CASE
+                     .Default(Distro::UnknownDistro);
+   return Version;
+ }
+diff --git a/clang/lib/Driver/ToolChains/Linux.cpp b/clang/lib/Driver/ToolChains/Linux.cpp
+index 46c83b002e6c..e356616229c1 100644
+--- a/clang/lib/Driver/ToolChains/Linux.cpp
++++ b/clang/lib/Driver/ToolChains/Linux.cpp
+@@ -77,6 +77,7 @@ std::string Linux::getMultiarchTriple(const Driver &D,
+       return "x86_64-linux-android";
+     if (TargetEnvironment == llvm::Triple::GNUX32)
+       return "x86_64-linux-gnux32";
++    //CLANG_EXTRA_OE_DISTRO_TRIPLE
+     return "x86_64-linux-gnu";
+   case llvm::Triple::aarch64:
+     if (IsAndroid)
+-- 
+2.32.0
+

--- a/recipes-devtools/clang/common.inc
+++ b/recipes-devtools/clang/common.inc
@@ -46,6 +46,8 @@ SRC_URI = "\
     file://0034-compiler-rt-Do-not-force-thumb-mode-directive.patch \
     file://0035-clang-Do-not-use-install-relative-libc-headers.patch \
     file://0036-clang-Fix-how-driver-finds-GCC-installation-path-on-.patch \
+    file://0037-Fix-lib-paths-for-OpenEmbedded-Host.patch \
+    file://0038-Correct-library-search-path-for-OpenEmbedded-Host.patch \
     "
 # Fallback to no-PIE if not set
 GCCPIE ??= ""

--- a/recipes-devtools/clang/llvm-project-source.inc
+++ b/recipes-devtools/clang/llvm-project-source.inc
@@ -22,6 +22,10 @@ PACKAGES = ""
 # space separated list of additional distro vendor values we want to support e.g.
 # "yoe webos" or "-yoe -webos" '-' is optional
 CLANG_EXTRA_OE_VENDORS ?= "${TARGET_VENDOR} ${SDK_VENDOR}"
+# Extra OE DISTRO that want to support as build host. space separated list of additional distro.
+# ":" separated the ID in "/etc/os-release" and the triple for finding gcc on this OE DISTRO.
+# eg: "poky:poky wrlinux:wrs"
+CLANG_EXTRA_OE_DISTRO ?= "poky:poky"
 
 python add_distro_vendor() {
     import subprocess
@@ -50,6 +54,33 @@ python add_distro_vendor() {
     cmd = d.expand("sed -i 's#//CLANG_EXTRA_OE_VENDORS_TRIPLES#%s#g' ${S}/clang/lib/Driver/ToolChains/Gnu.cpp" % (triple))
     subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True)
     cmd = d.expand("sed -i 's#//CLANG_EXTRA_OE_VENDORS_CASES#%s#g' -i ${S}/llvm/lib/Support/Triple.cpp" % (case))
+    subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True)
+
+
+    case = ""
+    triple = ""
+    name = ""
+    check = ""
+    oe_names = ""
+    distros = d.getVar('CLANG_EXTRA_OE_DISTRO')
+    for distro in distros.split():
+        distro_id = distro.split(":")[0].replace('-','_')
+        distro_triple = distro.split(":")[1]
+        case += '\\n    .Case("' + distro_id + '", Distro::' + distro_id.upper() + ')'
+        triple += '\\n   if (Distro.Is' + distro_id.upper() + '())\\n     return "x86_64-' + distro_triple + '-linux",'
+        name += '\\n    '+ distro_id.upper() + ','
+        check += '\\nbool Is' + distro_id.upper() + '() const { return DistroVal == ' + distro_id.upper() + '; }'
+        oe_names +=  distro_id.upper() + ' ||'
+
+    check += '\\nbool IsOpenEmbedded() const { return DistroVal == ' + oe_names[0:-3] + '; }'
+
+    cmd = d.expand("sed -i 's#//CLANG_EXTRA_OE_DISTRO_NAME#%s#g' ${S}/clang/include/clang/Driver/Distro.h" % (name))
+    subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True)
+    cmd = d.expand("sed -i 's#//CLANG_EXTRA_OE_DISTRO_CHECK#%s#g' ${S}/clang/include/clang/Driver/Distro.h" % (check))
+    subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True)
+    cmd = d.expand("sed -i 's#//CLANG_EXTRA_OE_DISTRO_TRIPLES#%s#g' ${S}/clang/lib/Driver/ToolChains/Linux.cpp" % (triple))
+    subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True)
+    cmd = d.expand("sed -i 's#//CLANG_EXTRA_OE_DISTRO_CASES#%s#g' -i ${S}/clang/lib/Driver/Distro.cpp" % (case))
     subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True)
 }
 


### PR DESCRIPTION
Build on OpenEmbedded Host, compiler-rt-native do_configure failed with
following error:
compiler-rt-native/13.0.1-r0/recipe-sysroot-native/usr/bin/clang -target x86_64-linux
-isystem/path/to/x86_64-linux/compiler-rt-native/13.0.1-r0/recipe-sysroot-native/usr/include
-O2 -pipe
/path/to/compiler-rt-native/13.0.1-r0/recipe-sysroot-native/usr/share/cmake-3.21/Modules/CMakeCCompilerABI.c`
|     /build/tmp-glibc/hosttools/ld: cannot find crtbeginS.o: No such file or directory
|     /build/tmp-glibc/hosttools/ld: cannot find -lgcc
|     /build/tmp-glibc/hosttools/ld: cannot find -lgcc
|     clang-13: error: linker command failed with exit code 1 (use -v to see invocation)

Since OpenEmbedded Host's gcc install path is different with clang's
default search form, patch for OpenEmbedded Host's gcc library install
path.

Signed-off-by: Changqing Li <changqing.li@windriver.com>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
