### PR TITLE
Use GCC runtime on ppc32 and armv5

### DIFF
--- a/classes/clang.bbclass
+++ b/classes/clang.bbclass
@@ -25,6 +25,8 @@ UNWINDLIB:armeb = "--unwindlib=libgcc"
 UNWINDLIB_libc-klibc = "--unwindlib=libgcc"
 
 LIBCPLUSPLUS ??= ""
+LIBCPLUSPLUS:powerpc = "-stdlib=libstdc++"
+LIBCPLUSPLUS:armv5 = "-stdlib=libstdc++"
 
 CXXFLAGS:append:toolchain-clang = " ${LIBCPLUSPLUS}"
 LDFLAGS:append:toolchain-clang = " ${COMPILER_RT} ${LIBCPLUSPLUS}"
@@ -73,6 +75,8 @@ TOOLCHAIN ??= "gcc"
 RUNTIME ??= "gnu"
 #RUNTIME:toolchain-gcc = "gnu"
 RUNTIME:armeb = "gnu"
+RUNTIME:armv5 = "gnu"
+RUNTIME:powerpc = "gnu"
 
 TOOLCHAIN:class-native = "gcc"
 TOOLCHAIN:class-nativesdk = "gcc"

--- a/conf/nonclangable.conf
+++ b/conf/nonclangable.conf
@@ -369,3 +369,8 @@ LTO:pn-cairo:toolchain-clang = ""
 
 # see https://bugs.llvm.org/show_bug.cgi?id=50443 this is in clang-13, until it is fixed do not use -O2
 SELECTED_OPTIMIZATION:remove:pn-poke:toolchain-clang = "-O2"
+
+# This works with gcc-ranlib wrapper only which expands $@ shell array,
+# but it will fail if RANLIB was set to <cross>-ranlib or
+# <cross>-llvn-ranlib has same behaviour
+RANLIB:append:pn-tcf-agent:toolchain-clang = " $@"


### PR DESCRIPTION
libcxx does not build for armv5 due to atomic locks issue
and compile-rt cross build needs to be fixed for ppc32

Signed-off-by: Khem Raj <raj.khem@gmail.com>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
