### PR TITLE
bcc: Add explicit dependency on flex target recipe

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-devtools/bcc/bcc_0.20.0.bb
+++ b/dynamic-layers/openembedded-layer/recipes-devtools/bcc/bcc_0.20.0.bb
@@ -7,6 +7,7 @@ inherit cmake python3native manpages
 
 DEPENDS += "bison-native \
             flex-native \
+            flex \
             elfutils \
             ${LUAJIT} \
             clang \


### PR DESCRIPTION
While building bcc for the target it depends on flex target recipe. So
add that dependency explicity.

Signed-off-by: Sumit Garg <sumit.garg@linaro.org>