### PR TITLE
intel-mediasdk: Fix meta-intel/meta-clang collisions

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -17,6 +17,8 @@ BBFILES_DYNAMIC += " \
     openembedded-layer:${LAYERDIR}/dynamic-layers/openembedded-layer/*/*/*.bbappend \
     networking-layer:${LAYERDIR}/dynamic-layers/networking-layer/*/*/*.bb \
     networking-layer:${LAYERDIR}/dynamic-layers/networking-layer/*/*/*.bbappend \
+    intel:${LAYERDIR}/dynamic-layers/intel/*/*/*.bb \
+    intel:${LAYERDIR}/dynamic-layers/intel/*/*/*.bbappend \
     selinux:${LAYERDIR}/dynamic-layers/selinux/*/*.bb \
 "
 

--- a/dynamic-layers/intel/recipes-multimedia/mediasdk/intel-mediasdk/intel-mediasdk-20.5.1-no-lgcc.patch
+++ b/dynamic-layers/intel/recipes-multimedia/mediasdk/intel-mediasdk/intel-mediasdk-20.5.1-no-lgcc.patch
@@ -1,0 +1,30 @@
+Author: Bernhard Rosenkraenzer <bernhard.rosenkraenzer.ext@huawei.com>
+
+Remove -lgcc -- it's unneeded and breaks building with compiler-rt.
+
+Signed-off-by: Bernhard Rosenkraenzer <bernhard.rosenkraenzer.ext@huawei.com>
+Upstream-Status: Pending
+
+diff -up git/builder/FindFunctions.cmake.omv~ git/builder/FindFunctions.cmake
+--- git/builder/FindFunctions.cmake.omv~	2021-06-03 20:35:11.230895070 +0200
++++ git/builder/FindFunctions.cmake	2021-06-03 20:35:49.750360067 +0200
+@@ -200,10 +200,6 @@ function( make_library name variant type
+   set_target_properties( ${target} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BIN_DIR}/${CMAKE_BUILD_TYPE} FOLDER ${folder} )
+   set_target_properties( ${target} PROPERTIES ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_LIB_DIR}/${CMAKE_BUILD_TYPE} FOLDER ${folder} )
+ 
+-  if( Linux )
+-    target_link_libraries( ${target} "-lgcc" )
+-  endif()
+-
+   set( target ${target} PARENT_SCOPE )
+ endfunction()
+ 
+@@ -278,7 +274,7 @@ function( make_executable name variant )
+   endforeach()
+ 
+   if( Linux )
+-    target_link_libraries( ${target} "-Xlinker --end-group -lgcc" )
++    target_link_libraries( ${target} "-Xlinker --end-group" )
+   endif()
+ 
+   set( target ${target} PARENT_SCOPE )

--- a/dynamic-layers/intel/recipes-multimedia/mediasdk/intel-mediasdk_%.bbappend
+++ b/dynamic-layers/intel/recipes-multimedia/mediasdk/intel-mediasdk_%.bbappend
@@ -1,0 +1,3 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+SRC_URI:append:toolchain-clang = " file://intel-mediasdk-20.5.1-no-lgcc.patch"

--- a/recipes-devtools/clang/llvm-project-source.bbappend
+++ b/recipes-devtools/clang/llvm-project-source.bbappend
@@ -1,0 +1,9 @@
+# This needs to override meta-intel (which pulls in the
+# LLVM 10/11 version of SPIRV-LLVM-Translator)
+
+SPIRV_BRANCH = "llvm_release_120"
+SRC_URI_append_intel-x86-common = " \
+                                    git://github.com/KhronosGroup/SPIRV-LLVM-Translator.git;protocol=https;branch=${SPIRV_BRANCH};destsuffix=git/llvm/projects/llvm-spirv;name=spirv \
+                                    "
+SRCREV_spirv = "67d3e271a28287b2c92ecef2f5e98c49134e5946"
+


### PR DESCRIPTION
meta-intel assumes LLVM 10 or 11 is being built, and forces a version
of SPIRV-LLVM-Translator that doesn't work with LLVM 12.
Override this with an LLVM 12 compatible version.

Also, meta-intel pulls in intel-mediasdk which, out of the box, doesn't
build with compiler-rt. Add a patch to intel-mediasdk that fixes this.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
