### PR TITLE
clang-tools-extra: apply upstream patch

### DIFF
--- a/recipes-devtools/clang/clang/0039-run-clang-tidy-on-unique-files-only.patch
+++ b/recipes-devtools/clang/clang/0039-run-clang-tidy-on-unique-files-only.patch
@@ -1,0 +1,31 @@
+From 0dc856ed20e0fb64dd7cb0a10db35c58c3ef95e6 Mon Sep 17 00:00:00 2001
+From: Serikzhan Kazi <se7kazi@gmail.com>
+Date: Sat, 6 Nov 2021 19:53:18 +1300
+Subject: [PATCH] [clang-tidy] run-clang-tidy.py: analyze unique files only
+
+The files in compile-commands.json can potentially include duplicates.
+Change run-clang-tidy.py so that it does not run on the duplicate entries.
+
+Differential Revision: https://reviews.llvm.org/D112926
+---
+ clang-tools-extra/clang-tidy/tool/run-clang-tidy.py | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/clang-tools-extra/clang-tidy/tool/run-clang-tidy.py b/clang-tools-extra/clang-tidy/tool/run-clang-tidy.py
+index acd1ed6979c0..e6cff6a7414d 100755
+--- a/clang-tools-extra/clang-tidy/tool/run-clang-tidy.py
++++ b/clang-tools-extra/clang-tidy/tool/run-clang-tidy.py
+@@ -273,8 +273,8 @@ def main():
+ 
+   # Load the database and extract all files.
+   database = json.load(open(os.path.join(build_path, db_path)))
+-  files = [make_absolute(entry['file'], entry['directory'])
+-           for entry in database]
++  files = set([make_absolute(entry['file'], entry['directory'])
++           for entry in database])
+ 
+   max_task = args.j
+   if max_task == 0:
+-- 
+2.34.1
+


### PR DESCRIPTION
run-clang-tidy.py is being run on unique files only
when using this patch

Signed-off-by: Serikzhan Kazi <doze-tile-ruse-exit@mbition.io>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
