### PR TITLE
nativesdk-clang-glue: delete spdx tasks

### DIFF
--- a/recipes-devtools/clang/nativesdk-clang-glue.bb
+++ b/recipes-devtools/clang/nativesdk-clang-glue.bb
@@ -31,3 +31,5 @@ deltask do_compile
 deltask do_patch
 deltask do_fetch
 deltask do_unpack
+deltask do_create_spdx
+deltask do_create_runtime_spdx


### PR DESCRIPTION
Extending poky's create-spdx class for SDKs results in a dependency loop:
nativesdk-clang-glue.bb:do_create_spdx ->clang_git.bb:do_create_spdx ->
clang-crosssdk_git.bb:do_create_spdx ->
nativesdk-clang-glue.bb:do_create_spdx. Delete spdx tasks from
nativesdk-clang-blue.bb

Signed-off-by: Andres Beltran <abeltran@microsoft.com>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
