### PR TITLE
concurrencykit: Disable internal clang assembler

### DIFF
--- a/conf/nonclangable.conf
+++ b/conf/nonclangable.conf
@@ -277,6 +277,14 @@ CFLAGS:append:pn-nettle:toolchain-clang:powerpc64le = " -no-integrated-as"
 # Fixes clang crash when compiling gnutls-3.7.2/lib/accelerated/aarch64/elf/sha512-armv8.s
 CFLAGS:append:pn-gnutls:toolchain-clang:aarch64 = " -no-integrated-as"
 
+# include/gcc/arm/ck_pr.h:201:1: error: instruction requires: arm-mode
+#| CK_PR_DOUBLE_STORE(uint64_t, 64)
+#| ^
+#include/gcc/arm/ck_pr.h:192:6: note: expanded from macro 'CK_PR_DOUBLE_STORE'
+#|                          "strexd        %1, %3, [%2]\n"         \
+#|                           ^
+CFLAGS:append:pn-concurrencykit:toolchain-clang:arm = " -no-integrated-as"
+
 # regtest.cc:374:39: error: invalid suffix on literal; C++11 requires a
 # space between literal and identifier [-Wreserved-user-defined-literal]
 #|   snprintf_func (buf, sizeof(buf), "%"Q"u", x);


### PR DESCRIPTION
The code has inline arm asm in header files which is not compilable with
clang's internal assembler.

Signed-off-by: Khem Raj <raj.khem@gmail.com>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
