### PR TITLE
[WIP] OpenMP Link fix

### DIFF
--- a/recipes-devtools/clang/clang/0029-OpenMP-link-fix.patch 
+++ b/recipes-devtools/clang/clang/0029-OpenMP-link-fix.patch 
@@ -1,0 +1,26 @@
+From 11bd98436bd7e99fb1fc2c07c150c71e2250a262 Mon Sep 17 00:00:00 2001
+From: Joel Winarske <joel.winarske@gmail.com>
+Date: Wed, 9 Feb 2022 11:11:55 -0800
+Subject: [PATCH] OpenMP link fix
+
+Signed-off-by: Joel Winarske <joel.winarske@gmail.com>
+---
+ openmp/runtime/src/CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/openmp/runtime/src/CMakeLists.txt b/openmp/runtime/src/CMakeLists.txt
+index 9f46b4bd4..3106e497d 100644
+--- a/openmp/runtime/src/CMakeLists.txt
++++ b/openmp/runtime/src/CMakeLists.txt
+@@ -168,7 +168,7 @@ endif()
+ 
+ # Linking command will include libraries in LIBOMP_CONFIGURED_LIBFLAGS
+ libomp_get_libflags(LIBOMP_CONFIGURED_LIBFLAGS)
+-target_link_libraries(omp ${LIBOMP_CONFIGURED_LIBFLAGS} ${CMAKE_DL_LIBS})
++target_link_libraries(omp ${LIBOMP_CONFIGURED_LIBFLAGS} ${CMAKE_DL_LIBS} "-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/exports_so.txt")
+ 
+ # Create *.inc before compiling any sources
+ # objects depend on : .inc files
+-- 
+2.31.1
+

--- a/recipes-devtools/clang/openmp_git.bb
+++ b/recipes-devtools/clang/openmp_git.bb
@@ -12,6 +12,10 @@ TOOLCHAIN = "clang"
 
 LIC_FILES_CHKSUM = "file://openmp/LICENSE.txt;md5=d75288d1ce0450b28b8d58a284c09c79"
 
+SRC_URI += "\
+    file://0029-OpenMP-link-fix.patch \
+"
+
 inherit cmake pkgconfig perlnative
 
 DEPENDS += "elfutils libffi"


### PR DESCRIPTION
-fixes "version node not found for symbol omp_get_num_places_@@VERSION"

Signed-off-by: Joel Winarske <joel.winarske@gmail.com>

Build matrix is currently running.  Will move from WIP state after builds all pass.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x ] `Signed-off-by` is present
- [ x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
