### PR TITLE
clang: Remove unintended dependency on gcc-runtime

### DIFF
--- a/classes/clang.bbclass
+++ b/classes/clang.bbclass
@@ -104,7 +104,9 @@ def clang_base_deps(d):
                 ret += " compiler-rt "
             else:
                 ret += " libgcc "
-            if (d.getVar('COMPILER_RT').find('--unwindlib=libunwind') != -1):
+            if (d.getVar('RUNTIME').find('llvm') != -1):
+                ret += " libcxx"
+            elif (d.getVar('COMPILER_RT').find('--unwindlib=libunwind') != -1):
                 ret += " libcxx "
             elif (d.getVar('LIBCPLUSPLUS').find('-stdlib=libc++') != -1):
                 ret += " libcxx "


### PR DESCRIPTION
Commit a494bbb6ec44 ("clang: support android runtime") introduced an
unrelated change causing builds with RUNTIME="llvm" and COMPILER_RT not
set to get a dependency on virtual/${TARGET_PREFIX}compilerlibs.

This is clearly unrelated to addition of support for android runtime,
and causing unwanted depdencies to gcc-runtime for LLVM builds.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
