### PR TITLE
clang.bbclass: Use llvm provided binutils when using toolchain-clang

### DIFF
--- a/classes/clang.bbclass
+++ b/classes/clang.bbclass
@@ -8,6 +8,11 @@ CCLD:toolchain-clang = "${CCACHE}${HOST_PREFIX}clang ${HOST_CC_ARCH}${TOOLCHAIN_
 RANLIB:toolchain-clang = "${HOST_PREFIX}llvm-ranlib"
 AR:toolchain-clang = "${HOST_PREFIX}llvm-ar"
 NM:toolchain-clang = "${HOST_PREFIX}llvm-nm"
+OBJDUMP:toolchain-clang = "${HOST_PREFIX}llvm-objdump"
+OBJCOPY:toolchain-clang = "${HOST_PREFIX}llvm-objcopy"
+STRIP:toolchain-clang = "${HOST_PREFIX}llvm-strip"
+STRINGS:toolchain-clang = "${HOST_PREFIX}llvm-strings"
+READELF:toolchain-clang = "${HOST_PREFIX}llvm-readelf"
 
 LTO:toolchain-clang = "${@bb.utils.contains('DISTRO_FEATURES', 'thin-lto', '-flto=thin', '-flto -fuse-ld=lld', d)}"
 PACKAGE_DEBUG_SPLIT_STYLE:toolchain-clang = "debug-without-src"


### PR DESCRIPTION
These tools are better integrated with clang produced output consumption
pipeline, therefore use them when using clang as compiler

Signed-off-by: Khem Raj <raj.khem@gmail.com>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
