### PR TITLE
bpftrace: Upgrade to latest master

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-devtools/bpftrace/bpftrace_0.14.1.bb
+++ b/dynamic-layers/openembedded-layer/recipes-devtools/bpftrace/bpftrace_0.14.1.bb
@@ -13,12 +13,12 @@ DEPENDS += "bison-native \
             libbpf \
             "
 
-#PV .= "+git${SRCREV}"
+PV .= "+git${SRCREV}"
 RDEPENDS:${PN} += "bash python3 xz"
 
-SRC_URI = "git://github.com/iovisor/bpftrace;branch=v0.14_release;protocol=https \
+SRC_URI = "git://github.com/iovisor/bpftrace;branch=master;protocol=https \
            "
-SRCREV = "20e48420ba3a5c6f3630ab25b6b5c28d950b5bb4"
+SRCREV = "0a318e53343aa51f811183534916a4be65a1871e"
 
 S = "${WORKDIR}/git"
 
@@ -38,5 +38,5 @@ EXTRA_OECMAKE = " \
     -DENABLE_MAN=OFF \
 "
 
-COMPATIBLE_HOST = "(x86_64.*|aarch64.*|powerpc64.*)-linux"
+COMPATIBLE_HOST = "(x86_64.*|aarch64.*|powerpc64.*|riscv64.*)-linux"
 COMPATIBLE_HOST:libc-musl = "null"


### PR DESCRIPTION
Enable riscv64 as the support is now available
this update is needed for it to work with clang14

Signed-off-by: Khem Raj <raj.khem@gmail.com>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
