### PR TITLE
clang: set POPULATESYSROOTDEPS so that strip is present

### DIFF
--- a/classes/clang.bbclass
+++ b/classes/clang.bbclass
@@ -124,6 +124,9 @@ BASE_DEFAULT_DEPS:toolchain-clang:class-target = "${@clang_base_deps(d)}"
 BASE_DEFAULT_DEPS:append:class-native:toolchain-clang:runtime-llvm = " libcxx-native compiler-rt-native"
 BASE_DEFAULT_DEPS:append:class-nativesdk:toolchain-clang:runtime-llvm = " clang-native nativesdk-libcxx nativesdk-compiler-rt"
 
+# do_populate_sysroot needs STRIP
+POPULATESYSROOTDEPS:toolchain-clang:class-target = "clang-cross-${TARGET_ARCH}:do_populate_sysroot"
+
 cmake_do_generate_toolchain_file:append:toolchain-clang () {
     cat >> ${WORKDIR}/toolchain.cmake <<EOF
 set( CMAKE_CLANG_TIDY ${HOST_PREFIX}clang-tidy )


### PR DESCRIPTION
do_populate_sysroot will execute the cross STRIP as part of the
processing. In non-clang builds this is present via POPULATESYSROOTDEPS
pulling in binutils, but in clang builds STRIP is set to llvm-strip which
obviously isn't part of binutils.

Set POPULATESYSROOTDEPS correctly to ensure that do_populate_sysroot has
the strip binary available.

Signed-off-by: Ross Burton <ross.burton@arm.com>
