### PR TITLE
libbsd: Use GNU objdump on mips

### DIFF
--- a/conf/nonclangable.conf
+++ b/conf/nonclangable.conf
@@ -427,6 +427,9 @@ STRIP:pn-kexec-tools-klibc:mips:toolchain-clang = "${HOST_PREFIX}strip"
 STRIP:pn-go-helloworld:mips:toolchain-clang = "${HOST_PREFIX}strip"
 OBJCOPY:pn-go-helloworld:mips:toolchain-clang = "${HOST_PREFIX}objcopy"
 
+# see https://github.com/llvm/llvm-project/issues/54213
+OBJDUMP:pn-libbsd:mips:toolchain-clang = "${HOST_PREFIX}objdump"
+
 # Need OBJDUMP during do_package_qa which is set to llvm-objdump with meta-clang
 # it might work with GNU objdump since it falls back to one from build host
 DEPENDS:pn-linux-firmware:append:toolchain-clang = " clang-native"


### PR DESCRIPTION
This is to workaround issue [1] seen with LLVM mips

[1] https://github.com/llvm/llvm-project/issues/54213

Signed-off-by: Khem Raj <raj.khem@gmail.com>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
