### PR TITLE
bcc: Enable riscv64 builds

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-devtools/bcc/bcc_0.24.0.bb
+++ b/dynamic-layers/openembedded-layer/recipes-devtools/bcc/bcc_0.24.0.bb
@@ -16,6 +16,7 @@ DEPENDS += "bison-native \
 LUAJIT ?= "luajit"
 LUAJIT:powerpc64le = ""
 LUAJIT:powerpc64 = ""
+LUAJIT:riscv64 = ""
 
 RDEPENDS:${PN} += "bash python3 python3-core python3-setuptools xz"
 
@@ -53,4 +54,4 @@ do_install:append() {
 FILES:${PN} += "${PYTHON_SITEPACKAGES_DIR}"
 FILES:${PN}-doc += "${datadir}/${PN}/man"
 
-COMPATIBLE_HOST = "(x86_64.*|aarch64.*|powerpc64.*)-linux"
+COMPATIBLE_HOST = "(x86_64.*|aarch64.*|powerpc64.*|riscv64.*)-linux"


### PR DESCRIPTION
Disable LuaJIT on rv64 since its not yes ported

Signed-off-by: Khem Raj <raj.khem@gmail.com>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
