### PR TITLE
opencv: Use gcc for ppc64

### DIFF
--- a/conf/nonclangable.conf
+++ b/conf/nonclangable.conf
@@ -161,6 +161,11 @@ TOOLCHAIN:pn-redis:mips = "gcc"
 # This header is only available with gcc-cross
 TOOLCHAIN:pn-mariadb:powerpc64le = "gcc"
 
+# OpenCV does not compile for ppc64 with clang due to VSX clashes with altivec.h from clang
+TOOLCHAIN:pn-opencv:powerpc64le = "gcc"
+# Ade is used by openCV and shared C++ runtime so we can not mix libstdc++ and libc++
+TOOLCHAIN:pn-ade:powerpc64le = "gcc"
+
 # latest 32bit arch versions fails to compile with clang 13
 # common/JackEngineControl.h:89:5: error: requested alignment is less than minimum alignment of 8 for type 'Jack::JackFrameTimer'
 #|     alignas(UInt32) JackFrameTimer fFrameTimer;


### PR DESCRIPTION
it will take some effort to fix it going with clang 14
due to VSX/altivec intrinsics conflicts

Signed-off-by: Khem Raj <raj.khem@gmail.com>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
