### PR TITLE
python3-grpcio-tools: Use gcc on mips for now

### DIFF
--- a/conf/nonclangable.conf
+++ b/conf/nonclangable.conf
@@ -408,6 +408,7 @@ SELECTED_OPTIMIZATION:append:pn-fio:mips:toolchain-clang = " -O0"
 
 # See https://github.com/llvm/llvm-project/issues/54005
 TOOLCHAIN:pn-qtlocation:mips = "gcc"
+TOOLCHAIN:pn-python3-grpcio-tools:mips = "gcc"
 
 # This works with gcc-ranlib wrapper only which expands $@ shell array,
 # but it will fail if RANLIB was set to <cross>-ranlib or


### PR DESCRIPTION
clang14 crashes compiling 1.44 version

Signed-off-by: Khem Raj <raj.khem@gmail.com>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
