### PR TITLE
clang: Avoid double libcxx in BASE_DEFAULT_DEPS

### DIFF
--- a/classes/clang.bbclass
+++ b/classes/clang.bbclass
@@ -105,7 +105,7 @@ def clang_base_deps(d):
                 ret += " libcxx"
                 return ret
             if (d.getVar('RUNTIME').find('llvm') != -1):
-                ret += " compiler-rt libcxx"
+                ret += " compiler-rt"
             elif (d.getVar('COMPILER_RT').find('-rtlib=compiler-rt') != -1):
                 ret += " compiler-rt "
             else:


### PR DESCRIPTION
When RUNTIME=="llvm" the libcxx entry will be added in a separate if clause
right after this.  We don't need it twice.

Signed-off-by: Esben Haabendal <esben.haabendal@huawei.com>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
