### PR TITLE
openmp: Exclude powerpc

### DIFF
--- a/recipes-devtools/clang/openmp_git.bb
+++ b/recipes-devtools/clang/openmp_git.bb
@@ -43,5 +43,6 @@ INSANE_SKIP:${PN} = "dev-so"
 
 COMPATIBLE_HOST:mips64 = "null"
 COMPATIBLE_HOST:riscv32 = "null"
+COMPATIBLE_HOST:powerpc = "null"
 
 BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
ppc is not yet supported by openmp
see https://github.com/llvm/llvm-project/blob/main/openmp/runtime/cmake/LibompGetArchitecture.cmake#L16

Signed-off-by: Khem Raj <raj.khem@gmail.com>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
