### PR TITLE
rpm: Do not use openmp on ppc

### DIFF
--- a/classes/clang.bbclass
+++ b/classes/clang.bbclass
@@ -94,14 +94,12 @@ OVERRIDES =. "${@['', 'toolchain-${TOOLCHAIN}:']['${TOOLCHAIN}' != '']}"
 OVERRIDES =. "${@['', 'runtime-${RUNTIME}:']['${RUNTIME}' != '']}"
 OVERRIDES[vardepsexclude] += "TOOLCHAIN RUNTIME"
 
-YOCTO_ALTERNATE_EXE_PATH[export] = "0"
-YOCTO_ALTERNATE_LIBDIR[export] = "0"
 
-YOCTO_ALTERNATE_EXE_PATH:class-target = "${STAGING_BINDIR}/llvm-config"
-YOCTO_ALTERNATE_LIBDIR:class-target = "${base_libdir}"
+YOCTO_ALTERNATE_EXE_PATH:toolchain-clang:class-target = "${STAGING_BINDIR}/llvm-config"
+YOCTO_ALTERNATE_LIBDIR:toolchain-clang:class-target = "${base_libdir}"
 
-YOCTO_ALTERNATE_EXE_PATH:class-target[export] = "1"
-YOCTO_ALTERNATE_LIBDIR:class-target[export] = "1"
+#YOCTO_ALTERNATE_EXE_PATH:toolchain-clang:class-target[export] = "1"
+#YOCTO_ALTERNATE_LIBDIR:toolchain-clang:class-target[export] = "1"
 
 #DEPENDS:append:toolchain-clang:class-target = " clang-cross-${TARGET_ARCH} "
 #DEPENDS:remove:toolchain-clang:allarch = "clang-cross-${TARGET_ARCH}"

--- a/recipes-devtools/rpm/rpm_%.bbappend
+++ b/recipes-devtools/rpm/rpm_%.bbappend
@@ -3,7 +3,9 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 DEPENDS:append:toolchain-clang = " openmp"
 DEPENDS:remove:toolchain-clang:riscv32 = "openmp"
 DEPENDS:remove:toolchain-clang:mipsarch = "openmp"
+DEPENDS:remove:toolchain-clang:powerpc = "openmp"
 
 # rpm needs OMP
 TOOLCHAIN:riscv32 = "gcc"
 TOOLCHAIN:mipsarch = "gcc"
+TOOLCHAIN:powerpc = "gcc"


### PR DESCRIPTION
openmp is not ported for ppc32

Signed-off-by: Khem Raj <raj.khem@gmail.com>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
