### PR TITLE
bpftrace: Fix build with new libbpf

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-devtools/bpftrace/bpftrace/0001-Detect-new-BTF-api-btf_dump__new-btf_dump__new_v0_6_.patch
+++ b/dynamic-layers/openembedded-layer/recipes-devtools/bpftrace/bpftrace/0001-Detect-new-BTF-api-btf_dump__new-btf_dump__new_v0_6_.patch
@@ -1,0 +1,212 @@
+From c5092eee7dc5f3d28a1de2c33bda6611e9ed9d34 Mon Sep 17 00:00:00 2001
+From: Jiri Olsa <jolsa@kernel.org>
+Date: Tue, 22 Feb 2022 16:36:44 +0100
+Subject: [PATCH] Detect new BTF api btf_dump__new/btf_dump__new_v0_6_0
+
+Some of the libbpf functions we use  got deprecated and
+replaced with new versions.
+
+   btf__get_nr_types to btf__type_cnt
+   btf_dump__new changed arguments
+
+Adding detection of this and making bpftrace to compile
+against latest libbpf.
+
+Upstream-Status: Backport [https://github.com/iovisor/bpftrace/commit/3d451feeddf725d11bb52dfbc49b616724d24fd0]
+
+Signed-off-by: Jiri Olsa <jolsa@kernel.org>
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ CMakeLists.txt         |  8 +++++++
+ cmake/FindLibBpf.cmake | 25 ++++++++++++++++++++
+ src/btf.cpp            | 52 +++++++++++++++++++++++++++---------------
+ 3 files changed, 66 insertions(+), 19 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index c5959732..8a9b0082 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -274,6 +274,14 @@ if (LIBBPF_BTF_DUMP_FOUND)
+   endif()
+ endif(LIBBPF_BTF_DUMP_FOUND)
+ 
++if (HAVE_LIBBPF_BTF_TYPE_CNT)
++	set(BPFTRACE_FLAGS "${BPFTRACE_FLAGS}" HAVE_LIBBPF_BTF_TYPE_CNT)
++endif(HAVE_LIBBPF_BTF_TYPE_CNT)
++
++if (HAVE_LIBBPF_BTF_DUMP_NEW_V0_6_0)
++	set(BPFTRACE_FLAGS "${BPFTRACE_FLAGS}" HAVE_LIBBPF_BTF_DUMP_NEW_V0_6_0)
++endif(HAVE_LIBBPF_BTF_DUMP_NEW_V0_6_0)
++
+ if (LIBDW_FOUND)
+   set(BPFTRACE_FLAGS "${BPFTRACE_FLAGS}" HAVE_LIBDW)
+ endif ()
+diff --git a/cmake/FindLibBpf.cmake b/cmake/FindLibBpf.cmake
+index 86eb8050..b088415f 100644
+--- a/cmake/FindLibBpf.cmake
++++ b/cmake/FindLibBpf.cmake
+@@ -55,4 +55,29 @@ if (LIBBPF_FOUND)
+   check_symbol_exists(bpf_link_create "${LIBBPF_INCLUDE_DIRS}/bpf/bpf.h" HAVE_LIBBPF_LINK_CREATE)
+   SET(CMAKE_REQUIRED_DEFINITIONS)
+   SET(CMAKE_REQUIRED_LIBRARIES)
++
++  INCLUDE(CheckCXXSourceCompiles)
++  SET(CMAKE_REQUIRED_INCLUDES ${LIBBPF_INCLUDE_DIRS})
++  SET(CMAKE_REQUIRED_LIBRARIES ${LIBBPF_LIBRARIES} elf z)
++  CHECK_CXX_SOURCE_COMPILES("
++#include <bpf/btf.h>
++
++int main(void) {
++  btf__type_cnt(NULL);
++  return 0;
++}
++" HAVE_LIBBPF_BTF_TYPE_CNT)
++
++  CHECK_CXX_SOURCE_COMPILES("
++#include <bpf/btf.h>
++
++int main(void) {
++  const struct btf_dump_opts *opts = (const struct btf_dump_opts*) 1;
++
++  btf_dump__new(NULL, NULL, NULL, opts);
++  return 0;
++}
++" HAVE_LIBBPF_BTF_DUMP_NEW_V0_6_0)
++  SET(CMAKE_REQUIRED_INCLUDES)
++  SET(CMAKE_REQUIRED_LIBRARIES)
+ endif()
+diff --git a/src/btf.cpp b/src/btf.cpp
+index 7d83cf68..c08ef17b 100644
+--- a/src/btf.cpp
++++ b/src/btf.cpp
+@@ -28,6 +28,15 @@
+ 
+ namespace bpftrace {
+ 
++static __u32 type_cnt(const struct btf *btf)
++{
++#ifdef HAVE_LIBBPF_BTF_TYPE_CNT
++  return btf__type_cnt(btf);
++#else
++  return btf__get_nr_types(btf);
++#endif
++}
++
+ static unsigned char *get_data(const char *file, ssize_t *sizep)
+ {
+   struct stat st;
+@@ -185,6 +194,21 @@ static void dump_printf(void *ctx, const char *fmt, va_list args)
+   free(str);
+ }
+ 
++static struct btf_dump *dump_new(const struct btf *btf,
++                                 btf_dump_printf_fn_t dump_printf,
++                                 void *ctx)
++{
++#ifdef HAVE_LIBBPF_BTF_DUMP_NEW_V0_6_0
++  return btf_dump__new(btf, dump_printf, ctx, nullptr);
++#else
++  struct btf_dump_opts opts = {
++    .ctx = ctx,
++  };
++
++  return btf_dump__new(btf, nullptr, &opts, dump_printf);
++#endif
++}
++
+ static const char *btf_str(const struct btf *btf, __u32 off)
+ {
+   if (!off)
+@@ -220,12 +244,11 @@ std::string BTF::c_def(const std::unordered_set<std::string> &set) const
+     return std::string("");
+ 
+   std::string ret = std::string("");
+-  struct btf_dump_opts opts = { .ctx = &ret, };
+   struct btf_dump *dump;
+   char err_buf[256];
+   int err;
+ 
+-  dump = btf_dump__new(btf, nullptr, &opts, dump_printf);
++  dump = dump_new(btf, dump_printf, &ret);
+   err = libbpf_get_error(dump);
+   if (err)
+   {
+@@ -235,7 +258,7 @@ std::string BTF::c_def(const std::unordered_set<std::string> &set) const
+   }
+ 
+   std::unordered_set<std::string> myset(set);
+-  __s32 id, max = (__s32) btf__get_nr_types(btf);
++  __s32 id, max = (__s32)type_cnt(btf);
+ 
+   for (id = 1; id <= max && myset.size(); id++)
+   {
+@@ -415,7 +438,7 @@ int BTF::resolve_args(const std::string &func,
+   if (!has_data())
+     throw std::runtime_error("BTF data not available");
+ 
+-  __s32 id, max = (__s32)btf__get_nr_types(btf);
++  __s32 id, max = (__s32)type_cnt(btf);
+   std::string name = func;
+ 
+   for (id = 1; id <= max; id++)
+@@ -486,17 +509,14 @@ int BTF::resolve_args(const std::string &func,
+ 
+ std::unique_ptr<std::istream> BTF::get_all_funcs() const
+ {
+-  __s32 id, max = (__s32)btf__get_nr_types(btf);
++  __s32 id, max = (__s32)type_cnt(btf);
+   std::string type = std::string("");
+-  struct btf_dump_opts opts = {
+-    .ctx = &type,
+-  };
+   struct btf_dump *dump;
+   std::string funcs;
+   char err_buf[256];
+   int err;
+ 
+-  dump = btf_dump__new(btf, nullptr, &opts, dump_printf);
++  dump = dump_new(btf, dump_printf, &type);
+   err = libbpf_get_error(dump);
+   if (err)
+   {
+@@ -545,16 +565,13 @@ std::map<std::string, std::vector<std::string>> BTF::get_params(
+     const std::set<std::string> &funcs) const
+ {
+ #ifdef HAVE_LIBBPF_BTF_DUMP_EMIT_TYPE_DECL
+-  __s32 id, max = (__s32)btf__get_nr_types(btf);
++  __s32 id, max = (__s32)type_cnt(btf);
+   std::string type = std::string("");
+-  struct btf_dump_opts opts = {
+-    .ctx = &type,
+-  };
+   struct btf_dump *dump;
+   char err_buf[256];
+   int err;
+ 
+-  dump = btf_dump__new(btf, nullptr, &opts, dump_printf);
++  dump = dump_new(btf, dump_printf, &type);
+   err = libbpf_get_error(dump);
+   if (err)
+   {
+@@ -639,16 +656,13 @@ std::map<std::string, std::vector<std::string>> BTF::get_params(
+ std::set<std::string> BTF::get_all_structs() const
+ {
+   std::set<std::string> struct_set;
+-  __s32 id, max = (__s32)btf__get_nr_types(btf);
++  __s32 id, max = (__s32)type_cnt(btf);
+   std::string types = std::string("");
+-  struct btf_dump_opts opts = {
+-    .ctx = &types,
+-  };
+   struct btf_dump *dump;
+   char err_buf[256];
+   int err;
+ 
+-  dump = btf_dump__new(btf, nullptr, &opts, dump_printf);
++  dump = dump_new(btf, dump_printf, &types);
+   err = libbpf_get_error(dump);
+   if (err)
+   {
+-- 
+2.36.0
+

--- a/dynamic-layers/openembedded-layer/recipes-devtools/bpftrace/bpftrace_0.14.1.bb
+++ b/dynamic-layers/openembedded-layer/recipes-devtools/bpftrace/bpftrace_0.14.1.bb
@@ -17,7 +17,8 @@ PV .= "+git${SRCREV}"
 RDEPENDS:${PN} += "bash python3 xz"
 
 SRC_URI = "git://github.com/iovisor/bpftrace;branch=master;protocol=https \
-           "
+           file://0001-Detect-new-BTF-api-btf_dump__new-btf_dump__new_v0_6_.patch \
+"
 SRCREV = "0a318e53343aa51f811183534916a4be65a1871e"
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
Fixes
git/src/btf.cpp:651:10: error: no matching function for call to 'btf_dump__new'

Signed-off-by: Khem Raj <raj.khem@gmail.com>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
