### PR TITLE
clang: Upgrade to 14.0.3

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -31,7 +31,7 @@ INHERIT += "clang"
 # Do not include clang in SDK unless user wants to
 CLANGSDK ??= "0"
 
-LLVMVERSION = "14.0.1"
+LLVMVERSION = "14.0.3"
 
 require conf/nonclangable.conf
 require conf/nonscanable.conf

--- a/recipes-devtools/clang/clang.inc
+++ b/recipes-devtools/clang/clang.inc
@@ -6,9 +6,9 @@ LLVM_GIT_PROTOCOL ?= "https"
 
 MAJOR_VER = "14"
 MINOR_VER = "0"
-PATCH_VER = "1"
+PATCH_VER = "3"
 
-SRCREV ?= "ec13fed5867f674bb96ab5502629ec209ef5a73a"
+SRCREV ?= "1f9140064dfbfb0bbda8e51306ea51080b2f7aac"
 
 PV = "${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}"
 BRANCH = "release/14.x"


### PR DESCRIPTION
Brings these changes

* 1f9140064dfb Bump version to 14.0.3
* 2e7e14177186 workflows: Add a test to ensure that the LLVM version is correct
* 0e27d08cdeb3 [RISCV] Fix crash for section alignment with .option norvc
* a36801750327 [asan] Always skip first object from dl_iterate_phdr
* 1f4c7b2a9120 [RISCV] Don't emit fractional VIDs with negative steps
* e19be4195b87 [RISCV] Add another test showing incorrect BUILD_VECTOR lowering
* 9efcce92b55b [RISCV] Fix lowering of BUILD_VECTORs as VID sequences
* 21ce6cfd1d93 [RISCV] Add tests showing incorrect BUILD_VECTOR lowering
* 58d5fbe2c20b [llvm-mt] Add support /notify_update
* 50c6ba751fa2 [RISCV] Only try LUI+SH*ADD+ADDI for int materialization if LUI+ADDI+SH*ADD failed.
* dc30b0d3320d [ELF] --emit-relocs: fix missing STT_SECTION when the first input section is synthetic
* 324127d8da95 [libcxx] Add some missing xlocale wrapper functions for OpenBSD
* ebf29ba9f0a3 [LV] Remove stray debug dump added in 0d2efbb8b82c.
* 0d2efbb8b82c [LV] Always use add to add scalar iv and (startidx + step) for ints.
* e7a9fd4f57d6 [LV] Add test case for PR54427.
* 9a3e81e1f91f [InstCombine] canonicalize select with signbit test
* b83c4a2dc0fb [x86] Fix infinite loop inside DAG combiner with lzcnt feature.
* 0fbe860711be [Clang][Fortify] drop inline decls when redeclared
* 571c7d8f6dae Reland "[llvm][AArch64] Insert "bti j" after call to setjmp"
* 0f56ce0fb207 [DebugInfo][InstrRef] Avoid a crash from mixed variable location modes
* e8f03f2057ee Force GHashCell to be 8-byte-aligned.
* 09fba23d41f7 [compiler-rt] Implement __clear_cache on FreeBSD/powerpc
* 33504b3bbe10 [PowerPC] Allow absolute expressions in relocations
* 3400d0293a14 [CMake] Update cache file for Win to ARM Linux cross toolchain builders. NFC.
* 6c41c8edb0cc [CMake] Replace `TARGET_TRIPLE` with `TOOLCHAIN_TARGET_TRIPLE` for Win-to-Arm cross toolchain cache file. NFC.
* b6dbee34387d [CMake] Update cache file for Win to ARM cross tooolchain. NFC.
* 46d19f3a8699 [CMake] Use CMAKE_SYSROOT to build libs for Win to ARM cross tooolchain. NFC.
* e11b929a3c97 [LLD][COFF] Fix TypeServerSource matcher with more than one collision
* d800180f6bee [lld][COFF] Fix TypeServerSource lookup on GUID collisions
* 8c3445ac1c8b [AArch64][LOH] Don't ignore regmasks in bundles by iterating over instrs.
* 43ee392dd462 [InstCombine] try to fold low-mask of ashr to lshr
* 5ea5e3c01b7b [InstCombine] add tests for low-mask of ashr; NFC
* fe8a27acd716 [LV] Handle zero cost loops in selectInterleaveCount.
* 2c4d288eae8b [RISCV][NFC] Add missing lit.local.cfg in test/CodeGen/MIR/RISCV/
* d0f27fb44952 [RISCV] Fixing stack offset for RVV object with vararg in stack.
* b6e91d4a331e [RISCV] Pre-commit for fixing stack offset for RVV object
* 87599bdabbd1 [RISCV] Store/restore RISCVMachineFunctionInfo into MIR YAML file
* 5c9eed741dbd [libc++] Make __dir_stream visibility declaration consistent
* c62053979489 [AArch64] Fix the upper limit for folded address offsets for COFF
* 6697c5bc3a1e [compiler-rt] [scudo] Use -mcrc32 on x86 when available
* 8475349bd639 [AARCH64] ssbs should be enabled by default for cortex-x1, cortex-x1c, cortex-a77
* d4e3c50b2bda [libc++] Define `namespace views` in its own detail header.

Signed-off-by: Khem Raj <raj.khem@gmail.com>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
