### PR TITLE
clang: Update to 14.0.4+

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -31,7 +31,7 @@ INHERIT += "clang"
 # Do not include clang in SDK unless user wants to
 CLANGSDK ??= "0"
 
-LLVMVERSION = "14.0.3"
+LLVMVERSION = "14.0.5"
 
 require conf/nonclangable.conf
 require conf/nonscanable.conf

--- a/recipes-devtools/clang/clang.inc
+++ b/recipes-devtools/clang/clang.inc
@@ -6,9 +6,9 @@ LLVM_GIT_PROTOCOL ?= "https"
 
 MAJOR_VER = "14"
 MINOR_VER = "0"
-PATCH_VER = "3"
+PATCH_VER = "5"
 
-SRCREV ?= "1f9140064dfbfb0bbda8e51306ea51080b2f7aac"
+SRCREV ?= "b950bd2ce7ff79b203b2acba02e1c468836989ae"
 
 PV = "${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}"
 BRANCH = "release/14.x"


### PR DESCRIPTION
This brings

* b950bd2ce7ff Bump version to 14.0.5
* 29f1039a7285 [CUDA][HIP] Externalize kernels with internal linkage
* e6de9ed37308 [CUDA][HIP] Externalize kernels in anonymous name space
* fecfc8394484 AST: Move __va_list tag back to std conditionally on AArch64.
* 725d57c39039 AST: Make getEffectiveDeclContext() a member function of ItaniumMangleContextImpl. NFCI.
* 0009cdbd8a3a [clang][NFC] Remove IgnoreLinkageSpecDecls
* 53eaee6bf3b3 [clang][NFC] Standard substitution checking cleanup
* c81f3d00cbd4 [AVR] Generate 'rcall' instead of 'call' on avr2 and avr25
* 5f6fe6b93e85 [AVR] Fix incorrect calling convention for varargs functions
* 42fe7ccbeb44 [SystemZ] Bugfix for symbolic displacements.
* f45a01e4a170 [libc++][CI] added XFAIL LIBCXX-AIX-FIXME to new runnning test cases after install locale fileset on AIX OS.
* 55e34f3b49b1 [libc++] Always enable the ranges concepts
* 5f66e721ec1d [ELF][ARM] Fix unneeded thunk for branches to hidden undefined weak
* 3bfae7816bdb Fix crash getting name of a template decl
* 76c1c1dd2a01 [OpenMP] Fix library path missing when using OpenMP
* 588b95a2b88e [ELF][AArch64] Fix unneeded thunk for branches to hidden undefined weak
* e70d79f1e8c0 [ELF] Ignore --no-add-needed
* 7a42b2fd5be3 [BOLT] Compact legacy profiles
* d6319246f89b [CodeGen] Use ABI alignment for C++ new expressions
* daef3113e819 [compiler-rt] Add NO_EXEC_STACK_DIRECTIVE on s390x
* c65b0cd2421d [GlobalIsel] Fix fallback if stack protector isn't supported.
* cda300eab8dd [Driver][Solaris] -r: imply -nostdlib like GCC
* 9827a185b611 [Driver][Ananas] -r: imply -nostdlib like GCC
* 087082a828ff [cmake] Increase -fms-compatibility-version in Windows toolchain file
* c56415735060 [SystemZ] Bugfix in SystemZTargetLowering::combineINT_TO_FP()
* be653f6292e7 [X86] combineX86ShuffleChain - don't fold to truncate(concat(V1,V2)) if it was already a PACK op
* 52528806579b [AArch64] Ampere1 does not support MTE
* 53433dd0b503 [AArch64] Support for Ampere1 core
* c6d56a324ef8 [AArch64] Add native CPU detection for Ampere1
* 60c8e02c9d12 [IPSCCP] Support unfeasible default dests for switch.
* 0108630f8bc5 [InstCombine] Fix scalable-vector bitwise select matching
* 39e909731a11 [InstCombine] add scalable vector test for logical select; NFC
* cd597588217a [HIP] Fix HIP include path
* 50d4a84152c6 Fix test for c7ee0b8bda8b32a800bc01e9151b364446a6e1b1
* 869c1d7d0902 [Clang] Fix the guaranteed alignment of memory returned by malloc/new on OpenBSD
* 5c4cf01f47da [Driver][Linux] Remove D.Dir+"/../lib" from default search paths for LLVM_ENABLE_RUNTIMES builds
* f3f90ec42ae6 [MC][ELF] Improve st_size propagation rule
* 9ed930e5cd74 [MC][test] Improve offset.s
* 5eb22621bcd2 Bump version to 14.0.4
* 019d4f1ceb96 [libc++abi] Remove XFAIL on arm64

Signed-off-by: Khem Raj <raj.khem@gmail.com>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
