### PR TITLE
spirv-llvm-translator: Update for branch rename

### DIFF
--- a/recipes-devtools/spirv-llvm-translator/spirv-llvm-translator_git.bb
+++ b/recipes-devtools/spirv-llvm-translator/spirv-llvm-translator_git.bb
@@ -1,7 +1,7 @@
 LICENSE = "NCSA"
 LIC_FILES_CHKSUM = "file://LICENSE.TXT;md5=47e311aa9caedd1b3abf098bd7814d1d"
 
-BRANCH = "master"
+BRANCH = "main"
 SRC_URI = "git://github.com/KhronosGroup/SPIRV-LLVM-Translator;protocol=https;branch=${BRANCH} \
            git://github.com/KhronosGroup/SPIRV-Headers;protocol=https;destsuffix=git/SPIRV-Headers;name=headers;branch=master \
           "


### PR DESCRIPTION
"master" branch in SPIRV-LLVM-Translator has been renamed to "main"

see https://github.com/KhronosGroup/SPIRV-LLVM-Translator/commit/6db0f312c918bba14a731822b38a18726bb4ce09

Signed-off-by: Teoh Jay Shen <jay.shen.teoh@intel.com>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
