### PR TITLE
clang: Update to 14.0.6

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -31,7 +31,7 @@ INHERIT += "clang"
 # Do not include clang in SDK unless user wants to
 CLANGSDK ??= "0"
 
-LLVMVERSION = "14.0.5"
+LLVMVERSION = "14.0.6"
 
 require conf/nonclangable.conf
 require conf/nonscanable.conf

--- a/recipes-devtools/clang/clang.inc
+++ b/recipes-devtools/clang/clang.inc
@@ -6,9 +6,9 @@ LLVM_GIT_PROTOCOL ?= "https"
 
 MAJOR_VER = "14"
 MINOR_VER = "0"
-PATCH_VER = "5"
+PATCH_VER = "6"
 
-SRCREV ?= "b950bd2ce7ff79b203b2acba02e1c468836989ae"
+SRCREV ?= "f28c006a5895fc0e329fe15fead81e37457cb1d1"
 
 PV = "${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}"
 BRANCH = "release/14.x"


### PR DESCRIPTION
Bring in following changes

* f28c006a5895 Bump version to 14.0.6
* aa586b6f5f55 [clang][AVR] Implement standard calling convention for AVR and AVRTiny
* ec42d3c069c7 [AVR] Add more devices
* c12386ae247c [MC][AArch64] Enable '+v8a' when nothing specified for MCSubtargetInfo
* 4d5dad43b2eb [analyzer] Fix null pointer deref in CastValueChecker
* 5b296385298f PR45879: Fix assert when constant evaluating union assignment.
* deb573739df9 [clang-tidy] `bugprone-use-after-move`: Fix handling of moves in lambda captures
* d0cd5a872f8d [clang-format] Fix SpacesInLineCommentPrefix deleting tokens.
* 3cd9df8443f8 [clang-format] Fix PointerAlignment: Right not working with tab indentation.
* d350783a0520 [LoopIdiom] Merge TBAA of adjacent stores when creating memset
* 198626ad43fd [MIPS] Address instruction selection failure for abs.[sd]
* b75bf750fdc2 [LoopIdiom] Fix bailout for aliasing in memcpy transform.
* 2e857fe6e390 [ARM] Fix MVE getShuffleCost legalized type check
* a517f3439671 [Support] Add missing <cstdint> header to Base64.h
* 4d039a7a7189 [Support] Add missing <cstdint> header to Signals.h
* 483db58f3eb5 compiler-rt: Allow build without __c11_atomic_fetch_nand
* 576e5b39ae4d [clang-tidy] Fix #55134 (regression introduced by 5da7c04)
* 99b5eb2d3a61 [Local] Don't remove invoke of non-willreturn function
* 885724c60cdc [SimplifyCFG] Add test for invoke of nounwind non-willreturn function (NFC)
* 2f0a69c32a4c [OpenMP] Fix partial unrolling off-by-one.
* 79147e4722cc [clang][CUDA][Windows] Fix compilation error on Windows with `uint32_t __nvvm_get_smem_pointer`
* ec0332328bd6 [clang] Fix some clang->llvm type cache invalidation issues
* 10d442522b1a [clang][AVR] Implement standard calling convention for AVR and AVRTiny
* 09ec80e16f47 [PowerPC] Treat llvm.fmuladd intrinsic as using CTR

Signed-off-by: Khem Raj <raj.khem@gmail.com>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
