### PR TITLE
clang: Build float128 soft float builtins for x86_64

### DIFF
--- a/recipes-devtools/clang/clang/0037-builtins-Build-float128-soft-float-builtins-for-x86_.patch
+++ b/recipes-devtools/clang/clang/0037-builtins-Build-float128-soft-float-builtins-for-x86_.patch
@@ -1,0 +1,115 @@
+From 99238fd5a0cd7179daa1f62228e437ede535a228 Mon Sep 17 00:00:00 2001
+From: Jose Quaresma <jose.quaresma@foundries.io>
+Date: Tue, 28 Jun 2022 14:34:34 +0000
+Subject: [PATCH] [builtins] Build float128 soft float builtins for x86_64.
+
+float128 builtins are currently not built for x86_64.
+This causes linker to complain baout missing symbols when linking
+glibc 2.27 with float128 support.
+
+Upstream-Status: Submitted [https://reviews.llvm.org/D53608]
+
+Signed-off-by: Jose Quaresma <jose.quaresma@foundries.io>
+---
+ compiler-rt/lib/builtins/extendhftf2.c | 4 +---
+ compiler-rt/lib/builtins/fp_lib.h      | 7 ++++++-
+ compiler-rt/lib/builtins/powitf2.c     | 4 ++--
+ compiler-rt/lib/builtins/trunctfdf2.c  | 2 +-
+ compiler-rt/lib/builtins/trunctfhf2.c  | 4 +---
+ compiler-rt/lib/builtins/trunctfsf2.c  | 2 +-
+ 6 files changed, 12 insertions(+), 11 deletions(-)
+
+diff --git a/compiler-rt/lib/builtins/extendhftf2.c b/compiler-rt/lib/builtins/extendhftf2.c
+index aefe9737d34f..0240380657ff 100644
+--- a/compiler-rt/lib/builtins/extendhftf2.c
++++ b/compiler-rt/lib/builtins/extendhftf2.c
+@@ -16,8 +16,6 @@
+ #define DST_QUAD
+ #include "fp_extend_impl.inc"
+ 
+-COMPILER_RT_ABI long double __extendhftf2(_Float16 a) {
+-  return __extendXfYf2__(a);
+-}
++COMPILER_RT_ABI fp_t __extendhftf2(_Float16 a) { return __extendXfYf2__(a); }
+ 
+ #endif
+diff --git a/compiler-rt/lib/builtins/fp_lib.h b/compiler-rt/lib/builtins/fp_lib.h
+index 3fb13a033a14..28935113dd5c 100644
+--- a/compiler-rt/lib/builtins/fp_lib.h
++++ b/compiler-rt/lib/builtins/fp_lib.h
+@@ -105,12 +105,17 @@ static __inline void wideMultiply(rep_t a, rep_t b, rep_t *hi, rep_t *lo) {
+ COMPILER_RT_ABI fp_t __adddf3(fp_t a, fp_t b);
+ 
+ #elif defined QUAD_PRECISION
+-#if __LDBL_MANT_DIG__ == 113 && defined(__SIZEOF_INT128__)
++#if (__LDBL_MANT_DIG__ == 113 || defined(__x86_64__)) &&                       \
++    defined(__SIZEOF_INT128__)
+ #define CRT_LDBL_128BIT
+ typedef uint64_t half_rep_t;
+ typedef __uint128_t rep_t;
+ typedef __int128_t srep_t;
++#if defined(__FLOAT128__) || defined(__SIZEOF_FLOAT128__)
++typedef __float128 fp_t;
++#else
+ typedef long double fp_t;
++#endif
+ #define HALF_REP_C UINT64_C
+ #define REP_C (__uint128_t)
+ // Note: Since there is no explicit way to tell compiler the constant is a
+diff --git a/compiler-rt/lib/builtins/powitf2.c b/compiler-rt/lib/builtins/powitf2.c
+index 8e639a03a3c4..2ba158900923 100644
+--- a/compiler-rt/lib/builtins/powitf2.c
++++ b/compiler-rt/lib/builtins/powitf2.c
+@@ -17,9 +17,9 @@
+ 
+ // Returns: a ^ b
+ 
+-COMPILER_RT_ABI long double __powitf2(long double a, int b) {
++COMPILER_RT_ABI fp_t __powitf2(fp_t a, int b) {
+   const int recip = b < 0;
+-  long double r = 1;
++  fp_t r = 1;
+   while (1) {
+     if (b & 1)
+       r *= a;
+diff --git a/compiler-rt/lib/builtins/trunctfdf2.c b/compiler-rt/lib/builtins/trunctfdf2.c
+index 6857ea54d8a5..2f35ecc8a287 100644
+--- a/compiler-rt/lib/builtins/trunctfdf2.c
++++ b/compiler-rt/lib/builtins/trunctfdf2.c
+@@ -14,6 +14,6 @@
+ #define DST_DOUBLE
+ #include "fp_trunc_impl.inc"
+ 
+-COMPILER_RT_ABI double __trunctfdf2(long double a) { return __truncXfYf2__(a); }
++COMPILER_RT_ABI double __trunctfdf2(fp_t a) { return __truncXfYf2__(a); }
+ 
+ #endif
+diff --git a/compiler-rt/lib/builtins/trunctfhf2.c b/compiler-rt/lib/builtins/trunctfhf2.c
+index e3a2309d954b..cd56e0c70dc1 100644
+--- a/compiler-rt/lib/builtins/trunctfhf2.c
++++ b/compiler-rt/lib/builtins/trunctfhf2.c
+@@ -16,8 +16,6 @@
+ #define DST_HALF
+ #include "fp_trunc_impl.inc"
+ 
+-COMPILER_RT_ABI _Float16 __trunctfhf2(long double a) {
+-  return __truncXfYf2__(a);
+-}
++COMPILER_RT_ABI _Float16 __trunctfhf2(fp_t a) { return __truncXfYf2__(a); }
+ 
+ #endif
+diff --git a/compiler-rt/lib/builtins/trunctfsf2.c b/compiler-rt/lib/builtins/trunctfsf2.c
+index 0261b1e90f5d..f08f0644b1f6 100644
+--- a/compiler-rt/lib/builtins/trunctfsf2.c
++++ b/compiler-rt/lib/builtins/trunctfsf2.c
+@@ -14,6 +14,6 @@
+ #define DST_SINGLE
+ #include "fp_trunc_impl.inc"
+ 
+-COMPILER_RT_ABI float __trunctfsf2(long double a) { return __truncXfYf2__(a); }
++COMPILER_RT_ABI float __trunctfsf2(fp_t a) { return __truncXfYf2__(a); }
+ 
+ #endif
+-- 
+2.34.1
+

--- a/recipes-devtools/clang/common.inc
+++ b/recipes-devtools/clang/common.inc
@@ -46,6 +46,7 @@ SRC_URI = "\
     file://0034-clang-exclude-openembedded-distributions-from-settin.patch \
     file://0035-compiler-rt-Enable-__int128-for-ppc32.patch \
     file://0036-compiler-rt-builtins-Move-DMB-definition-to-syn-opsh.patch \
+    file://0037-builtins-Build-float128-soft-float-builtins-for-x86_.patch \
     "
 # Fallback to no-PIE if not set
 GCCPIE ??= ""


### PR DESCRIPTION
Signed-off-by: Jose Quaresma <jose.quaresma@foundries.io>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
