### PR TITLE
Revert "python3: Use gcc for riscv/aarch64 and all musl"

### DIFF
--- a/conf/nonclangable.conf
+++ b/conf/nonclangable.conf
@@ -98,8 +98,6 @@ TOOLCHAIN:pn-pseudo = "gcc"
 TOOLCHAIN:pn-python3:riscv64 = "gcc"
 TOOLCHAIN:pn-python3:riscv32 = "gcc"
 TOOLCHAIN:pn-python3:libc-musl = "gcc"
-# Use until OE-core merges https://lists.openembedded.org/g/openembedded-core/message/164192
-TOOLCHAIN:pn-python3:aarch64 = "gcc"
 
 # mix_neon.c:179:9: error: invalid operand in inline asm: 'vld1.s32 ${0:h}, [$2]
 #      vld1.s32 ${1:h}, [$3] '


### PR DESCRIPTION
This reverts commit 3882c27310b16e6fc097cca1966cea591769cc5c.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
