### PR TITLE
toolchain-clang: Specify -ffile-compilation-dir to omit absolute file…

### DIFF
--- a/classes/clang.bbclass
+++ b/classes/clang.bbclass
@@ -60,6 +60,8 @@ TUNE_CCARGS:append:toolchain-clang:libc-musl:powerpc = " -mlong-double-64"
 TUNE_CCARGS:append:toolchain-clang = "${@bb.utils.contains("DISTRO_FEATURES", "usrmerge", " --dyld-prefix=/usr", "", d)}"
 
 TUNE_CCARGS:append:toolchain-clang = " -Qunused-arguments"
+# Get rid of absolute paths in .file asm directive
+TUNE_CCARGS:append:toolchain-clang = " -ffile-compilation-dir=."
 
 LDFLAGS:append:toolchain-clang:class-nativesdk:x86-64 = " -Wl,-dynamic-linker,${base_libdir}/ld-linux-x86-64.so.2"
 LDFLAGS:append:toolchain-clang:class-nativesdk:x86 = " -Wl,-dynamic-linker,${base_libdir}/ld-linux.so.2"


### PR DESCRIPTION
… paths in debug info

Clang does not remap the src filename in asm files debug info when using
-fdebug-prefix-map but gcc does [1], however, there is an option to help
reproducibility with clang namely ffile-compilation-dir to remove the
source directory from path. use it globally with clang compiler

[1] https://github.com/llvm/llvm-project/issues/56609
Signed-off-by: Khem Raj <raj.khem@gmail.com>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
