### PR TITLE
libcxx: Enable installing libc++.so as linker script

### DIFF
--- a/classes-recipe/clang-native.bbclass
+++ b/classes-recipe/clang-native.bbclass
@@ -1,0 +1,23 @@
+# inherit this class if you would like to use clang to compile the native
+# version of your recipes instead of system compiler ( which is normally gcc )
+# on build machines
+# to use it add
+#
+# inherit clang-native
+#
+# to the concerned recipe via a bbappend or directly to recipe file
+#
+DEPENDS:append:runtime-llvm = " clang-native compiler-rt-native libcxx-native"
+# Use libcxx headers for native parts
+CXXFLAGS:append:runtime-llvm = " -stdlib=libc++"
+BUILD_CXXFLAGS:append:runtime-llvm = " -isysroot=${STAGING_DIR_NATIVE} -stdlib=libc++"
+# Use libgcc for native parts
+LDFLAGS:append:runtime-llvm = " -stdlib=libc++ -rtlib=libgcc -unwindlib=libgcc"
+BUILD_LDFLAGS:append:runtime-llvm = " -stdlib=libc++ -rtlib=libgcc -unwindlib=libgcc"
+BUILD_CC:runtime-llvm  = "${CCACHE}clang -isysroot=${STAGING_DIR_NATIVE}"
+BUILD_CXX:runtime-llvm = "${CCACHE}clang++ -isysroot=${STAGING_DIR_NATIVE}"
+BUILD_CPP:runtime-llvm = "${CCACHE}clang -isysroot=${STAGING_DIR_NATIVE} -E"
+BUILD_CCLD:runtime-llvm = "${CCACHE}clang"
+BUILD_RANLIB:runtime-llvm = "llvm-ranlib"
+BUILD_AR:runtime-llvm = "llvm-ar"
+BUILD_NM:runtime-llvm = "llvm-nm"

--- a/classes/clang.bbclass
+++ b/classes/clang.bbclass
@@ -10,7 +10,7 @@ AR:toolchain-clang = "${HOST_PREFIX}llvm-ar"
 NM:toolchain-clang = "${HOST_PREFIX}llvm-nm"
 OBJDUMP:toolchain-clang = "${HOST_PREFIX}llvm-objdump"
 OBJCOPY:toolchain-clang = "${HOST_PREFIX}llvm-objcopy"
-STRIP:toolchain-clang = "${HOST_PREFIX}llvm-strip"
+#STRIP:toolchain-clang = "${HOST_PREFIX}llvm-strip"
 STRINGS:toolchain-clang = "${HOST_PREFIX}llvm-strings"
 READELF:toolchain-clang = "${HOST_PREFIX}llvm-readelf"
 

--- a/recipes-bsp/systemd-boot/systemd-boot_%.bbappend
+++ b/recipes-bsp/systemd-boot/systemd-boot_%.bbappend
@@ -1,4 +1,0 @@
-do_configure:append:toolchain-clang() {
-	export EFI_CC="${CC}"
-	sed -i -e "s#O0#O#g" ${S}/src/boot/efi/meson.build
-}

--- a/recipes-core/systemd/systemd_%.bbappend
+++ b/recipes-core/systemd/systemd_%.bbappend
@@ -1,0 +1,7 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+# systemd 251.4 started to cause boot issues see
+# https://bugzilla.yoctoproject.org/show_bug.cgi?id=14906
+# As a workaround disable O2 and use Os for now with clang
+SELECTED_OPTIMIZATION:append:toolchain-clang = "-Os"
+SELECTED_OPTIMIZATION:remove:toolchain-clang = "-O2"

--- a/recipes-devtools/clang/libcxx_git.bb
+++ b/recipes-devtools/clang/libcxx_git.bb
@@ -75,10 +75,8 @@ EXTRA_OECMAKE:append:class-target = " \
                   -DCMAKE_RANLIB=${STAGING_BINDIR_TOOLCHAIN}/${RANLIB} \
                   -DLLVM_DEFAULT_TARGET_TRIPLE=${HOST_SYS} \
 "
-EXTRA_OECMAKE:append:class-native = " -DLIBCXX_ENABLE_ABI_LINKER_SCRIPT=OFF \
-"
 
-EXTRA_OECMAKE:append:class-nativesdk = " -DLIBCXX_ENABLE_ABI_LINKER_SCRIPT=OFF \
+EXTRA_OECMAKE:append:class-nativesdk = " \
                   -DCMAKE_AR=${STAGING_BINDIR_TOOLCHAIN}/${AR} \
                   -DCMAKE_NM=${STAGING_BINDIR_TOOLCHAIN}/${NM} \
                   -DCMAKE_RANLIB=${STAGING_BINDIR_TOOLCHAIN}/${RANLIB} \

--- a/recipes-devtools/rust/rust-llvm_%.bbappend
+++ b/recipes-devtools/rust/rust-llvm_%.bbappend
@@ -1,0 +1,3 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+inherit clang-native

--- a/recipes-devtools/rust/rust_%.bbappend
+++ b/recipes-devtools/rust/rust_%.bbappend
@@ -1,0 +1,4 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+inherit clang-native
+


### PR DESCRIPTION
This ensures that -stdlib=libc++ option works as expected
by adding both -lc++ -c++abi to linker command in sequence

Signed-off-by: Khem Raj <raj.khem@gmail.com>
