### PR TITLE
bpftrace: Fix segfault when btf__type_by_id returns NULL

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-devtools/bpftrace/bpftrace/0001-Fix-segfault-when-btf__type_by_id-returns-NULL.patch
+++ b/dynamic-layers/openembedded-layer/recipes-devtools/bpftrace/bpftrace/0001-Fix-segfault-when-btf__type_by_id-returns-NULL.patch
@@ -1,0 +1,131 @@
+From 38c099dff9100bafeaaa7cee865f4dfda58134ac Mon Sep 17 00:00:00 2001
+From: Youlin Feng <fengyoulin@live.com>
+Date: Sat, 7 May 2022 18:50:25 +0800
+Subject: [PATCH] Fix segfault when btf__type_by_id returns NULL
+
+Upstream-Status: Backport [https://github.com/iovisor/bpftrace/commit/38c099dff9100bafeaaa7cee865f4dfda58134ac]
+
+Signed-off-by: Michal Wojcik <michal.wojcik@linaro.org>
+---
+ src/btf.cpp | 28 ++++++++++++++++++++++++----
+ 1 file changed, 24 insertions(+), 4 deletions(-)
+
+diff --git a/src/btf.cpp b/src/btf.cpp
+index 33bbb7ba..20ee6598 100644
+--- a/src/btf.cpp
++++ b/src/btf.cpp
+@@ -263,6 +263,9 @@ std::string BTF::c_def(const std::unordered_set<std::string> &set) const
+   for (id = 1; id <= max && myset.size(); id++)
+   {
+     const struct btf_type *t = btf__type_by_id(btf, id);
++    if (!t)
++      continue;
++
+     // Allow users to reference enum values by name to pull in entire enum defs
+     if (btf_is_enum(t))
+     {
+@@ -306,6 +309,8 @@ std::string BTF::type_of(const std::string& name, const std::string& field)
+     return std::string("");
+ 
+   const struct btf_type *type = btf__type_by_id(btf, type_id);
++  if (!type)
++    return std::string("");
+   return type_of(type, field);
+ }
+ 
+@@ -334,6 +339,8 @@ std::string BTF::type_of(const btf_type *type, const std::string &field)
+     if (m_name == "")
+     {
+       const struct btf_type *type = btf__type_by_id(btf, m[i].type);
++      if (!type)
++        return std::string("");
+       std::string type_name = type_of(type, field);
+       if (!type_name.empty())
+         return type_name;
+@@ -354,6 +361,8 @@ std::string BTF::type_of(const btf_type *type, const std::string &field)
+            BTF_INFO_KIND(f->info) == BTF_KIND_RESTRICT)
+     {
+       f = btf__type_by_id(btf, f->type);
++      if (!f)
++        return std::string("");
+     }
+ 
+     return full_type_str(btf, f);
+@@ -387,7 +396,7 @@ static bool btf_type_is_modifier(const struct btf_type *t)
+ 
+ const struct btf_type *BTF::btf_type_skip_modifiers(const struct btf_type *t)
+ {
+-  while (btf_type_is_modifier(t))
++  while (t && btf_type_is_modifier(t))
+   {
+     t = btf__type_by_id(btf, t->type);
+   }
+@@ -445,6 +454,9 @@ int BTF::resolve_args(const std::string &func,
+   {
+     const struct btf_type *t = btf__type_by_id(btf, id);
+ 
++    if (!t)
++      continue;
++
+     if (!btf_is_func(t))
+       continue;
+ 
+@@ -454,7 +466,7 @@ int BTF::resolve_args(const std::string &func,
+       continue;
+ 
+     t = btf__type_by_id(btf, t->type);
+-    if (!btf_is_func_proto(t))
++    if (!t || !btf_is_func_proto(t))
+     {
+       throw std::runtime_error("not a function");
+     }
+@@ -529,6 +541,9 @@ std::unique_ptr<std::istream> BTF::get_all_funcs() const
+   {
+     const struct btf_type *t = btf__type_by_id(btf, id);
+ 
++    if (!t)
++      continue;
++
+     if (!btf_is_func(t))
+       continue;
+ 
+@@ -536,7 +551,7 @@ std::unique_ptr<std::istream> BTF::get_all_funcs() const
+     std::string func_name = str;
+ 
+     t = btf__type_by_id(btf, t->type);
+-    if (!btf_is_func_proto(t))
++    if (!t || !btf_is_func_proto(t))
+     {
+       /* bad.. */
+       if (!bt_verbose)
+@@ -585,6 +600,9 @@ std::map<std::string, std::vector<std::string>> BTF::get_params(
+   {
+     const struct btf_type *t = btf__type_by_id(btf, id);
+ 
++    if (!t)
++      continue;
++
+     if (!btf_is_func(t))
+       continue;
+ 
+@@ -595,6 +613,8 @@ std::map<std::string, std::vector<std::string>> BTF::get_params(
+       continue;
+ 
+     t = btf__type_by_id(btf, t->type);
++    if (!t)
++      continue;
+ 
+     _Pragma("GCC diagnostic push")
+         _Pragma("GCC diagnostic ignored \"-Wmissing-field-initializers\"")
+@@ -675,7 +695,7 @@ std::set<std::string> BTF::get_all_structs() const
+   {
+     const struct btf_type *t = btf__type_by_id(btf, id);
+ 
+-    if (!(btf_is_struct(t) || btf_is_union(t) || btf_is_enum(t)))
++    if (!t || !(btf_is_struct(t) || btf_is_union(t) || btf_is_enum(t)))
+       continue;
+ 
+     const std::string name = full_type_str(btf, t);
+-- 
+2.34.1
+

--- a/dynamic-layers/openembedded-layer/recipes-devtools/bpftrace/bpftrace_0.14.1.bb
+++ b/dynamic-layers/openembedded-layer/recipes-devtools/bpftrace/bpftrace_0.14.1.bb
@@ -18,6 +18,7 @@ RDEPENDS:${PN} += "bash python3 xz"
 
 SRC_URI = "git://github.com/iovisor/bpftrace;branch=master;protocol=https \
            file://0001-Detect-new-BTF-api-btf_dump__new-btf_dump__new_v0_6_.patch \
+           file://0001-Fix-segfault-when-btf__type_by_id-returns-NULL.patch \
 "
 SRCREV = "0a318e53343aa51f811183534916a4be65a1871e"
 


### PR DESCRIPTION
Fixes segfault when running i.e. bpftrace -l

Signed-off-by: Michal Wojcik <michal.wojcik@linaro.org>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
