### PR TITLE
bpftrace: Add ptest support (kirkstone)

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-devtools/bpftrace/bpftrace/run-ptest
+++ b/dynamic-layers/openembedded-layer/recipes-devtools/bpftrace/bpftrace/run-ptest
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+# The whole test suite may take up to 40 minutes to run, so setting -t 2400
+# parameter in ptest-runner is necessary to not kill it before completion
+
+cd tests
+export BPFTRACE_RUNTIME_TEST_EXECUTABLE=/usr/bin
+
+PASS_CNT=0
+FAIL_CNT=0
+SKIP_CNT=0
+FAILED=()
+
+# Start unit tests
+for test_case in $(./bpftrace_test --gtest_list_tests | grep -v "^ "); do
+    if ./bpftrace_test --gtest_filter="${test_case}*" > /dev/null 2>&1 ; then
+        echo PASS: Unit test $test_case
+        PASS_CNT=$(($PASS_CNT + 1))
+    else
+        echo FAIL: Unit test $test_case
+        FAIL_CNT=$(($FAIL_CNT + 1))
+        FAILED+=("unit:${test_case}")
+    fi
+done
+
+# Start runtime tests
+for test_case in $(ls runtime); do
+    # Ignore test cases that hang the suite forever (bpftrace v0.16.0)
+    case $test_case in
+        sigint)
+            ;&
+        watchpoint)
+            echo SKIP: Runtime test $test_case
+            SKIP_CNT=$(($SKIP_CNT + 1))
+            continue
+            ;;
+    esac
+    if ./runtime-tests.sh --filter="${test_case}.*" > /dev/null 2>&1 ; then
+        echo PASS: Runtime test $test_case
+        PASS_CNT=$(($PASS_CNT + 1))
+    else
+        echo FAIL: Runtime test $test_case
+        FAIL_CNT=$(($FAIL_CNT + 1))
+        FAILED+=("runtime:${test_case}")
+    fi
+done
+
+echo "#### bpftrace tests summary ####"
+echo "# TOTAL: $(($PASS_CNT + $FAIL_CNT + $SKIP_CNT))"
+echo "# PASS:  $PASS_CNT"
+echo "# FAIL:  $FAIL_CNT (${FAILED[*]})"
+echo "# SKIP:  $SKIP_CNT"
+echo "################################"

--- a/dynamic-layers/openembedded-layer/recipes-devtools/bpftrace/bpftrace_0.14.1.bb
+++ b/dynamic-layers/openembedded-layer/recipes-devtools/bpftrace/bpftrace_0.14.1.bb
@@ -12,19 +12,29 @@ DEPENDS += "bison-native \
             libcereal \
             libbpf \
             "
+DEPENDS += "${@bb.utils.contains('PTEST_ENABLED', '1', 'gtest xxd-native', '', d)}"
 
 PV .= "+git${SRCREV}"
 RDEPENDS:${PN} += "bash python3 xz"
+RDEPENDS:${PN}-ptest += "bash"
 
 SRC_URI = "git://github.com/iovisor/bpftrace;branch=master;protocol=https \
            file://0001-Detect-new-BTF-api-btf_dump__new-btf_dump__new_v0_6_.patch \
            file://0001-Fix-segfault-when-btf__type_by_id-returns-NULL.patch \
+           file://run-ptest \
 "
 SRCREV = "0a318e53343aa51f811183534916a4be65a1871e"
 
 S = "${WORKDIR}/git"
 
-inherit cmake
+inherit cmake ptest
+
+do_install_ptest() {
+    install -d ${D}${PTEST_PATH}/tests
+    install -m 755 ${B}/tests/bpftrace_test ${D}${PTEST_PATH}/tests
+    cp -rf ${B}/tests/runtime* ${D}${PTEST_PATH}/tests
+    cp -rf ${B}/tests/test* ${D}${PTEST_PATH}/tests
+}
 
 def llvm_major_version(d):
     pvsplit = d.getVar('LLVMVERSION').split('.')
@@ -36,9 +46,9 @@ EXTRA_OECMAKE = " \
     -DCMAKE_ENABLE_EXPORTS=1 \
     -DCMAKE_BUILD_TYPE=Release \
     -DLLVM_REQUESTED_VERSION=${LLVM_MAJOR_VERSION} \
-    -DBUILD_TESTING=OFF \
     -DENABLE_MAN=OFF \
 "
+EXTRA_OECMAKE += "${@bb.utils.contains('PTEST_ENABLED', '1', '-DBUILD_TESTING=ON', '-DBUILD_TESTING=OFF', d)}"
 
 COMPATIBLE_HOST = "(x86_64.*|aarch64.*|powerpc64.*|riscv64.*)-linux"
 COMPATIBLE_HOST:libc-musl = "null"


### PR DESCRIPTION
Hi @kraj. I'd like to introduce ptest support for bpftrace and I'd like to hear your comments.

I had to start with kirkstone branch, because currently on master `bpftrace -info` segfaults (after 0.16.0 upgrade), so starting any test is not possible (I'll be working on that later).

Currently not all tests are passing, but it should be a good starting point to fix them. I also had to disable two runtime test suites as they hanged whole suite forever.

All tests may take up to 30 minutes, so running it with `ptest-runner -t 1800 bpftrace` is recommended.

Here is the ptest output this code produces:
```
root@qemuarm64:/# ptest-runner -t 1800 bpftrace
START: ptest-runner
2022-09-16T13:32
BEGIN: /usr/lib/bpftrace/ptest
PASS: Unit test ast.
PASS: Unit test bpftrace.
PASS: Unit test bpftrace_btf.
PASS: Unit test childproc.
FAIL: Unit test clang_parser.
PASS: Unit test clang_parser_btf.
PASS: Unit test LogStream.
PASS: Unit test Log.
PASS: Unit test Parser.
PASS: Unit test semantic_analyser.
PASS: Unit test portability_analyser.
PASS: Unit test portability_analyser_btf.
PASS: Unit test procmon.
PASS: Unit test probe.
PASS: Unit test probe_btf.
PASS: Unit test required_resources.
PASS: Unit test semantic_analyser_btf.
PASS: Unit test semantic_analyser_dwarf.
PASS: Unit test tracepoint_format_parser.
PASS: Unit test utils.
PASS: Runtime test addrspace
FAIL: Runtime test array
PASS: Runtime test banned_probes
PASS: Runtime test basic
PASS: Runtime test btf
PASS: Runtime test builtin
FAIL: Runtime test call
PASS: Runtime test complex_types
FAIL: Runtime test dwarf
PASS: Runtime test engine
PASS: Runtime test file-output
PASS: Runtime test intcast
FAIL: Runtime test intptrcast
FAIL: Runtime test json-output
PASS: Runtime test other
PASS: Runtime test outputs
PASS: Runtime test pointers
PASS: Runtime test precedence
FAIL: Runtime test probe
FAIL: Runtime test regression
PASS: Runtime test scripts
PASS: Runtime test signed_ints
PASS: Runtime test struct
PASS: Runtime test tuples
FAIL: Runtime test uprobe
FAIL: Runtime test usdt
FAIL: Runtime test variable
DURATION: 1525
END: /usr/lib/bpftrace/ptest
2022-09-16T13:57
STOP: ptest-runner
TOTAL: 1 FAIL: 0
```

I'll be offline for the next week, so unfortunately I won't be able to answer your comments sooner.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
