### PR TITLE
compiler-rt-sanitizers: fix multiple installations for orc lib

### DIFF
--- a/recipes-devtools/clang/compiler-rt-sanitizers_git.bb
+++ b/recipes-devtools/clang/compiler-rt-sanitizers_git.bb
@@ -65,7 +65,8 @@ do_install:append () {
         rmdir --ignore-fail-on-non-empty ${D}${libdir}
     fi
     # Already shipped with compile-rt Orc support
-    rm -rf ${D}${nonarch_libdir}/clang/${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}/lib/linux/libclang_rt.orc-x86_64.a
+    rm -rf ${D}${nonarch_libdir}/clang/${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}/lib/linux/libclang_rt.orc-*.a
+    rm -rf ${D}${nonarch_libdir}/clang/${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}/include/orc/
 }
 
 FILES_SOLIBSDEV = ""


### PR DESCRIPTION
Remove libclang_rt.orc and c_orc.h header since it is being installed by both compiler-rt and compiler-rt-sanitizer when built for arm.

While building for a custom test recipe ` test-sanitizer-1.0-r0`  inheriting clang and compiler-rt-sanitizer:


`ERROR: test-sanitizer-1.0-r0 do_prepare_recipe_sysroot: The file /usr/lib/clang/15.0.1/lib/linux/libclang_rt.orc-armhf.a is installed by both compiler-rt and compiler-rt-sanitizers, aborting `

`ERROR: test-sanitizer-1.0-r0 do_prepare_recipe_sysroot: The file /usr/lib/clang/15.0.1/include/orc/c_api.h is installed by both compiler-rt and compiler-rt-sanitizers, aborting `

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
