### PR TITLE
bpftrace: Upgrade package to latest master (a277ec4)

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-devtools/bpftrace/bpftrace_0.16.0.bb
+++ b/dynamic-layers/openembedded-layer/recipes-devtools/bpftrace/bpftrace_0.16.0.bb
@@ -17,7 +17,7 @@ PV .= "+git${SRCREV}"
 RDEPENDS:${PN} += "bash python3 xz"
 
 SRC_URI = "git://github.com/iovisor/bpftrace;branch=master;protocol=https"
-SRCREV = "475ad59c48ba3a85bb58283ea24d41f94d8d8ed6"
+SRCREV = "a277ec42102c463d656df8f64eb2f7e87e322210"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Include segfault workaround for LLVM 15 OpaquePointers (a277ec4).

Signed-off-by: Michal Wojcik <michal.wojcik@linaro.org>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
