### PR TITLE
bpftrace: Add ptest support

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-devtools/bpftrace/bpftrace/run-ptest
+++ b/dynamic-layers/openembedded-layer/recipes-devtools/bpftrace/bpftrace/run-ptest
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+# The whole test suite may take up to 40 minutes to run, so setting -t 2400
+# parameter in ptest-runner is necessary to not kill it before completion
+
+cd tests
+export BPFTRACE_RUNTIME_TEST_EXECUTABLE=/usr/bin
+
+PASS_CNT=0
+FAIL_CNT=0
+SKIP_CNT=0
+FAILED=()
+
+# Start unit tests
+for test_case in $(./bpftrace_test --gtest_list_tests | grep -v "^ "); do
+    if ./bpftrace_test --gtest_filter="${test_case}*" > /dev/null 2>&1 ; then
+        echo PASS: Unit test $test_case
+        PASS_CNT=$(($PASS_CNT + 1))
+    else
+        echo FAIL: Unit test $test_case
+        FAIL_CNT=$(($FAIL_CNT + 1))
+        FAILED+=("unit:${test_case}")
+    fi
+done
+
+# Start runtime tests
+for test_case in $(ls runtime); do
+    # Ignore test cases that hang the suite forever (bpftrace v0.16.0)
+    case $test_case in
+        signals)
+            ;&
+        watchpoint)
+            echo SKIP: Runtime test $test_case
+            SKIP_CNT=$(($SKIP_CNT + 1))
+            continue
+            ;;
+    esac
+    if ./runtime-tests.sh --filter="${test_case}.*" > /dev/null 2>&1 ; then
+        echo PASS: Runtime test $test_case
+        PASS_CNT=$(($PASS_CNT + 1))
+    else
+        echo FAIL: Runtime test $test_case
+        FAIL_CNT=$(($FAIL_CNT + 1))
+        FAILED+=("runtime:${test_case}")
+    fi
+done
+
+echo "#### bpftrace tests summary ####"
+echo "# TOTAL: $(($PASS_CNT + $FAIL_CNT + $SKIP_CNT))"
+echo "# PASS:  $PASS_CNT"
+echo "# FAIL:  $FAIL_CNT (${FAILED[*]})"
+echo "# SKIP:  $SKIP_CNT"
+echo "################################"


### PR DESCRIPTION
Hi @kraj,
bpftrace is now fully functional on master, so following your suggestions from https://github.com/kraj/meta-clang/pull/659 I'd like to add ptest support for it.

As expected not all tests pass, but it should be a good starting point to verify future fixes. I had to disable two runtime test suites as they hanged whole suite forever. Current results from poky master and qemuarm64:
```
root@qemuarm64:~# ptest-runner -t 2400 bpftrace
START: ptest-runner
2022-09-30T08:31
BEGIN: /usr/lib/bpftrace/ptest
PASS: Unit test ast.
PASS: Unit test bpftrace.
PASS: Unit test bpftrace_btf.
PASS: Unit test childproc.
PASS: Unit test clang_parser.
PASS: Unit test clang_parser_btf.
PASS: Unit test LogStream.
PASS: Unit test Log.
PASS: Unit test Parser.
PASS: Unit test semantic_analyser.
PASS: Unit test portability_analyser.
PASS: Unit test portability_analyser_btf.
PASS: Unit test procmon.
PASS: Unit test probe.
PASS: Unit test probe_btf.
PASS: Unit test resource_analyser.
PASS: Unit test required_resources.
PASS: Unit test semantic_analyser_btf.
PASS: Unit test semantic_analyser_dwarf.
PASS: Unit test tracepoint_format_parser.
PASS: Unit test utils.
FAIL: Runtime test addrspace
PASS: Runtime test array
PASS: Runtime test banned_probes
PASS: Runtime test basic
PASS: Runtime test btf
PASS: Runtime test builtin
FAIL: Runtime test call
FAIL: Runtime test complex_types
FAIL: Runtime test dwarf
PASS: Runtime test engine
PASS: Runtime test file-output
PASS: Runtime test intcast
PASS: Runtime test intptrcast
PASS: Runtime test json-output
PASS: Runtime test other
PASS: Runtime test outputs
FAIL: Runtime test pointers
PASS: Runtime test precedence
FAIL: Runtime test probe
FAIL: Runtime test regression
PASS: Runtime test scripts
SKIP: Runtime test signals
FAIL: Runtime test signed_ints
PASS: Runtime test struct
PASS: Runtime test tuples
FAIL: Runtime test uprobe
PASS: Runtime test usdt
FAIL: Runtime test variable
SKIP: Runtime test watchpoint
#### bpftrace tests summary ####
# TOTAL: 50
# PASS:  38
# FAIL:  10 (runtime:addrspace runtime:call runtime:complex_types runtime:dwarf runtime:pointers runtime:probe runtime:regression runtime:signed_ints runtime:uprobe runtime:variable)
# SKIP:  2
################################
DURATION: 1985
END: /usr/lib/bpftrace/ptest
2022-09-30T09:05
STOP: ptest-runner
TOTAL: 1 FAIL: 0
```

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
