### PR TITLE
fmt: Use libgcc on x86

### DIFF
--- a/conf/nonclangable.conf
+++ b/conf/nonclangable.conf
@@ -261,6 +261,7 @@ COMPILER_RT:pn-aufs-util:libc-glibc:toolchain-clang:x86 = "-rtlib=libgcc --unwin
 COMPILER_RT:pn-libhugetlbfs:libc-glibc:toolchain-clang:x86 = "-rtlib=libgcc --unwindlib=libgcc"
 COMPILER_RT:pn-tsocks:libc-glibc:toolchain-clang:x86 = "-rtlib=libgcc --unwindlib=libgcc"
 COMPILER_RT:pn-libc-bench:libc-glibc:toolchain-clang:x86 = "-rtlib=libgcc --unwindlib=libgcc"
+COMPILER_RT:pn-fmt:toolchain-clang:x86 = "-rtlib=libgcc --unwindlib=libgcc"
 COMPILER_RT:pn-libc-bench:libc-glibc:toolchain-clang:x86-64 = "-rtlib=libgcc --unwindlib=libgcc"
 COMPILER_RT:pn-mpich:toolchain-clang:x86-64 = "-rtlib=libgcc --unwindlib=libgcc"
 COMPILER_RT:pn-aufs-util:libc-glibc:toolchain-clang:x86-64 = "-rtlib=libgcc --unwindlib=libgcc"


### PR DESCRIPTION
This is because compiler-rt does not provide int128 builtins which fmt uses

Signed-off-by: Khem Raj <raj.khem@gmail.com>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
