### PR TITLE
clang: Implement finer grained packaging

### DIFF
--- a/classes/clang.bbclass
+++ b/classes/clang.bbclass
@@ -15,7 +15,6 @@ STRINGS:toolchain-clang = "${HOST_PREFIX}llvm-strings"
 READELF:toolchain-clang = "${HOST_PREFIX}llvm-readelf"
 
 LTO:toolchain-clang = "${@bb.utils.contains('DISTRO_FEATURES', 'thin-lto', '-flto=thin', '-flto -fuse-ld=lld', d)}"
-PACKAGE_DEBUG_SPLIT_STYLE:toolchain-clang = "debug-without-src"
 
 COMPILER_RT ??= ""
 COMPILER_RT:class-native = "-rtlib=libgcc ${UNWINDLIB}"

--- a/recipes-devtools/clang/clang_git.bb
+++ b/recipes-devtools/clang/clang_git.bb
@@ -266,7 +266,8 @@ do_install:append:class-nativesdk () {
     rm -rf ${D}${datadir}/llvm
 }
 
-PACKAGES =+ "${PN}-libllvm ${PN}-lldb-python libclang lldb lldb-server liblldb"
+PACKAGES =+ "${PN}-libllvm ${PN}-lldb-python ${PN}-libclang-cpp ${PN}-tidy ${PN}-format ${PN}-tools \
+             libclang lldb lldb-server liblldb llvm-linker-tools"
 
 PROVIDES += "llvm llvm${PV}"
 PROVIDES:append:class-native = " llvm-native"
@@ -275,7 +276,64 @@ BBCLASSEXTEND = "native nativesdk"
 
 RDEPENDS:lldb += "${PN}-lldb-python lldb-server"
 
+RRECOMMENDS:${PN}-tidy += "${PN}-tools"
+
+FILES:llvm-linker-tools = "${libdir}/LLVMgold* ${libdir}/libLTO.so.* ${libdir}/LLVMPolly*"
+
+FILES:${PN}-libclang-cpp = "${libdir}/libclang-cpp.so.*"
+
 FILES:${PN}-lldb-python = "${libdir}/python*/site-packages/lldb/*"
+
+FILES:${PN}-tidy = "${bindir}/*clang-tidy*"
+FILES:${PN}-format = "${bindir}/*clang-format*"
+
+FILES:${PN}-tools = "${bindir}/analyze-build \
+  ${bindir}/c-index-test \
+  ${bindir}/clang-apply-replacements \
+  ${bindir}/clang-change-namespace \
+  ${bindir}/clang-check \
+  ${bindir}/clang-cl \
+  ${bindir}/clang-doc \
+  ${bindir}/clang-extdef-mapping \
+  ${bindir}/clang-include-fixer \
+  ${bindir}/clang-linker-wrapper \
+  ${bindir}/clang-move \
+  ${bindir}/clang-nvlink-wrapper \
+  ${bindir}/clang-offload-bundler \
+  ${bindir}/clang-offload-packager \
+  ${bindir}/clang-offload-wrapper \
+  ${bindir}/clang-pseudo \
+  ${bindir}/clang-query \
+  ${bindir}/clang-refactor \
+  ${bindir}/clang-rename \
+  ${bindir}/clang-reorder-fields \
+  ${bindir}/clang-repl \
+  ${bindir}/clang-scan-deps \
+  ${bindir}/diagtool \
+  ${bindir}/find-all-symbols \
+  ${bindir}/hmaptool \
+  ${bindir}/hwasan_symbolize \
+  ${bindir}/intercept-build \
+  ${bindir}/modularize \
+  ${bindir}/pp-trace \
+  ${bindir}/sancov \
+  ${bindir}/scan-build \
+  ${bindir}/scan-build-py \
+  ${bindir}/scan-view \
+  ${bindir}/split-file \
+  ${libdir}/libscanbuild/* \
+  ${libdir}/libear/* \
+  ${libexecdir}/analyze-c++ \
+  ${libexecdir}/analyze-cc \
+  ${libexecdir}/c++-analyzer \
+  ${libexecdir}/ccc-analyzer \
+  ${libexecdir}/intercept-c++ \
+  ${libexecdir}/intercept-cc \
+  ${datadir}/scan-build/* \
+  ${datadir}/scan-view/* \
+  ${datadir}/opt-viewer/* \
+  ${datadir}/clang/* \
+"
 
 FILES:${PN} += "\
   ${libdir}/BugpointPasses.so \
@@ -291,6 +349,9 @@ FILES:${PN} += "\
 
 FILES:lldb = "\
   ${bindir}/lldb \
+  ${bindir}/lldb-argdumper \
+  ${bindir}/lldb-instr \
+  ${bindir}/lldb-vscode \
 "
 
 FILES:lldb-server = "\
@@ -307,6 +368,7 @@ FILES:${PN}-libllvm =+ "\
   ${libdir}/libLLVM-${MAJOR_VER}.so \
   ${libdir}/libLLVM-${MAJOR_VER}git.so \
   ${libdir}/libLLVM-${MAJOR_VER}.${MINOR_VER}git.so \
+  ${libdir}/libRemarks.so.* \
 "
 
 FILES:libclang = "\


### PR DESCRIPTION
Ensure that clang-tidy, clang-format, clang-tools are separated out into own packages and also move libclang-cpp shared object out of clang package too, which should remove every package depending on clang package since this shared object is needed by all tools.

Might fix https://github.com/kraj/meta-clang/issues/672

Signed-off-by: Khem Raj <raj.khem@gmail.com>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
