### PR TITLE
Revert "toolchain-clang: Specify -ffile-compilation-dir to omit absol…

### DIFF
--- a/classes/clang.bbclass
+++ b/classes/clang.bbclass
@@ -55,8 +55,6 @@ TUNE_CCARGS:append:toolchain-clang:libc-musl:powerpc = " -mlong-double-64"
 TUNE_CCARGS:append:toolchain-clang = "${@bb.utils.contains("DISTRO_FEATURES", "usrmerge", " --dyld-prefix=/usr", "", d)}"
 
 TUNE_CCARGS:append:toolchain-clang = " -Qunused-arguments"
-# Get rid of absolute paths in .file asm directive
-TUNE_CCARGS:append:toolchain-clang = " -ffile-compilation-dir=."
 
 LDFLAGS:append:toolchain-clang:class-nativesdk:x86-64 = " -Wl,-dynamic-linker,${base_libdir}/ld-linux-x86-64.so.2"
 LDFLAGS:append:toolchain-clang:class-nativesdk:x86 = " -Wl,-dynamic-linker,${base_libdir}/ld-linux.so.2"


### PR DESCRIPTION
…ute file paths in debug info"

Original issue has been fixed in clang 15+, -ffile-compilation-dir actually conflicts with creating separate -src packages since it confuses the packager about relative locations of the source files

This reverts commit 224863150c9320b32f344792928af7fbda56d65d.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
