### PR TITLE
fmt: Use libgcc on x86_64 as well

### DIFF
--- a/conf/nonclangable.conf
+++ b/conf/nonclangable.conf
@@ -262,6 +262,7 @@ COMPILER_RT:pn-libhugetlbfs:libc-glibc:toolchain-clang:x86 = "-rtlib=libgcc --un
 COMPILER_RT:pn-tsocks:libc-glibc:toolchain-clang:x86 = "-rtlib=libgcc --unwindlib=libgcc"
 COMPILER_RT:pn-libc-bench:libc-glibc:toolchain-clang:x86 = "-rtlib=libgcc --unwindlib=libgcc"
 COMPILER_RT:pn-fmt:toolchain-clang:x86 = "-rtlib=libgcc --unwindlib=libgcc"
+COMPILER_RT:pn-fmt:toolchain-clang:x86-64 = "-rtlib=libgcc --unwindlib=libgcc"
 COMPILER_RT:pn-libc-bench:libc-glibc:toolchain-clang:x86-64 = "-rtlib=libgcc --unwindlib=libgcc"
 COMPILER_RT:pn-mpich:toolchain-clang:x86-64 = "-rtlib=libgcc --unwindlib=libgcc"
 COMPILER_RT:pn-aufs-util:libc-glibc:toolchain-clang:x86-64 = "-rtlib=libgcc --unwindlib=libgcc"


### PR DESCRIPTION
compiler-rt does not provide the TF functions for x86 or x86_64 since it does not support TF functions on architectures which does not support 128-bit long double.

Signed-off-by: Khem Raj <raj.khem@gmail.com>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
