### PR TITLE
Fix compiler-rt-sanitizers to be able to build on arm targets

### DIFF
--- a/recipes-devtools/clang/compiler-rt-sanitizers_git.bb
+++ b/recipes-devtools/clang/compiler-rt-sanitizers_git.bb
@@ -15,11 +15,17 @@ LIC_FILES_CHKSUM = "file://compiler-rt/LICENSE.TXT;md5=d846d1d65baf322d4c485d6ee
 
 TUNE_CCARGS_remove = "-no-integrated-as"
 
-RUNTIME = "llvm"
+#compiler-rt-sanitizers will not compile for arm32 or arm64 based platforms without adding -fPIC
+CXXFLAGS:append = " -fPIC"
+
+#set RUNTIME variable according to documention to gnu as default value
+RUNTIME ?= "gnu"
 
 DEPENDS += "ninja-native clang-cross-${TARGET_ARCH} virtual/${MLPREFIX}libc virtual/${TARGET_PREFIX}compilerlibs"
 DEPENDS_append_libc-glibc = " libxcrypt"
 DEPENDS_append_class-nativesdk = " clang-native nativesdk-libxcrypt"
+
+
 
 PACKAGECONFIG ??= ""
 PACKAGECONFIG[crt] = "-DCOMPILER_RT_BUILD_CRT:BOOL=ON,-DCOMPILER_RT_BUILD_CRT:BOOL=OFF"
@@ -95,3 +101,5 @@ ALLOW_EMPTY_${PN}-dev = "1"
 
 TOOLCHAIN_forcevariable = "clang"
 SYSROOT_DIRS_append_class-target = " ${nonarch_libdir}"
+
+INSANE_SKIP += "${@ bb.utils.contains('CXXFLAGS', '-fPIC', 'textrel', '', d)}"


### PR DESCRIPTION
Signed off: Florian Wühr [fwuehr@rational-online.com](mailto:fwuehr@rational-online.com)
Signed off: Alexander Thoma [athoma@rational-online.com](mailto:athoma@rational-online.com)
---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
