### PR TITLE
bcc: Add ptest support

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-devtools/bcc/bcc/ptest_wrapper.sh
+++ b/dynamic-layers/openembedded-layer/recipes-devtools/bcc/bcc/ptest_wrapper.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+# Simple OE specific wrapper for bcc python tests
+
+name=$1
+kind=$2
+cmd=$3
+shift 3
+
+case $kind in
+    simple|sudo)
+        $cmd "$@"
+        ;;
+    *)
+        echo "Invalid kind $kind of test $name"
+        exit 1
+esac

--- a/dynamic-layers/openembedded-layer/recipes-devtools/bcc/bcc/run-ptest
+++ b/dynamic-layers/openembedded-layer/recipes-devtools/bcc/bcc/run-ptest
@@ -1,0 +1,42 @@
+#!/bin/sh
+
+cd tests || exit 1
+
+PASS_CNT=0
+FAIL_CNT=0
+FAILED=""
+
+print_test_result() {
+    if [ $? -eq 0 ]; then
+        echo PASS: "$1"
+        PASS_CNT=$((PASS_CNT + 1))
+    else
+        echo FAIL: "$1"
+        FAIL_CNT=$((FAIL_CNT + 1))
+        FAILED="$FAILED $1;"
+    fi
+}
+
+# Run CC tests, set IFS as test names have spaces
+IFS=$(printf '\n\t')
+for test_name in $(./cc/test_libbcc_no_libbpf --list-test-names-only); do
+    ./cc/test_libbcc_no_libbpf "$test_name" > /dev/null 2>&1
+    print_test_result "cc $test_name"
+done
+unset IFS
+
+# Run python tests, skip namespace tests as they currently don't work
+if cmake -DCMAKE_TESTING_ENABLED=ON -DTEST_WRAPPER="$(pwd)/ptest_wrapper.sh" python > /dev/null 2>&1; then
+    for test_name in $(awk -F '[( ]' '/^add_test/ && !/namespace/ {print $2}' CTestTestfile.cmake); do
+        ctest -Q -R "$test_name"
+        print_test_result "python $test_name"
+    done
+else
+    print_test_result "cmake error, couldn't start python tests"
+fi
+
+echo "#### bcc tests summary ####"
+echo "# TOTAL: $((PASS_CNT + FAIL_CNT))"
+echo "# PASS:  $PASS_CNT"
+echo "# FAIL:  $FAIL_CNT ($FAILED)"
+echo "###########################"

--- a/dynamic-layers/openembedded-layer/recipes-devtools/bcc/bcc_0.25.0.bb
+++ b/dynamic-layers/openembedded-layer/recipes-devtools/bcc/bcc_0.25.0.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/iovisor/bcc"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=e3fc50a88d0a364313df4b21ef20c29e"
 
-inherit cmake python3native manpages
+inherit cmake python3native manpages ptest
 
 DEPENDS += "bison-native \
             flex-native \
@@ -20,12 +20,15 @@ LUAJIT:powerpc64 = ""
 LUAJIT:riscv64 = ""
 
 RDEPENDS:${PN} += "bash python3 python3-core python3-setuptools xz"
+RDEPENDS:${PN}-ptest = "cmake python3 python3-distutils python3-netaddr python3-pyroute2"
 
 SRC_URI = "gitsm://github.com/iovisor/bcc;branch=master;protocol=https \
            file://0001-python-CMakeLists.txt-Remove-check-for-host-etc-debi.patch \
            file://0001-tools-trace.py-Fix-failing-to-exit.patch \
            file://0001-CMakeLists.txt-override-the-PY_CMD_ESCAPED.patch \
            file://0001-Vendor-just-enough-extra-headers-to-allow-libbpf-to-.patch \
+           file://run-ptest \
+           file://ptest_wrapper.sh \
            "
 
 SRCREV = "711f03024d776d174874b1f833dac0597f22a49a"
@@ -52,6 +55,14 @@ EXTRA_OECMAKE = " \
 do_install:append() {
         sed -e 's@#!/usr/bin/python@#!/usr/bin/env python3@g' \
             -i $(find ${D}${datadir}/${PN} -type f)
+}
+
+do_install_ptest() {
+    install -d ${D}${PTEST_PATH}/tests/cc
+    install ${B}/tests/cc/test_libbcc_no_libbpf ${B}/tests/cc/libusdt_test_lib.so ${D}${PTEST_PATH}/tests/cc
+    cp -rf ${S}/tests/python ${D}${PTEST_PATH}/tests/python
+    install ${WORKDIR}/ptest_wrapper.sh ${D}${PTEST_PATH}/tests
+    install ${S}/examples/networking/simulation.py ${D}${PTEST_PATH}/tests/python
 }
 
 FILES:${PN} += "${PYTHON_SITEPACKAGES_DIR}"


### PR DESCRIPTION
Hello @kraj, I added ptest support in bcc package reusing cc and python tests provided with the package. Lua tests are not included as they all fail on OE (and are also disabled in main repo).

Output from poky master on qemuarm64 and kernel built with `CONFIG_IKHEADERS=y`:
```
root@qemuarm64:~# ptest-runner -t 1800 bcc
START: ptest-runner
2022-10-14T11:57
BEGIN: /usr/lib/bcc/ptest
PASS: cc language detection
PASS: cc shared object resolution
PASS: cc shared object resolution using loaded libraries
PASS: cc binary resolution with `which`
PASS: cc list all kernel symbols
PASS: cc file-backed mapping identification
PASS: cc resolve symbol name in external library
PASS: cc resolve symbol name in external library using loaded libraries
FAIL: cc resolve symbol addresses for a given PID
PASS: cc resolve symbols using /tmp/perf-pid.map
PASS: cc searching for modules in /proc/[pid]/maps
PASS: cc resolve global addr in libc in this process
PASS: cc conversion of module offset to/from global_addr
PASS: cc get online CPUs
PASS: cc test array table
PASS: cc percpu array table
FAIL: cc test bpf table
PASS: cc test bpf percpu tables
PASS: cc test bpf hash table
FAIL: cc test bpf stack table
FAIL: cc test bpf stack_id table
PASS: cc test cgroup storage
PASS: cc test percpu cgroup storage
PASS: cc test hash table
PASS: cc percpu hash table
FAIL: cc test hash of maps
FAIL: cc test hash of maps using custom key
FAIL: cc test array of maps
FAIL: cc test read perf event
PASS: cc test attach perf event
PASS: cc test pinned table
PASS: cc test pinned sk_storage table
PASS: cc test prog table
PASS: cc queue table
PASS: cc stack table
PASS: cc test shared table
PASS: cc test sk_storage map
FAIL: cc test sock map
FAIL: cc test sock hash
FAIL: cc test usdt argument parsing
FAIL: cc test finding a probe in our own process
PASS: cc test probe's attributes with C++ API
FAIL: cc test fine a probe in our own binary with C++ API
FAIL: cc test fine probes in our own binary with C++ API
FAIL: cc test fine a probe in our Process with C++ API
FAIL: cc test find a probe in our process' shared libs with c++ API
FAIL: cc test usdt partial init w/ fail init_usdt
PASS: cc test listing all USDT probes in Ruby/MRI
PASS: cc test probing running Ruby process in namespaces
FAIL: cc Test uprobe refcnt semaphore activation
PASS: cc test tracepoint parser
PASS: python py_test_bpf_log
PASS: python py_test_trace2
FAIL: python py_test_trace3_c
PASS: python py_test_trace4
PASS: python py_test_trace_maxactive
PASS: python py_test_probe_count
PASS: python py_test_debuginfo
PASS: python py_test_brb
PASS: python py_test_brb2
FAIL: python py_test_clang
FAIL: python py_test_histogram
FAIL: python py_array
FAIL: python py_uprobes
PASS: python py_uprobes_2
FAIL: python py_test_stackid
PASS: python py_test_tracepoint
PASS: python py_test_perf_event
PASS: python py_test_attach_perf_event
PASS: python py_test_utils
PASS: python py_test_percpu
PASS: python py_test_dump_func
PASS: python py_test_disassembler
FAIL: python py_test_tools_smoke
FAIL: python py_test_tools_memleak
FAIL: python py_test_usdt
FAIL: python py_test_usdt2
FAIL: python py_test_usdt3
FAIL: python py_test_license
FAIL: python py_test_free_bcc_memory
PASS: python py_test_rlimit
PASS: python py_test_lpm_trie
FAIL: python py_ringbuf
PASS: python py_queuestack
PASS: python py_test_map_batch_ops
PASS: python py_test_map_in_map
#### bcc tests summary ####
# TOTAL: 86
# PASS:  54
# FAIL:  32 (cc resolve symbol addresses for a given PID; cc test bpf table; cc test bpf stack table; cc test bpf stack_id table; cc test hash of maps; cc test hash of maps using custom key; cc test array of maps; cc test read perf event; cc test sock map; cc test sock hash; cc test usdt argument parsing; cc test finding a probe in our own process; cc test fine a probe in our own binary with C++ API; cc test fine probes in our own binary with C++ API; cc test fine a probe in our Process with C++ API; cc test find a probe in our process' shared libs with c++ API; cc test usdt partial init w/ fail init_usdt; cc Test uprobe refcnt semaphore activation; python py_test_trace3_c; python py_test_clang; python py_test_histogram; python py_array; python py_uprobes; python py_test_stackid; python py_test_tools_smoke; python py_test_tools_memleak; python py_test_usdt; python py_test_usdt2; python py_test_usdt3; python py_test_license; python py_test_free_bcc_memory; python py_ringbuf;)
###########################
DURATION: 1413
END: /usr/lib/bcc/ptest
2022-10-14T12:21
STOP: ptest-runner
TOTAL: 1 FAIL: 0
```

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
