### PR TITLE
bpftrace: Simplify ptest script and use posix syntax

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-devtools/bpftrace/bpftrace/run-ptest
+++ b/dynamic-layers/openembedded-layer/recipes-devtools/bpftrace/bpftrace/run-ptest
@@ -1,53 +1,50 @@
-#!/bin/bash
+#!/bin/sh
 
 # The whole test suite may take up to 40 minutes to run, so setting -t 2400
 # parameter in ptest-runner is necessary to not kill it before completion
 
-cd tests
+cd tests || exit 1
 export BPFTRACE_RUNTIME_TEST_EXECUTABLE=/usr/bin
 
 PASS_CNT=0
 FAIL_CNT=0
 SKIP_CNT=0
-FAILED=()
+FAILED=""
 
+print_test_result() {
+     if [ $? -eq 0 ]; then
+         echo "PASS: $1"
+         PASS_CNT=$((PASS_CNT + 1))
+     else
+         echo "FAIL: $1"
+         FAIL_CNT=$((FAIL_CNT + 1))
+         FAILED="${FAILED:+$FAILED }$1;"
+     fi
+ }
+
+IFS=$(printf '\n\t')
 # Start unit tests
-for test_case in $(./bpftrace_test --gtest_list_tests | grep -v "^ "); do
-    if ./bpftrace_test --gtest_filter="${test_case}*" > /dev/null 2>&1 ; then
-        echo PASS: Unit test $test_case
-        PASS_CNT=$(($PASS_CNT + 1))
-    else
-        echo FAIL: Unit test $test_case
-        FAIL_CNT=$(($FAIL_CNT + 1))
-        FAILED+=("unit:${test_case}")
-    fi
+for test_name in $(./bpftrace_test --gtest_list_tests | grep -v "^ "); do
+    ./bpftrace_test --gtest_filter="${test_name}*" > /dev/null 2>&1
+    print_test_result "unit:$test_name"
 done
 
 # Start runtime tests
-for test_case in $(ls runtime); do
+for test_name in $(ls runtime); do
     # Ignore test cases that hang the suite forever (bpftrace v0.16.0)
-    case $test_case in
-        signals)
-            ;&
-        watchpoint)
-            echo SKIP: Runtime test $test_case
-            SKIP_CNT=$(($SKIP_CNT + 1))
-            continue
-            ;;
-    esac
-    if ./runtime-tests.sh --filter="${test_case}.*" > /dev/null 2>&1 ; then
-        echo PASS: Runtime test $test_case
-        PASS_CNT=$(($PASS_CNT + 1))
-    else
-        echo FAIL: Runtime test $test_case
-        FAIL_CNT=$(($FAIL_CNT + 1))
-        FAILED+=("runtime:${test_case}")
+    if [ "$test_name" = "signals" ] || [ "$test_name" = "watchpoint" ]; then
+        echo "SKIP: runtime:$test_name"
+        SKIP_CNT=$((SKIP_CNT + 1))
+        continue
     fi
+    python3 runtime/engine/main.py --filter="${test_name}.*" > /dev/null 2>&1
+    print_test_result "runtime:$test_name"
 done
+unset IFS
 
 echo "#### bpftrace tests summary ####"
-echo "# TOTAL: $(($PASS_CNT + $FAIL_CNT + $SKIP_CNT))"
+echo "# TOTAL: $((PASS_CNT + FAIL_CNT + SKIP_CNT))"
 echo "# PASS:  $PASS_CNT"
-echo "# FAIL:  $FAIL_CNT (${FAILED[*]})"
+echo "# FAIL:  $FAIL_CNT ($FAILED)"
 echo "# SKIP:  $SKIP_CNT"
 echo "################################"

--- a/dynamic-layers/openembedded-layer/recipes-devtools/bpftrace/bpftrace_0.16.0.bb
+++ b/dynamic-layers/openembedded-layer/recipes-devtools/bpftrace/bpftrace_0.16.0.bb
@@ -15,7 +15,6 @@ DEPENDS += "bison-native \
 
 PV .= "+git${SRCREV}"
 RDEPENDS:${PN} += "bash python3 xz"
-RDEPENDS:${PN}-ptest += "bash"
 
 SRC_URI = "git://github.com/iovisor/bpftrace;branch=master;protocol=https \
            file://run-ptest \
@@ -37,7 +36,7 @@ PACKAGECONFIG[tests] = "-DBUILD_TESTING=ON,-DBUILD_TESTING=OFF,gtest xxd-native"
 do_install_ptest() {
     if [ -e ${B}/tests/bpftrace_test ]; then
         install -Dm 755 ${B}/tests/bpftrace_test ${D}${PTEST_PATH}/tests/bpftrace_test
-        cp -rf ${B}/tests/runtime* ${D}${PTEST_PATH}/tests
+        cp -rf ${B}/tests/runtime ${D}${PTEST_PATH}/tests
         cp -rf ${B}/tests/test* ${D}${PTEST_PATH}/tests
     fi
 }


### PR DESCRIPTION
I simplified script a little and used posix syntax for better compatibility as in bcc ptest suite. Additionally now there is no need for bash runtime dependency. 

Ptest output after changes:
```
root@qemuarm64:~# ptest-runner -t 3600 bpftrace
START: ptest-runner
2022-10-20T13:10
BEGIN: /usr/lib/bpftrace/ptest
PASS: unit:ast.
PASS: unit:bpftrace.
PASS: unit:bpftrace_btf.
PASS: unit:childproc.
PASS: unit:clang_parser.
PASS: unit:clang_parser_btf.
PASS: unit:LogStream.
PASS: unit:Log.
PASS: unit:Parser.
PASS: unit:semantic_analyser.
PASS: unit:portability_analyser.
PASS: unit:portability_analyser_btf.
PASS: unit:procmon.
PASS: unit:probe.
PASS: unit:probe_btf.
PASS: unit:resource_analyser.
PASS: unit:required_resources.
PASS: unit:semantic_analyser_btf.
PASS: unit:semantic_analyser_dwarf.
PASS: unit:tracepoint_format_parser.
PASS: unit:utils.
PASS: runtime:addrspace
PASS: runtime:array
PASS: runtime:banned_probes
PASS: runtime:basic
PASS: runtime:btf
PASS: runtime:builtin
FAIL: runtime:call
PASS: runtime:complex_types
FAIL: runtime:dwarf
PASS: runtime:engine
PASS: runtime:file-output
PASS: runtime:intcast
PASS: runtime:intptrcast
PASS: runtime:json-output
PASS: runtime:other
PASS: runtime:outputs
PASS: runtime:pointers
PASS: runtime:precedence
FAIL: runtime:probe
FAIL: runtime:regression
PASS: runtime:scripts
SKIP: runtime:signals
PASS: runtime:signed_ints
PASS: runtime:struct
PASS: runtime:tuples
FAIL: runtime:uprobe
PASS: runtime:usdt
PASS: runtime:variable
SKIP: runtime:watchpoint
#### bpftrace tests summary ####
# TOTAL: 50
# PASS:  43
# FAIL:  5 (runtime:call; runtime:dwarf; runtime:probe; runtime:regression; runtime:uprobe;)
# SKIP:  2
################################
DURATION: 1746
END: /usr/lib/bpftrace/ptest
2022-10-20T13:39
STOP: ptest-runner
TOTAL: 1 FAIL: 0
```

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
