### PR TITLE
mybw: Use objcopy from binutils on mips

### DIFF
--- a/conf/nonclangable.conf
+++ b/conf/nonclangable.conf
@@ -263,6 +263,7 @@ COMPILER_RT:pn-tsocks:libc-glibc:toolchain-clang:x86 = "-rtlib=libgcc --unwindli
 COMPILER_RT:pn-libc-bench:libc-glibc:toolchain-clang:x86 = "-rtlib=libgcc --unwindlib=libgcc"
 COMPILER_RT:pn-fmt:toolchain-clang:x86 = "-rtlib=libgcc --unwindlib=libgcc"
 COMPILER_RT:pn-fmt:toolchain-clang:x86-64 = "-rtlib=libgcc --unwindlib=libgcc"
+COMPILER_RT:pn-mybw:toolchain-clang:x86 = "-rtlib=libgcc --unwindlib=libgcc"
 COMPILER_RT:pn-libc-bench:libc-glibc:toolchain-clang:x86-64 = "-rtlib=libgcc --unwindlib=libgcc"
 COMPILER_RT:pn-mpich:toolchain-clang:x86-64 = "-rtlib=libgcc --unwindlib=libgcc"
 COMPILER_RT:pn-aufs-util:libc-glibc:toolchain-clang:x86-64 = "-rtlib=libgcc --unwindlib=libgcc"
@@ -308,6 +309,9 @@ STRIP:pn-go-helloworld:mips:toolchain-clang = "${HOST_PREFIX}strip"
 OBJCOPY:pn-go-helloworld:mips:toolchain-clang = "${HOST_PREFIX}objcopy"
 STRIP:pn-gosu:mips:toolchain-clang = "${HOST_PREFIX}strip"
 OBJCOPY:pn-gosu:mips:toolchain-clang = "${HOST_PREFIX}objcopy"
+# mips-yoe-linux-llvm-objcopy: error: Link field value 42 in section .rel.dyn is not a symbol table
+OBJCOPY:pn-mybw:mips:toolchain-clang = "${HOST_PREFIX}objcopy"
+OBJCOPY:pn-mybw:x86:toolchain-clang = "${HOST_PREFIX}objcopy"
 
 # Fails with llvm strip
 # i686-yoe-linux-llvm-strip: error: SHT_STRTAB string table section [index 9] is non-null terminated


### PR DESCRIPTION
Use libgcc on x86 instead of compiler-rt

llvm objcopy errors out so disable it for now
Subprocess output:mips-yoe-linux-llvm-objcopy: error: Link field value 42 in section .rel.dyn is not a symbol table

Signed-off-by: Khem Raj <raj.khem@gmail.com>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
