### PR TITLE
mybw: USe gnu objcopy on riscv64

### DIFF
--- a/conf/nonclangable.conf
+++ b/conf/nonclangable.conf
@@ -314,6 +314,7 @@ OBJCOPY:pn-gosu:mips:toolchain-clang = "${HOST_PREFIX}objcopy"
 OBJCOPY:pn-mybw:mips:toolchain-clang = "${HOST_PREFIX}objcopy"
 OBJCOPY:pn-mybw:x86:toolchain-clang = "${HOST_PREFIX}objcopy"
 OBJCOPY:pn-mybw:x86-64:toolchain-clang = "${HOST_PREFIX}objcopy"
+OBJCOPY:pn-mybw:riscv64:toolchain-clang = "${HOST_PREFIX}objcopy"
 
 # Fails with llvm strip
 # i686-yoe-linux-llvm-strip: error: SHT_STRTAB string table section [index 9] is non-null terminated


### PR DESCRIPTION
Signed-off-by: Khem Raj <raj.khem@gmail.com>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
