### PR TITLE
bpftrace/bcc: backport ptest changes to kirkstone

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-devtools/bcc/bcc/ptest_wrapper.sh
+++ b/dynamic-layers/openembedded-layer/recipes-devtools/bcc/bcc/ptest_wrapper.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+# Simple OE specific wrapper for bcc python tests
+
+name=$1
+kind=$2
+cmd=$3
+shift 3
+
+case $kind in
+    simple|sudo)
+        $cmd "$@"
+        ;;
+    *)
+        echo "Invalid kind $kind of test $name"
+        exit 1
+esac

--- a/dynamic-layers/openembedded-layer/recipes-devtools/bcc/bcc/run-ptest
+++ b/dynamic-layers/openembedded-layer/recipes-devtools/bcc/bcc/run-ptest
@@ -1,0 +1,42 @@
+#!/bin/sh
+
+cd tests || exit 1
+
+PASS_CNT=0
+FAIL_CNT=0
+FAILED=""
+
+print_test_result() {
+    if [ $? -eq 0 ]; then
+        echo PASS: "$1"
+        PASS_CNT=$((PASS_CNT + 1))
+    else
+        echo FAIL: "$1"
+        FAIL_CNT=$((FAIL_CNT + 1))
+        FAILED="$FAILED $1;"
+    fi
+}
+
+# Run CC tests, set IFS as test names have spaces
+IFS=$(printf '\n\t')
+for test_name in $(./cc/test_libbcc_no_libbpf --list-test-names-only); do
+    ./cc/test_libbcc_no_libbpf "$test_name" > /dev/null 2>&1
+    print_test_result "cc $test_name"
+done
+unset IFS
+
+# Run python tests, skip namespace tests as they currently don't work
+if cmake -DCMAKE_TESTING_ENABLED=ON -DTEST_WRAPPER="$(pwd)/ptest_wrapper.sh" python > /dev/null 2>&1; then
+    for test_name in $(awk -F '[( ]' '/^add_test/ && !/namespace/ {print $2}' CTestTestfile.cmake); do
+        ctest -Q -R "$test_name"
+        print_test_result "python $test_name"
+    done
+else
+    print_test_result "cmake error, couldn't start python tests"
+fi
+
+echo "#### bcc tests summary ####"
+echo "# TOTAL: $((PASS_CNT + FAIL_CNT))"
+echo "# PASS:  $PASS_CNT"
+echo "# FAIL:  $FAIL_CNT ($FAILED)"
+echo "###########################"

--- a/dynamic-layers/openembedded-layer/recipes-devtools/bcc/bcc_0.24.0.bb
+++ b/dynamic-layers/openembedded-layer/recipes-devtools/bcc/bcc_0.24.0.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/iovisor/bcc"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=e3fc50a88d0a364313df4b21ef20c29e"
 
-inherit cmake python3native manpages
+inherit cmake python3native manpages ptest
 
 DEPENDS += "bison-native \
             flex-native \
@@ -20,12 +20,15 @@ LUAJIT:powerpc64 = ""
 LUAJIT:riscv64 = ""
 
 RDEPENDS:${PN} += "bash python3 python3-core python3-setuptools xz"
+RDEPENDS:${PN}-ptest = "cmake python3 python3-distutils python3-netaddr python3-pyroute2"
 
 SRC_URI = "gitsm://github.com/iovisor/bcc;branch=master;protocol=https \
            file://0001-python-CMakeLists.txt-Remove-check-for-host-etc-debi.patch \
            file://0001-tools-trace.py-Fix-failing-to-exit.patch \
            file://0001-CMakeLists.txt-override-the-PY_CMD_ESCAPED.patch \
            file://0001-Vendor-just-enough-extra-headers-to-allow-libbpf-to-.patch \
+           file://run-ptest \
+           file://ptest_wrapper.sh \
            "
 
 SRCREV = "8f40d6f57a8d94e7aee74ce358572d34d31b4ed4"
@@ -52,6 +55,14 @@ EXTRA_OECMAKE = " \
 do_install:append() {
         sed -e 's@#!/usr/bin/python@#!/usr/bin/env python3@g' \
             -i $(find ${D}${datadir}/${PN} -type f)
+}
+
+do_install_ptest() {
+    install -d ${D}${PTEST_PATH}/tests/cc
+    install ${B}/tests/cc/test_libbcc_no_libbpf ${B}/tests/cc/libusdt_test_lib.so ${D}${PTEST_PATH}/tests/cc
+    cp -rf ${S}/tests/python ${D}${PTEST_PATH}/tests/python
+    install ${WORKDIR}/ptest_wrapper.sh ${D}${PTEST_PATH}/tests
+    install ${S}/examples/networking/simulation.py ${D}${PTEST_PATH}/tests/python
 }
 
 FILES:${PN} += "${PYTHON_SITEPACKAGES_DIR}"

--- a/dynamic-layers/openembedded-layer/recipes-devtools/bpftrace/bpftrace/run-ptest
+++ b/dynamic-layers/openembedded-layer/recipes-devtools/bpftrace/bpftrace/run-ptest
@@ -1,53 +1,50 @@
-#!/bin/bash
+#!/bin/sh
 
 # The whole test suite may take up to 40 minutes to run, so setting -t 2400
 # parameter in ptest-runner is necessary to not kill it before completion
 
-cd tests
+cd tests || exit 1
 export BPFTRACE_RUNTIME_TEST_EXECUTABLE=/usr/bin
 
 PASS_CNT=0
 FAIL_CNT=0
 SKIP_CNT=0
-FAILED=()
+FAILED=""
 
+print_test_result() {
+     if [ $? -eq 0 ]; then
+         echo "PASS: $1"
+         PASS_CNT=$((PASS_CNT + 1))
+     else
+         echo "FAIL: $1"
+         FAIL_CNT=$((FAIL_CNT + 1))
+         FAILED="${FAILED:+$FAILED }$1;"
+     fi
+ }
+
+IFS=$(printf '\n\t')
 # Start unit tests
-for test_case in $(./bpftrace_test --gtest_list_tests | grep -v "^ "); do
-    if ./bpftrace_test --gtest_filter="${test_case}*" > /dev/null 2>&1 ; then
-        echo PASS: Unit test $test_case
-        PASS_CNT=$(($PASS_CNT + 1))
-    else
-        echo FAIL: Unit test $test_case
-        FAIL_CNT=$(($FAIL_CNT + 1))
-        FAILED+=("unit:${test_case}")
-    fi
+for test_name in $(./bpftrace_test --gtest_list_tests | grep -v "^ "); do
+    ./bpftrace_test --gtest_filter="${test_name}*" > /dev/null 2>&1
+    print_test_result "unit:$test_name"
 done
 
 # Start runtime tests
-for test_case in $(ls runtime); do
-    # Ignore test cases that hang the suite forever (bpftrace v0.16.0)
-    case $test_case in
-        sigint)
-            ;&
-        watchpoint)
-            echo SKIP: Runtime test $test_case
-            SKIP_CNT=$(($SKIP_CNT + 1))
-            continue
-            ;;
-    esac
-    if ./runtime-tests.sh --filter="${test_case}.*" > /dev/null 2>&1 ; then
-        echo PASS: Runtime test $test_case
-        PASS_CNT=$(($PASS_CNT + 1))
-    else
-        echo FAIL: Runtime test $test_case
-        FAIL_CNT=$(($FAIL_CNT + 1))
-        FAILED+=("runtime:${test_case}")
+for test_name in $(ls runtime); do
+    # Ignore test cases that hang the suite forever (bpftrace v0.14.1)
+    if [ "$test_name" = "sigint" ] || [ "$test_name" = "watchpoint" ]; then
+        echo "SKIP: runtime:$test_name"
+        SKIP_CNT=$((SKIP_CNT + 1))
+        continue
     fi
+    python3 runtime/engine/main.py --filter="${test_name}.*" > /dev/null 2>&1
+    print_test_result "runtime:$test_name"
 done
+unset IFS
 
 echo "#### bpftrace tests summary ####"
-echo "# TOTAL: $(($PASS_CNT + $FAIL_CNT + $SKIP_CNT))"
+echo "# TOTAL: $((PASS_CNT + FAIL_CNT + SKIP_CNT))"
 echo "# PASS:  $PASS_CNT"
-echo "# FAIL:  $FAIL_CNT (${FAILED[*]})"
+echo "# FAIL:  $FAIL_CNT ($FAILED)"
 echo "# SKIP:  $SKIP_CNT"
 echo "################################"

--- a/dynamic-layers/openembedded-layer/recipes-devtools/bpftrace/bpftrace_0.14.1.bb
+++ b/dynamic-layers/openembedded-layer/recipes-devtools/bpftrace/bpftrace_0.14.1.bb
@@ -15,7 +15,6 @@ DEPENDS += "bison-native \
 
 PV .= "+git${SRCREV}"
 RDEPENDS:${PN} += "bash python3 xz"
-RDEPENDS:${PN}-ptest += "bash"
 
 SRC_URI = "git://github.com/iovisor/bpftrace;branch=master;protocol=https \
            file://0001-Detect-new-BTF-api-btf_dump__new-btf_dump__new_v0_6_.patch \
@@ -39,7 +38,7 @@ PACKAGECONFIG[tests] = "-DBUILD_TESTING=ON,-DBUILD_TESTING=OFF,gtest xxd-native"
 do_install_ptest() {
     if [ -e ${B}/tests/bpftrace_test ]; then
         install -Dm 755 ${B}/tests/bpftrace_test ${D}${PTEST_PATH}/tests/bpftrace_test
-        cp -rf ${B}/tests/runtime* ${D}${PTEST_PATH}/tests
+        cp -rf ${B}/tests/runtime ${D}${PTEST_PATH}/tests
         cp -rf ${B}/tests/test* ${D}${PTEST_PATH}/tests
     fi
 }


### PR DESCRIPTION
Commits cherry-picked without major conflicts.

ptest output:
```
START: ptest-runner
2022-11-02T09:17
BEGIN: /usr/lib/bcc/ptest
PASS: cc language detection
PASS: cc shared object resolution
PASS: cc shared object resolution using loaded libraries
PASS: cc binary resolution with `which`
PASS: cc list all kernel symbols
PASS: cc file-backed mapping identification
PASS: cc resolve symbol name in external library
PASS: cc resolve symbol name in external library using loaded libraries
FAIL: cc resolve symbol addresses for a given PID
PASS: cc resolve symbols using /tmp/perf-pid.map
PASS: cc searching for modules in /proc/[pid]/maps
PASS: cc resolve global addr in libc in this process
PASS: cc get online CPUs
PASS: cc test array table
PASS: cc percpu array table
PASS: cc test bpf table
PASS: cc test bpf percpu tables
PASS: cc test bpf hash table
FAIL: cc test bpf stack table
FAIL: cc test bpf stack_id table
PASS: cc test cgroup storage
PASS: cc test percpu cgroup storage
PASS: cc test hash table
PASS: cc percpu hash table
FAIL: cc test hash of maps
FAIL: cc test hash of maps using custom key
FAIL: cc test array of maps
FAIL: cc test read perf event
PASS: cc test attach perf event
PASS: cc test pinned table
PASS: cc test prog table
PASS: cc queue table
PASS: cc stack table
PASS: cc test shared table
PASS: cc test sk_storage map
FAIL: cc test sock map
FAIL: cc test sock hash
PASS: cc test usdt argument parsing
FAIL: cc test finding a probe in our own process
PASS: cc test probe's attributes with C++ API
FAIL: cc test fine a probe in our own binary with C++ API
FAIL: cc test fine probes in our own binary with C++ API
FAIL: cc test fine a probe in our Process with C++ API
FAIL: cc test find a probe in our process' shared libs with c++ API
FAIL: cc test usdt partial init w/ fail init_usdt
PASS: cc test listing all USDT probes in Ruby/MRI
PASS: cc test probing running Ruby process in namespaces
FAIL: cc Test uprobe refcnt semaphore activation
PASS: cc test tracepoint parser
PASS: python py_test_bpf_log
PASS: python py_test_trace2
FAIL: python py_test_trace3_c
PASS: python py_test_trace4
PASS: python py_test_trace_maxactive
PASS: python py_test_probe_count
PASS: python py_test_debuginfo
PASS: python py_test_brb
PASS: python py_test_brb2
FAIL: python py_test_clang
FAIL: python py_test_histogram
FAIL: python py_array
FAIL: python py_uprobes
PASS: python py_uprobes_2
PASS: python py_test_stackid
PASS: python py_test_tracepoint
PASS: python py_test_perf_event
PASS: python py_test_attach_perf_event
PASS: python py_test_utils
PASS: python py_test_percpu
PASS: python py_test_dump_func
PASS: python py_test_disassembler
FAIL: python py_test_tools_smoke
FAIL: python py_test_tools_memleak
FAIL: python py_test_usdt
FAIL: python py_test_usdt2
FAIL: python py_test_usdt3
PASS: python py_test_license
FAIL: python py_test_free_bcc_memory
PASS: python py_test_rlimit
PASS: python py_test_lpm_trie
PASS: python py_ringbuf
PASS: python py_queuestack
PASS: python py_test_map_batch_ops
PASS: python py_test_map_in_map
#### bcc tests summary ####
# TOTAL: 84
# PASS:  57
# FAIL:  27 ( cc resolve symbol addresses for a given PID; cc test bpf stack table; cc test bpf stack_id table; cc test hash of maps; cc test hash of maps using custom key; cc test array of maps; cc test read perf event; cc test sock map; cc test sock hash; cc test finding a probe in our own process; cc test fine a probe in our own binary with C++ API; cc test fine probes in our own binary with C++ API; cc test fine a probe in our Process with C++ API; cc test find a probe in our process' shared libs with c++ API; cc test usdt partial init w/ fail init_usdt; cc Test uprobe refcnt semaphore activation; python py_test_trace3_c; python py_test_clang; python py_test_histogram; python py_array; python py_uprobes; python py_test_tools_smoke; python py_test_tools_memleak; python py_test_usdt; python py_test_usdt2; python py_test_usdt3; python py_test_free_bcc_memory;)
###########################
DURATION: 1343
END: /usr/lib/bcc/ptest
BEGIN: /usr/lib/bpftrace/ptest
PASS: unit:ast.
PASS: unit:bpftrace.
PASS: unit:bpftrace_btf.
PASS: unit:childproc.
FAIL: unit:clang_parser.
PASS: unit:clang_parser_btf.
PASS: unit:LogStream.
PASS: unit:Log.
PASS: unit:Parser.
PASS: unit:semantic_analyser.
PASS: unit:portability_analyser.
PASS: unit:portability_analyser_btf.
PASS: unit:procmon.
PASS: unit:probe.
PASS: unit:probe_btf.
PASS: unit:required_resources.
PASS: unit:semantic_analyser_btf.
PASS: unit:semantic_analyser_dwarf.
PASS: unit:tracepoint_format_parser.
PASS: unit:utils.
PASS: runtime:addrspace
FAIL: runtime:array
PASS: runtime:banned_probes
PASS: runtime:basic
PASS: runtime:btf
PASS: runtime:builtin
FAIL: runtime:call
PASS: runtime:complex_types
FAIL: runtime:dwarf
PASS: runtime:engine
PASS: runtime:file-output
PASS: runtime:intcast
FAIL: runtime:intptrcast
FAIL: runtime:json-output
PASS: runtime:other
PASS: runtime:outputs
PASS: runtime:pointers
PASS: runtime:precedence
FAIL: runtime:probe
FAIL: runtime:regression
PASS: runtime:scripts
SKIP: runtime:sigint
PASS: runtime:signed_ints
PASS: runtime:struct
PASS: runtime:tuples
FAIL: runtime:uprobe
FAIL: runtime:usdt
FAIL: runtime:variable
SKIP: runtime:watchpoint
#### bpftrace tests summary ####
# TOTAL: 49
# PASS:  36
# FAIL:  11 (unit:clang_parser.; runtime:array; runtime:call; runtime:dwarf; runtime:intptrcast; runtime:json-output; runtime:probe; runtime:regression; runtime:uprobe; runtime:usdt; runtime:variable;)
# SKIP:  2
################################
DURATION: 1180
END: /usr/lib/bpftrace/ptest
```
---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
