### PR TITLE
compiler-rt-sanitizers: backport to build compiler-rt sanitizers

### DIFF
--- a/recipes-devtools/clang/clang/0037-sanitizer-Remove-include-linux-fs.h-to-resolve-fscon.patch
+++ b/recipes-devtools/clang/clang/0037-sanitizer-Remove-include-linux-fs.h-to-resolve-fscon.patch
@@ -1,0 +1,62 @@
+From 2095a89e5724866ae20d7f123b1c12b2758b58bd Mon Sep 17 00:00:00 2001
+From: Fangrui Song <i@maskray.me>
+Date: Mon, 11 Jul 2022 12:53:34 -0700
+Subject: [PATCH] [sanitizer] Remove #include <linux/fs.h> to resolve
+ fsconfig_command/mount_attr conflict with glibc 2.36
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+It is generally not a good idea to mix usage of glibc headers and Linux UAPI
+headers (https://sourceware.org/glibc/wiki/Synchronizing_Headers). In glibc
+since 7eae6a91e9b1670330c9f15730082c91c0b1d570 (milestone: 2.36), sys/mount.h
+defines `fsconfig_command` which conflicts with linux/mount.h:
+
+    .../usr/include/linux/mount.h:95:6: error: redeclaration of ‘enum fsconfig_command’
+
+Remove #include <linux/fs.h> which pulls in linux/mount.h. Expand its 4 macros manually.
+Android sys/mount.h doesn't define BLKBSZGET and it still needs linux/fs.h.
+In the long term we should move Linux specific definitions to sanitizer_platform_limits_linux.cpp
+but this commit is easy to cherry pick into older compiler-rt releases.
+
+Fix https://github.com/llvm/llvm-project/issues/56421
+
+Reviewed By: #sanitizers, vitalybuka, zatrazz
+
+Differential Revision: https://reviews.llvm.org/D129471
+
+Upstream-Status: Backport [https://github.com/llvm/llvm-project/commit/9cf13067cb5088626ba7ee1ec4c42ec59c7995a0]
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ .../sanitizer_platform_limits_posix.cpp                | 10 ++++++----
+ 1 file changed, 6 insertions(+), 4 deletions(-)
+
+diff --git a/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.cpp b/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.cpp
+index 32b8f47ed633..a29b31a432f0 100644
+--- a/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.cpp
++++ b/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.cpp
+@@ -73,7 +73,9 @@
+ #include <sys/vt.h>
+ #include <linux/cdrom.h>
+ #include <linux/fd.h>
++#if SANITIZER_ANDROID
+ #include <linux/fs.h>
++#endif
+ #include <linux/hdreg.h>
+ #include <linux/input.h>
+ #include <linux/ioctl.h>
+@@ -857,10 +859,10 @@ unsigned struct_ElfW_Phdr_sz = sizeof(Elf_Phdr);
+   unsigned IOCTL_EVIOCGPROP = IOCTL_NOT_PRESENT;
+   unsigned IOCTL_EVIOCSKEYCODE_V2 = IOCTL_NOT_PRESENT;
+ #endif
+-  unsigned IOCTL_FS_IOC_GETFLAGS = FS_IOC_GETFLAGS;
+-  unsigned IOCTL_FS_IOC_GETVERSION = FS_IOC_GETVERSION;
+-  unsigned IOCTL_FS_IOC_SETFLAGS = FS_IOC_SETFLAGS;
+-  unsigned IOCTL_FS_IOC_SETVERSION = FS_IOC_SETVERSION;
++  unsigned IOCTL_FS_IOC_GETFLAGS = _IOR('f', 1, long);
++  unsigned IOCTL_FS_IOC_GETVERSION = _IOR('v', 1, long);
++  unsigned IOCTL_FS_IOC_SETFLAGS = _IOW('f', 2, long);
++  unsigned IOCTL_FS_IOC_SETVERSION = _IOW('v', 2, long);
+   unsigned IOCTL_GIO_CMAP = GIO_CMAP;
+   unsigned IOCTL_GIO_FONT = GIO_FONT;
+   unsigned IOCTL_GIO_UNIMAP = GIO_UNIMAP;

--- a/recipes-devtools/clang/clang_git.bb
+++ b/recipes-devtools/clang/clang_git.bb
@@ -193,7 +193,7 @@ EXTRA_OECMAKE:append:class-target = "\
 
 DEPENDS = "binutils zlib libffi libxml2 libxml2-native ninja-native swig-native"
 DEPENDS:append:class-nativesdk = " clang-crosssdk-${SDK_ARCH} virtual/${TARGET_PREFIX}binutils-crosssdk nativesdk-python3"
-DEPENDS:append:class-target = " clang-cross-${TARGET_ARCH} python3"
+DEPENDS:append:class-target = " clang-cross-${TARGET_ARCH} python3 compiler-rt libcxx"
 
 RRECOMMENDS:${PN} = "binutils"
 RRECOMMENDS:${PN}:append:class-target = " libcxx-dev"

--- a/recipes-devtools/clang/common.inc
+++ b/recipes-devtools/clang/common.inc
@@ -46,6 +46,7 @@ SRC_URI = "\
     file://0034-clang-exclude-openembedded-distributions-from-settin.patch \
     file://0035-compiler-rt-Enable-__int128-for-ppc32.patch \
     file://0036-compiler-rt-builtins-Move-DMB-definition-to-syn-opsh.patch \
+    file://0037-sanitizer-Remove-include-linux-fs.h-to-resolve-fscon.patch \
     "
 # Fallback to no-PIE if not set
 GCCPIE ??= ""

--- a/recipes-devtools/clang/compiler-rt-sanitizers_git.bb
+++ b/recipes-devtools/clang/compiler-rt-sanitizers_git.bb
@@ -61,7 +61,8 @@ do_install:append () {
         rmdir --ignore-fail-on-non-empty ${D}${libdir}
     fi
     # Already shipped with compile-rt Orc support
-    rm -rf ${D}${nonarch_libdir}/clang/${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}/lib/linux/libclang_rt.orc-x86_64.a
+    rm -rf ${D}${nonarch_libdir}/clang/${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}/lib/linux/libclang_rt.orc-*.a
+    rm -rf ${D}${nonarch_libdir}/clang/${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}/include/orc/
 }
 
 FILES_SOLIBSDEV = ""

--- a/recipes-devtools/clang/compiler-rt-sanitizers_git.bb
+++ b/recipes-devtools/clang/compiler-rt-sanitizers_git.bb
@@ -17,7 +17,7 @@ TUNE_CCARGS:remove = "-no-integrated-as"
 
 DEPENDS += "ninja-native virtual/crypt"
 DEPENDS:append:class-native = " clang-native libxcrypt-native"
-DEPENDS:append:class-nativesdk = " clang-native nativesdk-libxcrypt"
+DEPENDS:append:class-nativesdk = " clang-native clang-crosssdk-${SDK_ARCH} nativesdk-libxcrypt"
 
 PACKAGECONFIG ??= ""
 PACKAGECONFIG[crt] = "-DCOMPILER_RT_BUILD_CRT:BOOL=ON,-DCOMPILER_RT_BUILD_CRT:BOOL=OFF"


### PR DESCRIPTION
Commits cherry picked from master:
     *   3dd695755cda  compiler-rt-sanitizers: fix multiple installations for orc lib  
     *   245e2346ab83  clang: Add compiler-rt and libcxx to build time depends for target  
     *   79236c2f7b01   compiler-rt-sanitizer: fix nativesdk-compiler-rt-sanitizers build    
     *   710434252979  sanitizer: Fix build with glibc 2.36 


To build compiler-rt and compiler-rt-sanitizer in SDK add in local.conf or in packagegroups:
```
TOOLCHAIN_HOST_TASK:append = "  nativesdk-compiler-rt  nativesdk-compiler-rt-sanitizers"   

TOOLCHAIN_TARGET_TASK:append = "  libcxx-dev libcxx-staticdev compiler-rt-dev compiler-rt-staticdev compiler-rt-sanitizers-dev compiler-rt-sanitizers-staticdev" 
```

 To Test:
Tested for a simple program to check address sanitizer by evoking return after free: 
```
#include<stdio.h>
int main() { 
       char *x = (char*)malloc(10 * sizeof(char*)); 
       free(x); 
       return x[5]; 
}
```
To Compile using SDK:
```
${CLANGCC} -rtlib=compiler-rt -fsanitize=address -O1 -fno-omit-frame-pointer -g test.c -o test   
```

To test for arm if built for qemuarm and same for aarch64:
```
qemu-arm  -L <path_to_sysroot_of_sdk> ./test  -v
```

Tested on full qemuarm image also.


### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
