### PR TITLE
clang: backport patches to fix lldb errors

### DIFF
--- a/recipes-devtools/clang/clang/0035-lldb-fix-swig-error.patch
+++ b/recipes-devtools/clang/clang/0035-lldb-fix-swig-error.patch
@@ -1,0 +1,30 @@
+From 392963bb1daf7ec8822a0f02929a8ada17eb0a0a Mon Sep 17 00:00:00 2001
+From: Jitka Plesnikova <jplesnik@redhat.com>
+Date: Wed, 21 Sep 2022 11:42:46 +0200
+Subject: [PATCH] [lldb] Fix 'error: non-const lvalue...' caused by SWIG 4.1.0
+
+Fix the failure caused by change in SwigValueWraper for C++11 and later
+for improved move semantics in SWIG commit.
+
+https://github.com/swig/swig/commit/d1055f4b3d51cb8060893f8036846ac743302dab
+(cherry picked from commit f0a25fe0b746f56295d5c02116ba28d2f965c175)
+
+Upstream-Status: Backport
+Signed-off-by: Anuj Mittal <anuj.mittal@intel.com>
+---
+ lldb/bindings/python/python-typemaps.swig | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/lldb/bindings/python/python-typemaps.swig b/lldb/bindings/python/python-typemaps.swig
+index bf3de66b91bf..d45431c771ca 100644
+--- a/lldb/bindings/python/python-typemaps.swig
++++ b/lldb/bindings/python/python-typemaps.swig
+@@ -435,7 +435,7 @@ template <> bool SetNumberFromPyObject<double>(double &number, PyObject *obj) {
+ 
+ %typemap(out) lldb::FileSP {
+   $result = nullptr;
+-  lldb::FileSP &sp = $1;
++  const lldb::FileSP &sp = $1;
+   if (sp) {
+     PythonFile pyfile = unwrapOrSetPythonException(PythonFile::FromFile(*sp));
+     if (!pyfile.IsValid())

--- a/recipes-devtools/clang/clang/0036-dc8f6ffc3bf297098a1dfd3fbce801afbe9f5238.patch
+++ b/recipes-devtools/clang/clang/0036-dc8f6ffc3bf297098a1dfd3fbce801afbe9f5238.patch
@@ -1,0 +1,46 @@
+From dc8f6ffc3bf297098a1dfd3fbce801afbe9f5238 Mon Sep 17 00:00:00 2001
+From: serge-sans-paille <sguelton@redhat.com>
+Date: Thu, 29 Sep 2022 21:48:38 +0200
+Subject: [PATCH] [lldb] Get rid of __STDC_LIMIT_MACROS and
+ __STDC_CONSTANT_MACROS
+
+C++11 made the use of these macro obsolete, see https://sourceware.org/bugzilla/show_bug.cgi?id=15366
+
+As a side effect this prevents https://github.com/swig/swig/issues/2193.
+
+Differential Revision: https://reviews.llvm.org/D134877
+
+(cherry picked from commit 81fc5f7909a4ef5a8d4b5da2a10f77f7cb01ba63)
+Upstream-Status: Backport
+Signed-off-by: Anuj Mittal <anuj.mittal@intel.com>
+---
+ lldb/bindings/CMakeLists.txt  | 2 --
+ lldb/bindings/interfaces.swig | 3 ---
+ 2 files changed, 5 deletions(-)
+
+diff --git a/lldb/bindings/CMakeLists.txt b/lldb/bindings/CMakeLists.txt
+index c8aa0bcf9681..9eed2f1e6299 100644
+--- a/lldb/bindings/CMakeLists.txt
++++ b/lldb/bindings/CMakeLists.txt
+@@ -26,8 +26,6 @@ set(SWIG_COMMON_FLAGS
+   -features autodoc
+   -I${LLDB_SOURCE_DIR}/include
+   -I${CMAKE_CURRENT_SOURCE_DIR}
+-  -D__STDC_LIMIT_MACROS
+-  -D__STDC_CONSTANT_MACROS
+   ${DARWIN_EXTRAS}
+ )
+ 
+diff --git a/lldb/bindings/interfaces.swig b/lldb/bindings/interfaces.swig
+index c9a6d0f06056..021c7683d170 100644
+--- a/lldb/bindings/interfaces.swig
++++ b/lldb/bindings/interfaces.swig
+@@ -1,8 +1,5 @@
+ /* Various liblldb typedefs that SWIG needs to know about.  */
+ #define __extension__ /* Undefine GCC keyword to make Swig happy when processing glibc's stdint.h. */
+-/* The ISO C99 standard specifies that in C++ implementations limit macros such
+-   as INT32_MAX should only be defined if __STDC_LIMIT_MACROS is. */
+-#define __STDC_LIMIT_MACROS
+ %include "stdint.i"
+ 
+ %include "lldb/lldb-defines.h"

--- a/recipes-devtools/clang/common.inc
+++ b/recipes-devtools/clang/common.inc
@@ -44,6 +44,8 @@ SRC_URI = "\
     file://0032-compiler-rt-Enable-__int128-for-ppc32.patch \
     file://0033-llvm-Do-not-use-cmake-infra-to-detect-libzstd.patch \
     file://0034-Revert-MIPS-compiler-rt-Fix-stat-struct-s-size-for-O.patch \
+    file://0035-lldb-fix-swig-error.patch \
+    file://0036-dc8f6ffc3bf297098a1dfd3fbce801afbe9f5238.patch \
     "
 # Fallback to no-PIE if not set
 GCCPIE ??= ""


### PR DESCRIPTION
OE-core recently upgraded to swig 4.1.0 which results in errors:

11:49:31  | /poky/build/tmp/work-shared/llvm-project-source-15.0.4-r0/git/lldb/bindings/interfaces.swig:5: Error: Macro '__STDC_LIMIT_MACROS' redefined, 11:49:31  | :1: Error: previous definition of '__STDC_LIMIT_MACROS'.

Backport patches from release/15.x branch to fix these.

Signed-off-by: Anuj Mittal <anuj.mittal@intel.com>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
