### PR TITLE
pixman: Do not use clang assembler for now

### DIFF
--- a/conf/nonclangable.conf
+++ b/conf/nonclangable.conf
@@ -344,4 +344,5 @@ DEPENDS:append:pn-pixman:mips:toolchain-clang = " openmp"
 #| .endfunc
 #| ^
 CFLAGS:append:pn-pixman:arm:toolchain-clang = " -no-integrated-as"
+CFLAGS:append:pn-pixman:aarch64:toolchain-clang = " -no-integrated-as"
 


### PR DESCRIPTION
Results in assembly file errors e.g.

| <instantiation>:1:1: error: unknown directive
| .func fname
| ^
| <instantiation>:2:1: note: while in macro instantiation | pixman_asm_function fname
| ^

Signed-off-by: Khem Raj <raj.khem@gmail.com>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
