### PR TITLE
rsync: Use gcc for now

### DIFF
--- a/conf/nonclangable.conf
+++ b/conf/nonclangable.conf
@@ -134,6 +134,9 @@ TOOLCHAIN:pn-php:mips = "gcc"
 # Clang-15 compiled openSSH tools crash on target ssh-keygen specifically
 TOOLCHAIN:pn-openssh = "gcc"
 
+# Workaround oe-core patching problem temporarily
+TOOLCHAIN:pn-rsync = "gcc"
+
 CFLAGS:append:pn-liboil:toolchain-clang:x86-64 = " -fheinous-gnu-extensions "
 
 #../libffi-3.2.1/src/arm/sysv.S:363:2: error: invalid instruction, did you mean: fldmiax?


### PR DESCRIPTION
Needed until [1] is merged into oe-core

[1] https://patchwork.yoctoproject.org/project/oe-core/patch/20221123215941.2411460-1-raj.khem@gmail.com/

Signed-off-by: Khem Raj <raj.khem@gmail.com>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
