### PR TITLE
objcopy: fix path for RISC-V

### DIFF
--- a/conf/nonclangable.conf
+++ b/conf/nonclangable.conf
@@ -1,3 +1,18 @@
+#linux-ld: ls-caps-vendor.o: relocation R_RISCV_HI20 against `a local symbol' can not be used when making a shared object; recompile with -fPIC
+#| clang-14: error: unable to execute command: Segmentation fault (core dumped)
+#| clang-14: error: linker command failed due to signal (use -v to see invocation)
+TOOLCHAIN:pn-pciutils:riscv64 = "gcc"
+
+#| riscv64-yadro-linux-ld: erl_bits.c:(.text+0xc60): undefined reference to `__extendhfsf2'
+#| riscv64-yadro-linux-ld: erl_bits.c:(.text+0x1a8a): undefined reference to `__truncdfhf2'
+TOOLCHAIN:pn-erlang:riscv64 = "gcc"
+
+#| linux-yocto/5.15.72+gitAUTOINC+c6aba7f07a_0b628306d1-r0/temp/run.do_uboot_mkimage.47933: 185: riscv64-yadro-linux-llvm-objcopy: not found
+OBJCOPY:pn-linux-yocto:riscv64:toolchain-clang = "${HOST_PREFIX}objcopy"
+
+#babeltrace2: ELF binary /usr/lib/babeltrace2/plugins/babeltrace-plugin-text.so has relocations in .text [textrel]
+TOOLCHAIN:pn-babeltrace2 = "gcc"
+TOOLCHAIN:pn-u-boot = "gcc"
 TOOLCHAIN:pn-cpufrequtils = "gcc"
 
 # | grub-mkimage: error: relocation 0x2b is not implemented yet.


### PR DESCRIPTION
Make path to OBJCOPY correct for linux-yocto package. Use gcc for now for erlang and pciutils.

Signed-off-by: Alexey Smirnov <pyih.soft@gmail.com>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
