### PR TITLE
nonclangable.conf: Add new exceptions

### DIFF
--- a/conf/nonclangable.conf
+++ b/conf/nonclangable.conf
@@ -1,3 +1,20 @@
+#| clang-15: error: unable to execute command: Segmentation fault (core dumped)
+#| clang-15: error: linker command failed due to signal (use -v to see invocation)
+TOOLCHAIN:pn-pciutils:riscv64 = "gcc"
+
+#| erl_bits.c:(.text+0xc2a): undefined reference to `__extendhfsf2'
+#| erl_bits.c:(.text+0x1bfa): undefined reference to `__truncsfhf2'
+#| clang-15: error: linker command failed with exit code 1 (use -v to see invocation)
+# both riscv64 and x86-64
+TOOLCHAIN:pn-erlang = "gcc"
+
+# run.do_uboot_mkimage.1228: 185: riscv64-yadro-linux-llvm-objcopy: not found
+# FileNotFoundError: [Errno 2] No such file or directory: 'x86_64-yadro-linux-llvm-objcopy'
+# both riscv64 and x86-64
+OBJCOPY:pn-linux-yocto:toolchain-clang = "${HOST_PREFIX}objcopy"
+
+TOOLCHAIN:pn-grub:genericx86-64 = "gcc"
+
 TOOLCHAIN:pn-cpufrequtils = "gcc"
 
 # | grub-mkimage: error: relocation 0x2b is not implemented yet.


### PR DESCRIPTION
Add "pciutils" for riscv64 architecture
Add "erlang" for all architectures (found on riscv64 and x86-64) Add "grub" for x86-64 architecture
Use proper OBJCOPY for "linux-yocto" for all architectures

Signed-off-by: Aleksey Smirnov <aleksey.smirnov@yadro.com>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
