### PR TITLE
clang: Fix build with LFS64 on musl

### DIFF
--- a/recipes-devtools/clang/clang/0035-cmake-Enable-64bit-off_t-on-32bit-glibc-systems.patch
+++ b/recipes-devtools/clang/clang/0035-cmake-Enable-64bit-off_t-on-32bit-glibc-systems.patch
@@ -1,0 +1,84 @@
+From e5edc21a119c9bc0bea6e942adf8b172ec8a987a Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Fri, 9 Dec 2022 16:17:12 -0800
+Subject: [PATCH] cmake: Enable 64bit off_t on 32bit glibc systems
+
+Pass -D_FILE_OFFSET_BITS=64 to compiler flags on 32bit glibc based
+systems. This will make sure that 64bit versions of LFS functions are
+used e.g. seek will behave same as lseek64. Also revert [1] partially
+because this added a cmake test to detect lseek64 but then forgot to
+pass the needed macro to actual compile, this test was incomplete too
+since libc implementations like musl has 64bit off_t by default on 32bit
+systems and does not bundle[2] -D_LARGEFILE64_SOURCE under -D_GNU_SOURCE
+like glibc, which means the compile now fails on musl because the cmake
+check passes but we do not have _LARGEFILE64_SOURCE defined. Using the
+*64 function was transitional anyways so use -D_FILE_OFFSET_BITS=64
+instead
+
+[1] https://github.com/llvm/llvm-project/commit/8db7e5e4eed4c4e697dc3164f2c9351d8c3e942b
+[2] https://git.musl-libc.org/cgit/musl/commit/?id=25e6fee27f4a293728dd15b659170e7b9c7db9bc
+
+Upstream-Status: Submitted [https://reviews.llvm.org/D139752]
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ llvm/cmake/config-ix.cmake              | 8 +++++---
+ llvm/include/llvm/Config/config.h.cmake | 3 ---
+ llvm/lib/Support/raw_ostream.cpp        | 2 --
+ 3 files changed, 5 insertions(+), 8 deletions(-)
+
+diff --git a/llvm/cmake/config-ix.cmake b/llvm/cmake/config-ix.cmake
+index 7e657fd1532d..b03d433ea5b0 100644
+--- a/llvm/cmake/config-ix.cmake
++++ b/llvm/cmake/config-ix.cmake
+@@ -284,9 +284,6 @@ check_symbol_exists(futimes sys/time.h HAVE_FUTIMES)
+ if( HAVE_SIGNAL_H AND NOT LLVM_USE_SANITIZER MATCHES ".*Address.*" AND NOT APPLE )
+   check_symbol_exists(sigaltstack signal.h HAVE_SIGALTSTACK)
+ endif()
+-set(CMAKE_REQUIRED_DEFINITIONS "-D_LARGEFILE64_SOURCE")
+-check_symbol_exists(lseek64 "sys/types.h;unistd.h" HAVE_LSEEK64)
+-set(CMAKE_REQUIRED_DEFINITIONS "")
+ check_symbol_exists(mallctl malloc_np.h HAVE_MALLCTL)
+ check_symbol_exists(mallinfo malloc.h HAVE_MALLINFO)
+ check_symbol_exists(mallinfo2 malloc.h HAVE_MALLINFO2)
+@@ -350,6 +347,11 @@ check_symbol_exists(__GLIBC__ stdio.h LLVM_USING_GLIBC)
+ if( LLVM_USING_GLIBC )
+   add_definitions( -D_GNU_SOURCE )
+   list(APPEND CMAKE_REQUIRED_DEFINITIONS "-D_GNU_SOURCE")
++# enable 64bit off_t on 32bit systems using glibc
++  if (CMAKE_SIZEOF_VOID_P EQUAL 4)
++    add_definitions( -D_FILE_OFFSET_BITS=64 )
++    list(APPEND CMAKE_REQUIRED_DEFINITIONS "-D_FILE_OFFSET_BITS=64")
++  endif()
+ endif()
+ # This check requires _GNU_SOURCE
+ if (NOT PURE_WINDOWS)
+diff --git a/llvm/include/llvm/Config/config.h.cmake b/llvm/include/llvm/Config/config.h.cmake
+index 21ce3a94a5ed..d551ebad5c0c 100644
+--- a/llvm/include/llvm/Config/config.h.cmake
++++ b/llvm/include/llvm/Config/config.h.cmake
+@@ -128,9 +128,6 @@
+ /* Define to 1 if you have the <link.h> header file. */
+ #cmakedefine HAVE_LINK_H ${HAVE_LINK_H}
+ 
+-/* Define to 1 if you have the `lseek64' function. */
+-#cmakedefine HAVE_LSEEK64 ${HAVE_LSEEK64}
+-
+ /* Define to 1 if you have the <mach/mach.h> header file. */
+ #cmakedefine HAVE_MACH_MACH_H ${HAVE_MACH_MACH_H}
+ 
+diff --git a/llvm/lib/Support/raw_ostream.cpp b/llvm/lib/Support/raw_ostream.cpp
+index 651949ad5765..0bc71812cbd4 100644
+--- a/llvm/lib/Support/raw_ostream.cpp
++++ b/llvm/lib/Support/raw_ostream.cpp
+@@ -804,8 +804,6 @@ uint64_t raw_fd_ostream::seek(uint64_t off) {
+   flush();
+ #ifdef _WIN32
+   pos = ::_lseeki64(FD, off, SEEK_SET);
+-#elif defined(HAVE_LSEEK64)
+-  pos = ::lseek64(FD, off, SEEK_SET);
+ #else
+   pos = ::lseek(FD, off, SEEK_SET);
+ #endif
+-- 
+2.38.1
+

--- a/recipes-devtools/clang/common.inc
+++ b/recipes-devtools/clang/common.inc
@@ -44,6 +44,7 @@ SRC_URI = "\
     file://0032-compiler-rt-Enable-__int128-for-ppc32.patch \
     file://0033-llvm-Do-not-use-cmake-infra-to-detect-libzstd.patch \
     file://0034-Revert-MIPS-compiler-rt-Fix-stat-struct-s-size-for-O.patch \
+    file://0035-cmake-Enable-64bit-off_t-on-32bit-glibc-systems.patch \
     "
 # Fallback to no-PIE if not set
 GCCPIE ??= ""


### PR DESCRIPTION
Ensures that correct cmake checks are used to enable LFS64

Signed-off-by: Khem Raj <raj.khem@gmail.com>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
