### PR TITLE
nonclangable.conf: Add new exceptions

### DIFF
--- a/conf/nonclangable.conf
+++ b/conf/nonclangable.conf
@@ -1,5 +1,6 @@
 TOOLCHAIN:pn-cpufrequtils = "gcc"
 
+TOOLCHAIN:pn-grub:genericx86-64 = "gcc"
 # | grub-mkimage: error: relocation 0x2b is not implemented yet.
 TOOLCHAIN:pn-grub-efi:aarch64 = "gcc"
 TOOLCHAIN:pn-grub-efi:riscv32 = "gcc"
@@ -12,6 +13,13 @@ TOOLCHAIN:pn-grub:aarch64 = "gcc"
 TOOLCHAIN:pn-crash = "gcc"
 # | ../../elfutils-0.187/libasm/asm_newscn.c:49:22: error: field 'pattern' with variable sized type 'struct FillPattern' not at the end of a struct or class is a GNU extension [-Werror,-Wgnu-variable-sized-type-not-at-end]
 TOOLCHAIN:pn-elfutils:libc-glibc = "gcc"
+
+#| erl_bits.c:(.text+0xc2a): undefined reference to `__extendhfsf2'
+#| erl_bits.c:(.text+0x1bfa): undefined reference to `__truncsfhf2'
+#| clang-15: error: linker command failed with exit code 1 (use -v to see invocation)
+# both riscv64 and x86-64
+TOOLCHAIN:pn-erlang = "gcc"
+
 # /mnt/a/yoe/build/tmp/work/cortexa7t2hf-neon-vfpv4-yoe-linux-gnueabi/firefox/60.1.0esr-r0/recipe-sysroot-native/usr/lib/clang/7.0.1/include/arm_neon.h:433:1: error: unknown type name 'inline'
 # __ai uint8x16_t vabdq_u8(uint8x16_t __p0, uint8x16_t __p1) {
 TOOLCHAIN:pn-firefox = "gcc"
@@ -301,7 +309,8 @@ LTO:pn-cairo:toolchain-clang = ""
 RANLIB:append:pn-tcf-agent:toolchain-clang = " $@"
 
 # Subprocess output:mips-yoe-linux-llvm-objcopy: error: Link field value 22 in section .rel.dyn is not a symbol table
-OBJCOPY:pn-linux-yocto:toolchain-clang:mips = "${HOST_PREFIX}objcopy"
+# also seen on riscv64 and x86-64
+OBJCOPY:pn-linux-yocto:toolchain-clang = "${HOST_PREFIX}objcopy"
 
 # see https://github.com/llvm/llvm-project/issues/53948
 OBJCOPY:pn-opensbi:toolchain-clang = "${HOST_PREFIX}objcopy"


### PR DESCRIPTION
Add "erlang" for all architectures (found on riscv64 and x86-64) Add "grub" for x86-64 architecture
Use proper OBJCOPY for "linux-yocto" for all architectures

Signed-off-by: Aleksey Smirnov <aleksey.smirnov@yadro.com>
Signed-off-by: Khem Raj <raj.khem@gmail.com>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
