### PR TITLE
Fix OpenMP builds with thin LTO enabled.

### DIFF
--- a/recipes-devtools/clang/openmp_git.bb
+++ b/recipes-devtools/clang/openmp_git.bb
@@ -12,6 +12,8 @@ TOOLCHAIN = "clang"
 
 LIC_FILES_CHKSUM = "file://openmp/LICENSE.TXT;md5=d75288d1ce0450b28b8d58a284c09c79"
 
+LDFLAGS:append = " -fuse-ld=lld"
+
 inherit cmake pkgconfig perlnative
 
 DEPENDS += "elfutils libffi clang"


### PR DESCRIPTION
When built with thin LTO enabled, LLVM produces object files containing LLVM IR, which ld can't understand. Since we're forcing the toolchain to clang anyway, let's also force using lld.

I was supposed to make this patch against master, but I can not reproduce it there, and my machine is too weak to repeatedly rebuild various clang versions in a reasonable time.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
- [X] `Signed-off-by` is present
- [X] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
