### PR TITLE
mybw: Use gnu objcopy on rv32

### DIFF
--- a/conf/nonclangable.conf
+++ b/conf/nonclangable.conf
@@ -333,6 +333,7 @@ OBJCOPY:pn-mybw:mips:toolchain-clang = "${HOST_PREFIX}objcopy"
 OBJCOPY:pn-mybw:x86:toolchain-clang = "${HOST_PREFIX}objcopy"
 OBJCOPY:pn-mybw:x86-64:toolchain-clang = "${HOST_PREFIX}objcopy"
 OBJCOPY:pn-mybw:riscv64:toolchain-clang = "${HOST_PREFIX}objcopy"
+OBJCOPY:pn-mybw:riscv32:toolchain-clang = "${HOST_PREFIX}objcopy"
 
 # Fails with llvm strip
 # i686-yoe-linux-llvm-strip: error: SHT_STRTAB string table section [index 9] is non-null terminated

--- a/conf/nonclangable.conf
+++ b/conf/nonclangable.conf
@@ -270,6 +270,7 @@ LDFLAGS:append:pn-qemu:toolchain-clang:x86 = " -latomic"
 # warning: <elfFile> has a LOAD segment with RWX permissions
 LDFLAGS:append:pn-ruby:toolchain-clang:powerpc = " -Wl,--no-warn-rwx-segment"
 LDFLAGS:append:pn-cairo:toolchain-clang:powerpc = " -Wl,--no-warn-rwx-segment"
+LDFLAGS:append:pn-systemd:toolchain-clang:powerpc = " -Wl,--no-warn-rwx-segment"
 
 # glibc is built with gcc and hence encodes some libgcc specific builtins which are not found
 # when doing static linking with clang using compiler-rt, so use libgcc

--- a/conf/nonclangable.conf
+++ b/conf/nonclangable.conf
@@ -267,6 +267,9 @@ COMPILER_RT:pn-qtbase:toolchain-clang:riscv32 = "-rtlib=compiler-rt ${UNWINDLIB}
 
 LDFLAGS:append:pn-qtwebengine:toolchain-clang:runtime-gnu:x86 = " -latomic"
 LDFLAGS:append:pn-qemu:toolchain-clang:x86 = " -latomic"
+# warning: <elfFile> has a LOAD segment with RWX permissions
+LDFLAGS:append:pn-ruby:toolchain-clang:powerpc = " -Wl,--no-warn-rwx-segment"
+LDFLAGS:append:pn-cairo:toolchain-clang:powerpc = " -Wl,--no-warn-rwx-segment"
 
 # glibc is built with gcc and hence encodes some libgcc specific builtins which are not found
 # when doing static linking with clang using compiler-rt, so use libgcc

--- a/recipes-core/systemd/systemd_%.bbappend
+++ b/recipes-core/systemd/systemd_%.bbappend
@@ -1,7 +1,0 @@
-FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
-
-# systemd 251.4 started to cause boot issues see
-# https://bugzilla.yoctoproject.org/show_bug.cgi?id=14906
-# As a workaround disable O2 and use Os for now with clang
-SELECTED_OPTIMIZATION:append:toolchain-clang = "-Os"
-SELECTED_OPTIMIZATION:remove:toolchain-clang = "-O2"


### PR DESCRIPTION
Fixes
/usr/bin/mybw', 'TOPDIR/build/tmp/work/riscv32-yoe-linux/mybw/0.0+gitAUTOINC+f4bdeee126-r0/package/usr/bin/.debug/mybw']' returned non-zero exit status 1. Subprocess output:riscv32-yoe-linux-llvm-objcopy: error: Link field value 37 in section .rela.dyn is not a symbol table

Signed-off-by: Khem Raj <raj.khem@gmail.com>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
