### PR TITLE
layer.conf: update LAYERSERIES_COMPAT for mickledore

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -7,7 +7,7 @@ BBFILES += "${LAYERDIR}/recipes*/*/*.bb ${LAYERDIR}/recipes*/*/*.bbappend"
 BBFILE_COLLECTIONS += "clang-layer"
 BBFILE_PATTERN_clang-layer := "^${LAYERDIR}/"
 BBFILE_PRIORITY_clang-layer = "7"
-LAYERSERIES_COMPAT_clang-layer = "kirkstone langdale"
+LAYERSERIES_COMPAT_clang-layer = "mickledore"
 LAYERDEPENDS_clang-layer = "core"
 
 BBFILES_DYNAMIC += " \


### PR DESCRIPTION
* oe-core switched to mickedore in: https://git.openembedded.org/openembedded-core/commit/?id=57239d66b933c4313cf331d35d13ec2d0661c38f