### PR TITLE
pixman: Use gcc on aarch64

### DIFF
--- a/conf/nonclangable.conf
+++ b/conf/nonclangable.conf
@@ -148,6 +148,9 @@ TOOLCHAIN:pn-rsync = "gcc"
 # U-boot does compile with clang but clang-15 crashes compiling it :(
 TOOLCHAIN:pn-u-boot = "gcc"
 
+# See https://github.com/kraj/meta-clang/issues/696
+TOOLCHAIN:pn-pixman:aarch64 = "gcc"
+
 CFLAGS:append:pn-liboil:toolchain-clang:x86-64 = " -fheinous-gnu-extensions "
 
 #../libffi-3.2.1/src/arm/sysv.S:363:2: error: invalid instruction, did you mean: fldmiax?
@@ -367,5 +370,4 @@ DEPENDS:append:pn-pixman:mips:toolchain-clang = " openmp"
 #| .endfunc
 #| ^
 CFLAGS:append:pn-pixman:arm:toolchain-clang = " -no-integrated-as"
-CFLAGS:append:pn-pixman:aarch64:toolchain-clang = " -no-integrated-as"
 


### PR DESCRIPTION
Some upgrades have regressed pixman with clang on aarch64, until this is sorted, lets use gcc for it as a workaround

Signed-off-by: Khem Raj <raj.khem@gmail.com>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
