### PR TITLE
openmp: skip buildpaths QA check for openmp-staticdev

### DIFF
--- a/recipes-devtools/clang/openmp_git.bb
+++ b/recipes-devtools/clang/openmp_git.bb
@@ -44,6 +44,8 @@ FILES_SOLIBSDEV = ""
 FILES:${PN} += "${libdir}/lib*${SOLIBSDEV}"
 FILES:${PN}-libomptarget = "${libdir}/libomptarget-*.bc"
 INSANE_SKIP:${PN} = "dev-so"
+# Currently the static libraries contain buildpaths
+INSANE_SKIP:${PN}-staticdev += "buildpaths"
 
 COMPATIBLE_HOST:mips64 = "null"
 COMPATIBLE_HOST:riscv32 = "null"


### PR DESCRIPTION
The /usr/lib/libomptarget.devicertl.a static library ends up with build paths embedded.  The CMake files don't respect our CXXFLAGS so don't use the -fdebug-path-map arguments, but even adding those didn't solve it: it looks like code via goes via LLVM bytecode files doesn't get remapped?

Until that is solved, skip the buildpath check.

Signed-off-by: Ross Burton <ross.burton@arm.com>
