### PR TITLE
Fix/spdx for clang

### DIFF
--- a/recipes-devtools/clang/common-source.inc
+++ b/recipes-devtools/clang/common-source.inc
@@ -9,3 +9,9 @@ SRC_URI = ""
 
 do_configure[depends] += "llvm-project-source-${PV}:do_patch"
 do_populate_lic[depends] += "llvm-project-source-${PV}:do_unpack"
+do_create_spdx[depends] += "llvm-project-source-${PV}:do_patch"
+
+# spdx shared workdir detection fails as not WORKDIR is altered but S and B
+# return always true to fix that
+def is_work_shared_spdx(d):
+    return True

--- a/recipes-devtools/clang/llvm-project-source.inc
+++ b/recipes-devtools/clang/llvm-project-source.inc
@@ -92,3 +92,5 @@ python add_distro_vendor() {
 }
 
 do_patch[postfuncs] += "add_distro_vendor"
+do_create_spdx[depends] += "${PN}:do_patch"
+


### PR DESCRIPTION
This PR fixes the use of llvm-project-sources from their shared location in combination with create-spdx class code from core

Relates to #721 
---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
