### PR TITLE
libcxx: Build libc++abi into static libc++.a

### DIFF
--- a/conf/nonclangable.conf
+++ b/conf/nonclangable.conf
@@ -172,6 +172,8 @@ TOOLCHAIN:pn-u-boot-coral = "gcc"
 
 # See https://github.com/kraj/meta-clang/issues/696
 TOOLCHAIN:pn-pixman:aarch64 = "gcc"
+# libomp needs to link in libatomic after itself when -fopenmp is used
+TOOLCHAIN:pn-pixman:mipsarcho32 = "gcc"
 
 CFLAGS:append:pn-liboil:toolchain-clang:x86-64 = " -fheinous-gnu-extensions "
 

--- a/recipes-devtools/clang/libcxx_git.bb
+++ b/recipes-devtools/clang/libcxx_git.bb
@@ -60,6 +60,7 @@ EXTRA_OECMAKE += "\
                   -DLLVM_TEMPORARILY_ALLOW_OLD_TOOLCHAIN=ON \
                   -DLLVM_ENABLE_RTTI=ON \
                   -DLIBUNWIND_ENABLE_CROSS_UNWINDING=ON \
+                  -DLIBCXX_ENABLE_STATIC_ABI_LIBRARY=ON \
                   -DLIBCXXABI_INCLUDE_TESTS=OFF \
                   -DLIBCXXABI_ENABLE_SHARED=ON \
                   -DLIBCXXABI_LIBCXX_INCLUDES=${S}/libcxx/include \

--- a/recipes-devtools/clang/openmp_git.bb
+++ b/recipes-devtools/clang/openmp_git.bb
@@ -32,7 +32,7 @@ PACKAGECONFIG ?= "ompt-tools offloading-plugin"
 PACKAGECONFIG:remove:arm = "ompt-tools offloading-plugin"
 PACKAGECONFIG:remove:powerpc = "ompt-tools offloading-plugin"
 
-PACKAGECONFIG:append:mips = " no-atomics"
+PACKAGECONFIG:append:mipsarcho32 = " no-atomics"
 
 PACKAGECONFIG[ompt-tools] = "-DOPENMP_ENABLE_OMPT_TOOLS=ON,-DOPENMP_ENABLE_OMPT_TOOLS=OFF,"
 PACKAGECONFIG[aliases] = "-DLIBOMP_INSTALL_ALIASES=ON,-DLIBOMP_INSTALL_ALIASES=OFF,"


### PR DESCRIPTION
This helps statically linking c++ runtime into binaries which use exceptions functions e.g. std::out_of_range as used in rwmem package and using -static-libstdc++ compiler flags

Signed-off-by: Khem Raj <raj.khem@gmail.com>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
