### PR TITLE
llvm-project-source: Ensure sstate hash doesn't change

### DIFF
--- a/recipes-devtools/clang/llvm-project-source.inc
+++ b/recipes-devtools/clang/llvm-project-source.inc
@@ -8,7 +8,6 @@ RM_WORK_EXCLUDE += "${PN}"
 inherit nopackages
 
 PN = "llvm-project-source-${PV}"
-
 WORKDIR = "${TMPDIR}/work-shared/llvm-project-source-${PV}-${PR}"
 SSTATE_SWSPEC = "sstate:llvm-project-source::${PV}:${PR}::${SSTATE_VERSION}:"
 
@@ -18,6 +17,13 @@ STAMPCLEAN = "${STAMPS_DIR}/work-shared/llvm-project-source-${PV}-*"
 INHIBIT_DEFAULT_DEPS = "1"
 DEPENDS = ""
 PACKAGES = ""
+TARGET_ARCH = "allarch"
+TARGET_AS_ARCH = "none"
+TARGET_CC_ARCH = "none"
+TARGET_LD_ARCH = "none"
+TARGET_OS = "linux"
+baselib = "lib"
+PACKAGE_ARCH = "all"
 
 # space separated list of additional distro vendor values we want to support e.g.
 # "yoe webos" or "-yoe -webos" '-' is optional


### PR DESCRIPTION
This if a follow-up of the gcc-source in oe-core [1] and this will fix this recipe when used with multiconfig machines in a way that it can be reused between the machines.

[1] https://git.yoctoproject.org/poky/commit/?id=2cdaa164e8b4618a82ccd3fcb87cf58e36b6d6d3

Signed-off-by: Jose Quaresma <jose.quaresma@foundries.io>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ x] Changes have been tested
- [x ] `Signed-off-by` is present
- [x ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
