### PR TITLE
openmp: Provide missing tools during cross compile

### DIFF
--- a/recipes-devtools/clang/openmp_git.bb
+++ b/recipes-devtools/clang/openmp_git.bb
@@ -12,7 +12,7 @@ TOOLCHAIN = "clang"
 
 LIC_FILES_CHKSUM = "file://openmp/LICENSE.TXT;md5=d75288d1ce0450b28b8d58a284c09c79"
 
-inherit cmake pkgconfig perlnative
+inherit cmake pkgconfig perlnative python3native
 
 DEPENDS += "elfutils libffi clang"
 
@@ -23,6 +23,9 @@ EXTRA_OECMAKE += "-DCMAKE_BUILD_TYPE=RelWithDebInfo \
                   -DCLANG_TOOL=${STAGING_BINDIR_NATIVE}/clang \
                   -DLINK_TOOL=${STAGING_BINDIR_NATIVE}/llvm-link \
                   -DOPT_TOOL=${STAGING_BINDIR_NATIVE}/opt \
+                  -DOPENMP_LLVM_LIT_EXECUTABLE=${STAGING_BINDIR_NATIVE}/llvm-lit \
+                  -DEXTRACT_TOOL=${STAGING_BINDIR_NATIVE}/llvm-extract \
+                  -DPACKAGER_TOOL=${STAGING_BINDIR_NATIVE}/clang-offload-packager \
                   -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
                   "
 
@@ -40,10 +43,14 @@ PACKAGECONFIG[aliases] = "-DLIBOMP_INSTALL_ALIASES=ON,-DLIBOMP_INSTALL_ALIASES=O
 PACKAGECONFIG[offloading-plugin] = ",,elfutils libffi,libelf libffi"
 PACKAGECONFIG[no-atomics] = "-DLIBOMP_HAVE_BUILTIN_ATOMIC=OFF -DLIBOMP_LIBFLAGS='-latomic',,"
 
-PACKAGES += "${PN}-libomptarget"
+PACKAGES += "${PN}-libomptarget ${PN}-gdb-plugin"
 FILES_SOLIBSDEV = ""
 FILES:${PN} += "${libdir}/lib*${SOLIBSDEV}"
 FILES:${PN}-libomptarget = "${libdir}/libomptarget-*.bc"
+FILES:${PN}-gdb-plugin = "${datadir}/gdb/python/ompd"
+
+RDEPENDS:${PN}-gdb-plugin += "python3-core"
+
 INSANE_SKIP:${PN} = "dev-so"
 # Currently the static libraries contain buildpaths
 INSANE_SKIP:${PN}-staticdev += "buildpaths"


### PR DESCRIPTION
Enable ompd gdb plugin build and add py3 to depndencies as it is required by the plugin

Signed-off-by: Khem Raj <raj.khem@gmail.com>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
