### PR TITLE
nonclangable.conf: Add new exceptions for alternative Linux kernel re…

### DIFF
--- a/conf/nonclangable.conf
+++ b/conf/nonclangable.conf
@@ -343,6 +343,8 @@ RANLIB:append:pn-tcf-agent:toolchain-clang = " $@"
 # Subprocess output:mips-yoe-linux-llvm-objcopy: error: Link field value 22 in section .rel.dyn is not a symbol table
 # also seen on riscv64 and x86-64
 OBJCOPY:pn-linux-yocto:toolchain-clang = "${HOST_PREFIX}objcopy"
+OBJCOPY:pn-linux-yocto-dev:toolchain-clang = "${HOST_PREFIX}objcopy"
+OBJCOPY:pn-linux-yocto-rt:toolchain-clang = "${HOST_PREFIX}objcopy"
 OBJCOPY:pn-linux-variscite:toolchain-clang = "${HOST_PREFIX}objcopy"
 OBJCOPY:pn-linux-ti-staging:toolchain-clang = "${HOST_PREFIX}objcopy"
 OBJCOPY:pn-linux-raspberrypi:toolchain-clang = "${HOST_PREFIX}objcopy"


### PR DESCRIPTION
…cipes

Other Linux kernel recipes are seeing the same objcopy issue.  Add entries for them to work around the issue here as well.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
