### PR TITLE
bindgen-cli: New recipe for version 0.64.0

### DIFF
--- a/recipes-devtools/bindgen-cli/bindgen-cli_0.64.0.bb
+++ b/recipes-devtools/bindgen-cli/bindgen-cli_0.64.0.bb
@@ -1,0 +1,23 @@
+SUMMARY = "Automatically generates Rust FFI bindings to C and C++ libraries."
+HOMEPAGE = "https://rust-lang.github.io/rust-bindgen/"
+LICENSE = "BSD-3-Clause"
+
+LIC_FILES_CHKSUM = "file://bindgen-cli/LICENSE;md5=0b9a98cb3dcdefcceb145324693fda9b"
+
+inherit rust cargo cargo-update-recipe-crates
+
+SRC_URI = "git://github.com/rust-lang/rust-bindgen.git;protocol=https;nobranch=1;branch=main"
+SRCREV = "ae6817256ac557981906e93a1f866349db85053e"
+
+S = "${WORKDIR}/git"
+
+CARGO_SRC_DIR = "bindgen-cli"
+CARGO_LOCK_SRC_DIR = "bindgen-cli"
+
+do_install:append:class-native() {
+	create_wrapper ${D}/${bindir}/bindgen LIBCLANG_PATH="${STAGING_LIBDIR_NATIVE}"
+}
+
+RDEPENDS:${PN} = "libclang"
+
+BBCLASSEXTEND = "native"


### PR DESCRIPTION
It is used by Mesa to build Rusticl.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
