### PR TITLE
Revert "webkitgtk: Use gcc for now"

### DIFF
--- a/conf/nonclangable.conf
+++ b/conf/nonclangable.conf
@@ -304,9 +304,6 @@ COMPILER_RT:remove:pn-m4:armeb = "-rtlib=compiler-rt"
 COMPILER_RT:remove:pn-ruby:armeb = "-rtlib=compiler-rt"
 COMPILER_RT:remove:pn-webkitgtk:armeb = "-rtlib=compiler-rt"
 
-# Does not work with libc++ 15.x
-TOOLCHAIN:pn-webkitgtk = "gcc"
-
 # build/lib/libQt5Widgets.so: undefined reference to `__lshrti3'
 # __lshrti3 is missing in libgcc
 COMPILER_RT:pn-qtbase:toolchain-clang:riscv32 = "-rtlib=compiler-rt ${UNWINDLIB}"


### PR DESCRIPTION
This reverts commit 20a8cff8ba0ce02773946cd7ba398fc08969ce1e.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
