### PR TITLE
clang: Move clang-cl from clang-tools -> clang package

### DIFF
--- a/recipes-devtools/clang/clang_git.bb
+++ b/recipes-devtools/clang/clang_git.bb
@@ -303,7 +303,6 @@ FILES:${PN}-tools = "${bindir}/analyze-build \
   ${bindir}/clang-apply-replacements \
   ${bindir}/clang-change-namespace \
   ${bindir}/clang-check \
-  ${bindir}/clang-cl \
   ${bindir}/clang-doc \
   ${bindir}/clang-extdef-mapping \
   ${bindir}/clang-include-fixer \
@@ -346,15 +345,12 @@ FILES:${PN}-tools = "${bindir}/analyze-build \
 "
 
 FILES:${PN} += "\
+  ${bindir}/clang-cl \
   ${libdir}/BugpointPasses.so \
   ${libdir}/LLVMHello.so \
-  ${libdir}/LLVMgold.so \
   ${libdir}/*Plugin.so \
   ${libdir}/${BPN} \
   ${nonarch_libdir}/${BPN}/*/include/ \
-  ${datadir}/scan-* \
-  ${nonarch_libdir}/libscanbuild \
-  ${datadir}/opt-viewer/ \
 "
 
 FILES:lldb = "\


### PR DESCRIPTION
clang-cl is a symlink to clang, if we package it into clang-tools then it created an automatic dependency on the package providing clang binary which is clang in this case. So when someone wants to install just clang-tools, it will drag the compiler along as well, which may not be desired, this fixes the problem.

Fixes https://github.com/kraj/meta-clang/issues/676

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
