### PR TITLE
clang: Move .so symlinks to -dev package fixes multilib build

### DIFF
--- a/recipes-devtools/clang/clang_git.bb
+++ b/recipes-devtools/clang/clang_git.bb
@@ -283,8 +283,8 @@ FILES:lldb-server = "\
 "
 
 FILES:liblldb = "\
-  ${libdir}/liblldbIntelFeatures.so* \
-  ${libdir}/liblldb.so* \
+  ${libdir}/liblldbIntelFeatures.so.* \
+  ${libdir}/liblldb.so.* \
 "
 
 FILES:${PN}-libllvm =+ "\


### PR DESCRIPTION
Fixes
ERROR: lib32-clang-15.0.7-r0 do_package_qa: QA Issue: non -dev/-dbg/nativesdk- package lib32-liblldb contains symlink .so '/usr/lib/liblldbIntelFeatures.so'
non -dev/-dbg/nativesdk- package lib32-liblldb contains symlink .so '/usr/lib/liblldb.so' [dev-so]                                                                                      ERROR: lib32-clang-15.0.7-r0 do_package_qa: Fatal QA errors were found, failing task.

cherry-pick from master:9133a0f788f605da6d752bdb20d5e5062253f480

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
