### PR TITLE
Add missing scan-build runtime dependencies (dunfell)

### DIFF
--- a/recipes-devtools/clang/clang_git.bb
+++ b/recipes-devtools/clang/clang_git.bb
@@ -223,6 +223,18 @@ PROVIDES_append_class-native = " llvm-native"
 
 BBCLASSEXTEND = "native nativesdk"
 
+RDEPENDS:${PN} += "\
+  perl-module-digest-md5 \
+  perl-module-file-basename \
+  perl-module-file-copy \
+  perl-module-file-find \
+  perl-module-file-path \
+  perl-module-findbin \
+  perl-module-hash-util \
+  perl-module-sys-hostname \
+  perl-module-term-ansicolor \
+"
+
 RDEPENDS_lldb += "${PN}-lldb-python"
 
 FILES_${PN}-lldb-python = "${libdir}/python*/site-packages/lldb/*"


### PR DESCRIPTION
---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)

Missing perl modules runtime dependencies causes errors when executing perl scan-build script. For example:

```shell
`Can't locate FindBin.pm in @INC (you may need to install the FindBin module) (@INC contains: /opt/poky/3.1.24/sysroots/x86_64-pokysdk-linux//usr/lib/perl5/site_perl/5.30.1/x86_64-linux /opt/poky/3.1.24/sysroots/x86_64-pokysdk-linux//usr/lib/perl5/site_perl/5.30.1 /opt/poky/3.1.24/sysroots/x86_64-pokysdk-linux//usr/lib/perl5/vendor_perl/5.30.1 /opt/poky/3.1.24/sysroots/x86_64-pokysdk-linux//usr/lib/perl5/5.30.1/x86_64-linux /opt/poky/3.1.24/sysroots/x86_64-pokysdk-linux//usr/lib/perl5/5.30.1 /usr/local/oe-sdk-hardcoded-buildpath/sysroots/x86_64-pokysdk-linux/usr/lib/perl5/site_perl/5.30.1/x86_64-linux /usr/local/oe-sdk-hardcoded-buildpath/sysroots/x86_64-pokysdk-linux/usr/lib/perl5/site_perl/5.30.1 /usr/local/oe-sdk-hardcoded-buildpath/sysroots/x86_64-pokysdk-linux/usr/lib/perl5/vendor_perl/5.30.1/x86_64-linux /usr/local/oe-sdk-hardcoded-buildpath/sysroots/x86_64-pokysdk-linux/usr/lib/perl5/vendor_perl/5.30.1 /usr/local/oe-sdk-hardcoded-buildpath/sysroots/x86_64-pokysdk-linux/usr/lib/perl5/5.30.1/x86_64-linux /usr/local/oe-sdk-hardcoded-buildpath/sysroots/x86_64-pokysdk-linux/usr/lib/perl5/5.30.1 .) at /opt/poky/3.1.24/sysroots/x86_64-pokysdk-linux/usr/bin/scan-build line 16.
BEGIN failed--compilation aborted at /opt/poky/3.1.24/sysroots/x86_64-pokysdk-linux/usr/bin/scan-build line 16.
```

Same fix as #777  but on dunfell are the binaries inside the clang package instead of the clang-tools package.
