### PR TITLE
clang: fix reproducibily issue

### DIFF
--- a/recipes-devtools/clang/clang/0037-clang-Call-printName-to-get-name-of-Decl.patch
+++ b/recipes-devtools/clang/clang/0037-clang-Call-printName-to-get-name-of-Decl.patch
@@ -1,0 +1,70 @@
+From d33d6a8c4f43907cb53130730a2bc48624a34b74 Mon Sep 17 00:00:00 2001
+From: Dan McGregor <dan.mcgregor@usask.ca>
+Date: Tue, 21 Mar 2023 13:04:51 -0600
+Subject: [PATCH] [clang] Call printName to get name of Decl
+
+Rather than sending a name directly to the stream, use printName
+to preserve any PrintingPolicy. This ensures that names are properly
+affected by path remapping.
+
+Differential Revision: https://reviews.llvm.org/D149272
+
+Upstream-Status: pending
+---
+ clang/lib/AST/Decl.cpp                  |  4 ++--
+ clang/lib/AST/DeclarationName.cpp       |  4 ++--
+ clang/test/CodeGen/debug-prefix-map.cpp | 11 +++++++++++
+ 3 files changed, 15 insertions(+), 4 deletions(-)
+ create mode 100644 clang/test/CodeGen/debug-prefix-map.cpp
+
+diff --git a/clang/lib/AST/Decl.cpp b/clang/lib/AST/Decl.cpp
+index e60cc28f6e0f..24de6156c0f5 100644
+--- a/clang/lib/AST/Decl.cpp
++++ b/clang/lib/AST/Decl.cpp
+@@ -1626,8 +1626,8 @@ Module *Decl::getOwningModuleForLinkage(bool IgnoreLinkage) const {
+   llvm_unreachable("unknown module kind");
+ }
+ 
+-void NamedDecl::printName(raw_ostream &OS, const PrintingPolicy&) const {
+-  OS << Name;
++void NamedDecl::printName(raw_ostream &OS, const PrintingPolicy &Policy) const {
++  Name.print(OS, Policy);
+ }
+ 
+ void NamedDecl::printName(raw_ostream &OS) const {
+diff --git a/clang/lib/AST/DeclarationName.cpp b/clang/lib/AST/DeclarationName.cpp
+index c1219041a466..da8b3886c340 100644
+--- a/clang/lib/AST/DeclarationName.cpp
++++ b/clang/lib/AST/DeclarationName.cpp
+@@ -117,12 +117,12 @@ static void printCXXConstructorDestructorName(QualType ClassType,
+   Policy.adjustForCPlusPlus();
+ 
+   if (const RecordType *ClassRec = ClassType->getAs<RecordType>()) {
+-    OS << *ClassRec->getDecl();
++    ClassRec->getDecl()->printName(OS, Policy);
+     return;
+   }
+   if (Policy.SuppressTemplateArgsInCXXConstructors) {
+     if (auto *InjTy = ClassType->getAs<InjectedClassNameType>()) {
+-      OS << *InjTy->getDecl();
++      InjTy->getDecl()->printName(OS, Policy);
+       return;
+     }
+   }
+diff --git a/clang/test/CodeGen/debug-prefix-map.cpp b/clang/test/CodeGen/debug-prefix-map.cpp
+new file mode 100644
+index 000000000000..7ddaee531282
+--- /dev/null
++++ b/clang/test/CodeGen/debug-prefix-map.cpp
+@@ -0,0 +1,11 @@
++// RUN: %clang_cc1 -debug-info-kind=standalone -fdebug-prefix-map=%p=./UNLIKELY_PATH/empty -S %s -emit-llvm -o - | FileCheck %s
++
++struct alignas(64) an {
++  struct {
++    unsigned char x{0};
++  } arr[64];
++};
++
++struct an *pan = new an;
++
++// CHECK: !DISubprogram(name: "(unnamed struct at ./UNLIKELY_PATH/empty{{/|\\\\}}{{.*}}",

--- a/recipes-devtools/clang/common.inc
+++ b/recipes-devtools/clang/common.inc
@@ -46,6 +46,7 @@ SRC_URI = "\
     file://0034-compiler-rt-Undef-_TIME_BITS-along-with-_FILE_OFFSET.patch \
     file://0035-compiler-rt-Fix-stat-struct-s-size-for-O32-ABI.patch \
     file://0036-compiler-rt-Undef-_TIME_BITS-along-with-_FILE_OFFSET.patch \
+    file://0037-clang-Call-printName-to-get-name-of-Decl.patch \
     "
 # Fallback to no-PIE if not set
 GCCPIE ??= ""


### PR DESCRIPTION
Clang gives a name to the constructors of anonymous structures in debug info that's based on the filename of the structure's definition. It didn't respect the debug-prefix-map setting, causimg QA warnings in several recipes, notably libcxx.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
