### PR TITLE
btrfs-tools: Error out on x86 options on non-x86 arches

### DIFF
--- a/conf/nonclangable.conf
+++ b/conf/nonclangable.conf
@@ -261,6 +261,8 @@ TUNE_CCARGS:remove:pn-nfs-utils:toolchain-clang = "-Qunused-arguments"
 TUNE_CCARGS:remove:pn-pipewire:toolchain-clang = "-Qunused-arguments"
 TUNE_CCARGS:remove:pn-tesseract:toolchain-clang = "-Qunused-arguments"
 TUNE_CCARGS:remove:pn-pulseaudio:toolchain-clang = "-Qunused-arguments"
+TUNE_CCARGS:remove:pn-btrfs-tools:toolchain-clang = "-Qunused-arguments"
+TUNE_CCARGS:append:pn-btrfs-tools:toolchain-clang = " -Werror=unused-command-line-argument"
 
 # Disable altivec on ppc32
 #/usr/include/eigen3/Eigen/src/Core/arch/AltiVec/PacketMath.h:1345:32: error: use of undeclared identifier 'vec_sqrt'; did you mean 'vec_rsqrt'?


### PR DESCRIPTION
e.g. -msha will otherwise be deemed available when using clang which is not correct, therefore treat unused-command-line-argument as error which will be flagged on non-x86 arches

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
