### PR TITLE
mesa: remove bbappend

### DIFF
--- a/recipes-graphics/mesa/mesa_%.bbappend
+++ b/recipes-graphics/mesa/mesa_%.bbappend
@@ -1,2 +1,0 @@
-YOCTO_ALTERNATE_EXE_PATH:toolchain-clang = "${STAGING_LIBDIR}/llvm-config"
-YOCTO_ALTERNATE_EXE_PATH:toolchain-clang = "1"


### PR DESCRIPTION
This bbappend is now just:

YOCTO_ALTERNATE_EXE_PATH:toolchain-clang = "${STAGING_LIBDIR}/llvm-config" YOCTO_ALTERNATE_EXE_PATH:toolchain-clang = "1"

This results in YOCTO_ALTERNATE_EXE_PATH being "1". The second line is clearly a typo, so if we remove this then it changes the path from STAGING_BINDIR (as set in clang.bbclass) to STAGING_LIBDIR. If this is the correct change to make then it should be done in clang.bbclass instead.

Also, the only place that YOCTO_ALTERNATE_EXE_PATH is respected is as an environment variable, and this is never exported. It is likely that the second line was meant to end [export] = "1".

This parameter appears to be no longer needed, so remove the append.