### PR TITLE
clang: Fix upstream status of 0037-clang-Call-printName-to-get-name-o…

### DIFF
--- a/recipes-devtools/clang/clang/0037-clang-Call-printName-to-get-name-of-Decl.patch
+++ b/recipes-devtools/clang/clang/0037-clang-Call-printName-to-get-name-of-Decl.patch
@@ -9,7 +9,7 @@ affected by path remapping.
 
 Differential Revision: https://reviews.llvm.org/D149272
 
-Upstream-Status: pending
+Upstream-Status: Pending
 ---
  clang/lib/AST/Decl.cpp                  |  4 ++--
  clang/lib/AST/DeclarationName.cpp       |  4 ++--


### PR DESCRIPTION
…f-Decl.patch

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
