### PR TITLE
llvm-config: add --libfiles option

### DIFF
--- a/recipes-devtools/clang/clang/llvm-config
+++ b/recipes-devtools/clang/clang/llvm-config
@@ -22,6 +22,11 @@ if [[ $1 == "--bindir" ]]; then
   exec "$NEXT_LLVM_CONFIG" $@
 fi
 
+if [[ $1 == "--libfiles" ]]; then
+  exec "$NEXT_LLVM_CONFIG" $@
+fi
+
+
 for arg in "$@"; do
   case "$arg" in
     --cppflags)


### PR DESCRIPTION
--libfiles        Fully qualified library filenames for makefile depends.

This option is being used by ispc cmake.
https://github.com/ispc/ispc/blob/main/cmake/FindLLVM.cmake#L116

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
