### PR TITLE
ffmpeg: Enable zbb manip extensions for rv32/rv64

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -32,7 +32,7 @@ INHERIT += "clang"
 # Do not include clang in SDK unless user wants to
 CLANGSDK ??= "0"
 
-LLVMVERSION = "16.0.3"
+LLVMVERSION = "16.0.5"
 
 require conf/nonclangable.conf
 require conf/nonscanable.conf

--- a/conf/nonclangable.conf
+++ b/conf/nonclangable.conf
@@ -254,6 +254,9 @@ CFLAGS:append:pn-seatd:toolchain-clang = " -Wno-sign-compare"
 CXXFLAGS:remove:pn-mozjs:toolchain-clang = "-fno-tree-vrp"
 CFLAGS:remove:pn-mozjs:toolchain-clang = "-fno-tree-vrp"
 
+CFLAGS:append:pn-ffmpeg:riscv64 = " -march=rv64gczbb"
+CFLAGS:append:pn-ffmpeg:riscv32 = " -march=rv32gczbb"
+
 TUNE_CCARGS:remove:pn-omxplayer:toolchain-clang = "-no-integrated-as"
 TUNE_CCARGS:remove:pn-nfs-utils:toolchain-clang = "-Qunused-arguments"
 

--- a/recipes-devtools/clang/clang.inc
+++ b/recipes-devtools/clang/clang.inc
@@ -6,9 +6,9 @@ LLVM_GIT_PROTOCOL ?= "https"
 
 MAJOR_VER = "16"
 MINOR_VER = "0"
-PATCH_VER = "3"
+PATCH_VER = "5"
 
-SRCREV ?= "bd6783b380768bd35f37e0034dccf6c5736dd031"
+SRCREV ?= "5729e63ac7b47c6ad40f904fedafad3c07cf71ea"
 
 PV = "${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}"
 #BRANCH = "release/15.x"


### PR DESCRIPTION
This is required with clang after the assembly file is added which uses these instructions. it works with gcc because it uses .option directive to enable zbb extentions in toolchain on the fly clang does not have similar option

| <instantiation>:6:21: warning: unknown option, expected 'push', 'pop', 'rvc', 'norvc', 'relax' or 'norelax'
|             .option arch, +zbb

This fixes

| src/libavcodec/riscv/bswapdsp_rvb.S:61:9: error: instruction requires the following: 'Zbb' (Basic Bit-Manipulation) or 'Zbkb' (Bitmanip instructions for Cryptography)
|         rev8 t0, t0
|         ^

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
