### PR TITLE
clang.bbclass: create lld symbolic link in sysroot when ld-is-lld is set

### DIFF
--- a/classes/clang.bbclass
+++ b/classes/clang.bbclass
@@ -137,6 +137,16 @@ set( CMAKE_CLANG_TIDY ${HOST_PREFIX}clang-tidy )
 EOF
     sed -i 's/ -mmusl / /g' ${WORKDIR}/toolchain.cmake
 }
+
+RECIPESYSROOTFUNCS = ""
+RECIPESYSROOTFUNCS:toolchain-clang = "recipe_sysroot_check_ld_is_lld"
+
+recipe_sysroot_check_ld_is_lld () {
+    if "${@bb.utils.contains('DISTRO_FEATURES', 'ld-is-lld', 'true', 'false', d)}"; then
+        ln -srf ${RECIPE_SYSROOT_NATIVE}${bindir}/${TARGET_SYS}/${TARGET_PREFIX}ld.lld ${RECIPE_SYSROOT_NATIVE}${bindir}/${TARGET_SYS}/${TARGET_PREFIX}ld
+    fi
+}
+do_prepare_recipe_sysroot[postfuncs] += "${RECIPESYSROOTFUNCS}"
 #
 # dump recipes which still use gcc
 #python __anonymous() {


### PR DESCRIPTION
Create a symbolic link lld -> ld in recipe sysroot to choose the default linker lld when ld-is-lld is set in DISTRO_FEATURES. othereise, we can get linking issues when '-fuse-ld=lld' is in LDFLAGS but the actual ld is not lld.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
