### PR TITLE
bcc: updating the shebang of python scripts in tools to python3

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-devtools/bcc/bcc_0.26.0.bb
+++ b/dynamic-layers/openembedded-layer/recipes-devtools/bcc/bcc_0.26.0.bb
@@ -55,6 +55,8 @@ EXTRA_OECMAKE = " \
 "
 
 do_install:append() {
+        sed -e 's@#!/usr/bin/env python@#!/usr/bin/env python3@g' \
+            -i $(find ${D}${datadir}/${PN} -type f)
         sed -e 's@#!/usr/bin/python@#!/usr/bin/env python3@g' \
             -i $(find ${D}${datadir}/${PN} -type f)
 }


### PR DESCRIPTION
the upstream changed the shebang of python scripts in tools folder[1], this would cause do_install:append cannot conver all scripts.

[1] https://github.com/iovisor/bcc/commit/3f5e402bcadf44ce0250864db52673bf7317797b

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
