### PR TITLE
clang: Apply upstream D152570

### DIFF
--- a/recipes-devtools/clang/clang/0038-clang-Apply-fmacro-prefix-map-to-anonymous-tags-in-t.patch
+++ b/recipes-devtools/clang/clang/0038-clang-Apply-fmacro-prefix-map-to-anonymous-tags-in-t.patch
@@ -1,0 +1,86 @@
+From 98a5709ff5a34a2906536e110d227f83898f550b Mon Sep 17 00:00:00 2001
+From: Dan McGregor <dan.mcgregor@usask.ca>
+Date: Fri, 16 Jun 2023 08:47:00 -0700
+Subject: [PATCH] [clang] Apply -fmacro-prefix-map to anonymous tags in
+ template arguments
+
+When expanding template arguments for pretty function printing,
+such as for __PRETTY_FUNCTION__, make TypePrinter apply
+macro-prefix-map remapping to anonymous tags such as lambdas.
+
+Fixes https://github.com/llvm/llvm-project/issues/63219
+
+Reviewed By: MaskRay, aaron.ballman
+
+Differential Revision: https://reviews.llvm.org/D152570
+
+Upstream-Status: Backport
+---
+ clang/docs/ReleaseNotes.rst                       |  2 ++
+ clang/lib/AST/Expr.cpp                            | 14 ++++++++++++++
+ clang/test/CodeGenCXX/macro-prefix-map-lambda.cpp | 14 ++++++++++++++
+ 3 files changed, 30 insertions(+)
+ create mode 100644 clang/test/CodeGenCXX/macro-prefix-map-lambda.cpp
+
+diff --git a/clang/docs/ReleaseNotes.rst b/clang/docs/ReleaseNotes.rst
+index 8d67ff904469..bf3ea4a54d01 100644
+--- a/clang/docs/ReleaseNotes.rst
++++ b/clang/docs/ReleaseNotes.rst
+@@ -724,6 +724,8 @@ Bug Fixes in This Version
+ - Fix crash when passing a braced initializer list to a parentehsized aggregate
+   initialization expression.
+   (`#63008 <https://github.com/llvm/llvm-project/issues/63008>`_).
++- Apply ``-fmacro-prefix-map`` to anonymous tags in template arguments
++  (`#63219 <https://github.com/llvm/llvm-project/issues/63219>`_).
+ 
+ Bug Fixes to Compiler Builtins
+ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+diff --git a/clang/lib/AST/Expr.cpp b/clang/lib/AST/Expr.cpp
+index e45ae68cd5fe..a65678f5998c 100644
+--- a/clang/lib/AST/Expr.cpp
++++ b/clang/lib/AST/Expr.cpp
+@@ -783,7 +783,21 @@ std::string PredefinedExpr::ComputeName(IdentKind IK, const Decl *CurrentDecl) {
+         Out << "static ";
+     }
+ 
++    class PrettyCallbacks final : public PrintingCallbacks {
++    public:
++      PrettyCallbacks(const LangOptions &LO) : LO(LO) {}
++      std::string remapPath(StringRef Path) const override {
++        SmallString<128> p(Path);
++        LO.remapPathPrefix(p);
++        return std::string(p);
++      }
++
++    private:
++      const LangOptions &LO;
++    };
+     PrintingPolicy Policy(Context.getLangOpts());
++    PrettyCallbacks PrettyCB(Context.getLangOpts());
++    Policy.Callbacks = &PrettyCB;
+     std::string Proto;
+     llvm::raw_string_ostream POut(Proto);
+ 
+diff --git a/clang/test/CodeGenCXX/macro-prefix-map-lambda.cpp b/clang/test/CodeGenCXX/macro-prefix-map-lambda.cpp
+new file mode 100644
+index 000000000000..e87f0ab484dc
+--- /dev/null
++++ b/clang/test/CodeGenCXX/macro-prefix-map-lambda.cpp
+@@ -0,0 +1,14 @@
++// RUN: %clang_cc1 -triple %itanium_abi_triple -fmacro-prefix-map=%p=./UNLIKELY_PATH/empty %s -emit-llvm -o - | FileCheck %s
++
++template<typename f>
++auto lambdatest(f&& cb) {
++  const char *s = __PRETTY_FUNCTION__;
++  return s;
++}
++
++int main() {
++  auto *s = lambdatest([](){});
++// CHECK: @"__PRETTY_FUNCTION__._Z10lambdatestIZ4mainE3$_0EDaOT_" = private unnamed_addr constant [{{[0-9]+}} x i8] c"auto lambdatest(f &&) [f = (lambda at ./UNLIKELY_PATH/empty{{/|\\\\}}{{.*}}.cpp:[[#@LINE-1]]:24)]\00", align 1
++
++  return 0;
++}
+-- 
+2.40.1
+

--- a/recipes-devtools/clang/common.inc
+++ b/recipes-devtools/clang/common.inc
@@ -47,6 +47,7 @@ SRC_URI = "\
     file://0035-compiler-rt-Fix-stat-struct-s-size-for-O32-ABI.patch \
     file://0036-compiler-rt-Undef-_TIME_BITS-along-with-_FILE_OFFSET.patch \
     file://0037-clang-Call-printName-to-get-name-of-Decl.patch \
+    file://0038-clang-Apply-fmacro-prefix-map-to-anonymous-tags-in-t.patch \
     "
 # Fallback to no-PIE if not set
 GCCPIE ??= ""


### PR DESCRIPTION
This fixes real file names appearing in lambda names that are used as arguments to function templates.

This fixes llvm/llvm-project#63219, which I spotted when building cmake.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
