### PR TITLE
llvm-config: fix script for multilib build

### DIFF
--- a/recipes-devtools/clang/clang/llvm-config
+++ b/recipes-devtools/clang/clang/llvm-config
@@ -8,7 +8,11 @@
 SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 NEXT_LLVM_CONFIG="$(which -a llvm-config | sed -n 2p)"
 export YOCTO_ALTERNATE_EXE_PATH="${YOCTO_ALTERNATE_EXE_PATH:="$(readlink -f "$SCRIPT_DIR/../llvm-config")"}"
-export YOCTO_ALTERNATE_LIBDIR="${YOCTO_ALTERNATE_LIBDIR:="/lib"}"
+if [ -n "$( echo $base_libdir | sed -n '/lib64/p')" ]; then
+    export YOCTO_ALTERNATE_LIBDIR="${YOCTO_ALTERNATE_LIBDIR:="/lib64"}"
+else
+    export YOCTO_ALTERNATE_LIBDIR="${YOCTO_ALTERNATE_LIBDIR:="/lib"}"
+fi
 if [[ $# == 0 ]]; then
   exec "$NEXT_LLVM_CONFIG"
 fi


### PR DESCRIPTION
From multilib build:
| CMake Error at cmake/FindLLVM.cmake:79 (message):
|   Failed running
|  tmp-glibc/work/x86-64-v3-oe-linux/ispc/1.20.0-r0/recipe-sysroot/usr/bin/crossscripts/llvm-config;--libfiles;engine;ipo;bitreader;bitwriter;instrumentation;linker;option;frontendopenmp;windowsdriver;x86
| Call Stack (most recent call first):
|   cmake/FindLLVM.cmake:116 (run_llvm_config)
|   CMakeLists.txt:377 (get_llvm_libfiles)

Currently hardcoded to /lib, which causing multilib build failure.

An easy solution could be set and export YOCTO_ALTERNATE_LIBDIR to $baselib in recipe, but it would require to add this in all affected recipes.

Other approach is to handle in llvm-config script itself. Unfortunately $baselib is not available in env for the llvm-config script, so extracting baselib value from $base_libdir as its being exported and available in env and then set YOCTO_ALTERNATE_LIBDIR accordingly.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
