### PR TITLE
[kirkstone] clang: fix build with yocto uninative gcc 13

### DIFF
--- a/recipes-devtools/clang/clang/0038-Add-missing-cstdint.patch
+++ b/recipes-devtools/clang/clang/0038-Add-missing-cstdint.patch
@@ -1,0 +1,32 @@
+From ff1681ddb303223973653f7f5f3f3435b48a1983 Mon Sep 17 00:00:00 2001
+From: Sergei Trofimovich <slyich@gmail.com>
+Date: Mon, 23 May 2022 08:03:23 +0100
+Subject: [PATCH] [Support] Add missing <cstdint> header to Signals.h
+
+Without the change llvm build fails on this week's gcc-13 snapshot as:
+
+    [  0%] Building CXX object lib/Support/CMakeFiles/LLVMSupport.dir/Signals.cpp.o
+    In file included from llvm/lib/Support/Signals.cpp:14:
+    llvm/include/llvm/Support/Signals.h:119:8: error: variable or field 'CleanupOnSignal' declared void
+      119 |   void CleanupOnSignal(uintptr_t Context);
+          |        ^~~~~~~~~~~~~~~
+
+Upstream-Status: Backport [https://github.com/llvm/llvm-project/commit/ff1681ddb303223973653f7f5f3f3435b48a1983]
+
+Signed-off-by: Jose Quaresma <jose.quaresma@foundries.io>
+---
+ llvm/include/llvm/Support/Signals.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/llvm/include/llvm/Support/Signals.h b/llvm/include/llvm/Support/Signals.h
+index 44f5a750ff5cb..937e0572d4a72 100644
+--- a/llvm/include/llvm/Support/Signals.h
++++ b/llvm/include/llvm/Support/Signals.h
+@@ -14,6 +14,7 @@
+ #ifndef LLVM_SUPPORT_SIGNALS_H
+ #define LLVM_SUPPORT_SIGNALS_H
+ 
++#include <cstdint>
+ #include <string>
+ 
+ namespace llvm {

--- a/recipes-devtools/clang/common.inc
+++ b/recipes-devtools/clang/common.inc
@@ -47,6 +47,7 @@ SRC_URI = "\
     file://0035-compiler-rt-Enable-__int128-for-ppc32.patch \
     file://0036-compiler-rt-builtins-Move-DMB-definition-to-syn-opsh.patch \
     file://0037-sanitizer-Remove-include-linux-fs.h-to-resolve-fscon.patch \
+    file://0038-Add-missing-cstdint.patch \
     "
 # Fallback to no-PIE if not set
 GCCPIE ??= ""


### PR DESCRIPTION
---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ x ] Changes have been tested
- [ x ] `Signed-off-by` is present
- [ x ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
