### PR TITLE
bpftrace: Fix v0.18.0 build with PTEST_ENABLED

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-devtools/bpftrace/bpftrace_0.18.0.bb
+++ b/dynamic-layers/openembedded-layer/recipes-devtools/bpftrace/bpftrace_0.18.0.bb
@@ -12,6 +12,7 @@ DEPENDS += "bison-native \
             libcereal \
             libbpf \
             "
+DEPENDS += "${@bb.utils.contains('PTEST_ENABLED', '1', 'pahole-native llvm-native', '', d)}"
 
 PV .= "+git${SRCREV}"
 RDEPENDS:${PN} += "bash python3 xz"


### PR DESCRIPTION
Building bpftrace tests after upgrade requires pahole and llvm-objcopy.
Otherwise do_configure fails with errors:
```
| CMake Error at tests/data/CMakeLists.txt:5 (find_program):
|   Could not find PAHOLE using the following names: pahole

| CMake Error at tests/data/CMakeLists.txt:6 (find_program):
|   Could not find LLVM_OBJCOPY using the following names: llvm-objcopy,
|   llvm-objcopy-16, llvm16-objcopy
```

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
