### PR TITLE
clang: Move .so symlinks to -dev package fixes multilib build

### DIFF
--- a/recipes-devtools/clang/clang_git.bb
+++ b/recipes-devtools/clang/clang_git.bb
@@ -371,8 +371,8 @@ FILES:lldb-server = "\
 "
 
 FILES:liblldb = "\
-  ${libdir}/liblldbIntelFeatures.so* \
-  ${libdir}/liblldb.so* \
+  ${libdir}/liblldbIntelFeatures.so.* \
+  ${libdir}/liblldb.so.* \
 "
 
 FILES:${PN}-libllvm =+ "\


### PR DESCRIPTION
Fixes
ERROR: lib32-clang-15.0.7-r0 do_package_qa: QA Issue: non -dev/-dbg/nativesdk- package lib32-liblldb contains symlink .so '/usr/lib/liblldbIntelFeatures.so'
non -dev/-dbg/nativesdk- package lib32-liblldb contains symlink .so '/usr/lib/liblldb.so' [dev-so]                                                                                      ERROR: lib32-clang-15.0.7-r0 do_package_qa: Fatal QA errors were found, failing task.

I know langdale is out of support, but if you can apply this simple backport it will keep my CI world builds a bit happier, thanks.