### PR TITLE
libclc: Define llvm tools needed during build

### DIFF
--- a/recipes-devtools/clang/libclc_git.bb
+++ b/recipes-devtools/clang/libclc_git.bb
@@ -17,6 +17,11 @@ OECMAKE_SOURCEPATH = "${S}/libclc"
 
 EXTRA_OECMAKE += " \
 				-DCMAKE_CROSSCOMPILING_EMULATOR=${WORKDIR}/qemuwrapper \
+				-DLLVM_CLANG=${STAGING_BINDIR_NATIVE}/clang \
+				-DLLVM_AS=${STAGING_BINDIR_NATIVE}/llvm-as \
+				-DLLVM_LINK=${STAGING_BINDIR_NATIVE}/llvm-link \
+				-DLLVM_OPT=${STAGING_BINDIR_NATIVE}/opt \
+				-DLLVM_SPIRV=${STAGING_BINDIR_NATIVE}/llvm-spirv \
 				-Dclc_comp_in:FILEPATH=${OECMAKE_SOURCEPATH}/cmake/CMakeCLCCompiler.cmake.in \
 				-Dll_comp_in:FILEPATH=${OECMAKE_SOURCEPATH}/cmake/CMakeLLAsmCompiler.cmake.in \
 			"


### PR DESCRIPTION
It pokes at target llvm.cmake and gets the path
LLVM_TOOLS_BINARY_DIR pointing to target sysroot
however during cross builds it should be looking
for tools for cross building in native sysroot

MJ: otherwise it may fail to build with gold linker:
    DWARF error: invalid or unhandled FORM value: 0x23