### PR TITLE
qtbase: Do not use internal assembler with clang

### DIFF
--- a/conf/nonclangable.conf
+++ b/conf/nonclangable.conf
@@ -249,6 +249,13 @@ CFLAGS:append:pn-nettle:toolchain-clang:powerpc64le = " -no-integrated-as"
 #|                           ^
 CFLAGS:append:pn-concurrencykit:toolchain-clang:arm = " -no-integrated-as"
 CFLAGS:append:pn-sysbench:toolchain-clang:arm = " -no-integrated-as"
+#error: expected absolute expression
+#.elseif (bpp == 24) && (numpix == 8)
+#        ^
+#<instantiation>:50:5: note: while in macro instantiation
+#    pixld chunk_size, mask_bpp, mask_basereg, MASK
+#    ^
+CFLAGS:append:pn-qtbase:toolchain-clang:arm = " -no-integrated-as"
 
 #../git/common/connection.c:154:55: error: comparison of integers of different signs: 'unsigned long' and 'int' [-Werror,-Wsign-compare]
 #        for (cmsg = CMSG_FIRSTHDR(msg); cmsg != NULL; cmsg = CMSG_NXTHDR(msg, cmsg)) {


### PR DESCRIPTION
This ends up with compile errors when using clang compiler, therefore internal assembler is disabled with qt6

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
