### PR TITLE
nonclangable.conf: fix systemd efi build

### DIFF
--- a/conf/nonclangable.conf
+++ b/conf/nonclangable.conf
@@ -269,6 +269,11 @@ CFLAGS:remove:pn-mozjs:toolchain-clang = "-fno-tree-vrp"
 CFLAGS:append:pn-ffmpeg:riscv64 = " -march=rv64gczbb"
 CFLAGS:append:pn-ffmpeg:riscv32 = " -march=rv32gczbb"
 
+# otherwise systemd efi fails to build
+# error: the 'sse' unit is not supported with this instruction set
+TUNE_CCARGS:remove:pn-systemd:toolchain-clang = "-mfpmath=sse"
+TUNE_CCARGS:remove:pn-systemd-boot:toolchain-clang = "-mfpmath=sse"
+
 TUNE_CCARGS:remove:pn-omxplayer:toolchain-clang = "-no-integrated-as"
 TUNE_CCARGS:remove:pn-nfs-utils:toolchain-clang = "-Qunused-arguments"
 


### PR DESCRIPTION
- systemd-boot have it fixed on recipe but as it a clang issue it's better to move it here
- systemd needs it when build with efi package config enabled since v254

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
