### PR TITLE
recipe_sysroot_check_ld_is_lld: Do not create symlink for allarch rec…

### DIFF
--- a/classes/clang.bbclass
+++ b/classes/clang.bbclass
@@ -143,6 +143,7 @@ RECIPESYSROOTFUNCS:toolchain-clang = "recipe_sysroot_check_ld_is_lld"
 
 recipe_sysroot_check_ld_is_lld () {
     if ${@bb.utils.contains('DISTRO_FEATURES', 'ld-is-lld', 'true', 'false', d)} &&  \
+        ${@bb.utils.contains('PACKAGE_ARCH', 'all', 'false', 'true', d)}   &&  \
         ${@bb.utils.contains('INHIBIT_DEFAULT_DEPS', '1', 'false', 'true', d)}; then
         ln -srf ${STAGING_BINDIR_TOOLCHAIN}/${TARGET_PREFIX}ld.lld ${STAGING_BINDIR_TOOLCHAIN}/${TARGET_PREFIX}ld
     fi


### PR DESCRIPTION
…ipes

allarch recipes do not really need compiler toolchains, otherwise they are not allarch

Fixes issues like
| ln: failed to create symbolic link 'TOPDIR/build/tmp/work/cortexa72-cortexa53-crypto-yoe-linux/ca-certificates/20211016-r0/recipe-sysroot-native/usr/bin/aarch64-yoe-linux/aarch64-yoe-linux-ld': No such file or directory

Reported-by: Cliff Brake <cbrake@bec-systems.com>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
