### PR TITLE
clang.bbclass: fix recipe_sysroot_check_ld_is_lld

### DIFF
--- a/classes/clang.bbclass
+++ b/classes/clang.bbclass
@@ -142,7 +142,9 @@ RECIPESYSROOTFUNCS = ""
 RECIPESYSROOTFUNCS:toolchain-clang = "recipe_sysroot_check_ld_is_lld"
 
 recipe_sysroot_check_ld_is_lld () {
-    if "${@bb.utils.contains('DISTRO_FEATURES', 'ld-is-lld', 'true', 'false', d)}"; then
+    if "${@bb.utils.contains('DISTRO_FEATURES', 'ld-is-lld', 'true', 'false', d)}" && \
+        "${@bb.utils.contains('TARGET_ARCH', 'allarch', 'false', 'true', d)}"
+    then
         ln -srf ${RECIPE_SYSROOT_NATIVE}${bindir}/${TARGET_SYS}/${TARGET_PREFIX}ld.lld ${RECIPE_SYSROOT_NATIVE}${bindir}/${TARGET_SYS}/${TARGET_PREFIX}ld
     fi
 }

--- a/classes/clang.bbclass
+++ b/classes/clang.bbclass
@@ -145,7 +145,7 @@ recipe_sysroot_check_ld_is_lld () {
     if "${@bb.utils.contains('DISTRO_FEATURES', 'ld-is-lld', 'true', 'false', d)}" && \
         "${@bb.utils.contains('TARGET_ARCH', 'allarch', 'false', 'true', d)}"
     then
-        ln -srf ${RECIPE_SYSROOT_NATIVE}${bindir}/${TARGET_SYS}/${TARGET_PREFIX}ld.lld ${RECIPE_SYSROOT_NATIVE}${bindir}/${TARGET_SYS}/${TARGET_PREFIX}ld
+        ln -srf ${STAGING_BINDIR_NATIVE}/${TARGET_SYS}/${TARGET_PREFIX}ld.lld ${STAGING_BINDIR_NATIVE}/${TARGET_SYS}/${TARGET_PREFIX}ld
     fi
 }
 do_prepare_recipe_sysroot[postfuncs] += "${RECIPESYSROOTFUNCS}"


### PR DESCRIPTION
Currently, the check added in #802 breaks my builds. I have been able to find, and fix, two cases:

- allarch recipes, where lld is simply not installed in native sysroot
- for some recipes (`ed` for example), `${bindir}` evaluates to `/bin`, not `/usr/bin`, which results in incorrect path to lld

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [X] Changes have been tested
- [X] `Signed-off-by` is present
- [X] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
