### PR TITLE
llvm-project-source: Remove "MULTILIBS" from do_patch dependecies

### DIFF
--- a/recipes-devtools/clang/llvm-project-source.inc
+++ b/recipes-devtools/clang/llvm-project-source.inc
@@ -91,6 +91,6 @@ python add_distro_vendor() {
     subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True)
 }
 
+do_patch[vardepsexclude] = "MULTILIBS"
 do_patch[postfuncs] += "add_distro_vendor"
 do_create_spdx[depends] += "${PN}:do_patch"
-


### PR DESCRIPTION
MULTILIBS maybe defined by distros/projects and in some cases not, this would result in rebuilding clang-native for no reason.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
