### PR TITLE
gtk4: Disable integer conversion warning as error

### DIFF
--- a/conf/nonclangable.conf
+++ b/conf/nonclangable.conf
@@ -299,6 +299,9 @@ CXXFLAGS:pn-libeigen:append:toolchain-clang:powerpc = " -DEIGEN_ALTIVEC_DISABLE_
 CXXFLAGS:pn-opengl-es-cts:append:toolchain-clang = " -Wno-error=unsafe-buffer-usage -Wno-error=cast-function-type-strict"
 CXXFLAGS:pn-vulkan-cts:append:toolchain-clang = " -Wno-error=unsafe-buffer-usage -Wno-error=cast-function-type-strict"
 
+# Workaround for https://gitlab.gnome.org/GNOME/gtk/-/issues/6033
+CFLAGS:pn-gtk4:append:toolchain-clang = " -Wno-error=int-conversion"
+
 # usr/include/glib-2.0/glib/glib-autocleanups.h:49:1: error: cast from 'void (*)(void)' to 'GDestroyNotify'
 # (aka 'void (*)(void *)') converts to incompatible function type [-Werror,-Wcast-function-type-strict]
 CFLAGS:pn-pidgin-sipe:append:toolchain-clang = " -Wno-error=cast-function-type-strict"


### PR DESCRIPTION
clang 15+ has started to treated int-conversion as error and pipeline cache code added snippets[1] in gtk4 which causes this error

[1] https://gitlab.gnome.org/GNOME/gtk/-/commit/684a015c9852ede9d57103852217b428546fe472
Signed-off-by: Khem Raj <raj.khem@gmail.com>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
