### PR TITLE
go-runtime: Use BFD linker when LLD is default system linker on aarch64

### DIFF
--- a/conf/nonclangable.conf
+++ b/conf/nonclangable.conf
@@ -564,4 +564,9 @@ LDFLAGS:append:pn-libffi:x86:toolchain-clang = "${@bb.utils.contains('DISTRO_FEA
 LDFLAGS:append:pn-libffi:arm:toolchain-clang = "${@bb.utils.contains('DISTRO_FEATURES', 'ld-is-lld', ' -Wl,--undefined-version', '', d)}"
 LDFLAGS:append:pn-elfutils:toolchain-clang = "${@bb.utils.contains('DISTRO_FEATURES', 'ld-is-lld', ' -Wl,--undefined-version', '', d)}"
 
+# Avoid's go linker crash as reported in https://github.com/golang/go/issues/61872
+# it happens when libstd.so is linked with lld for aarch64
+LDFLAGS:append:pn-go-runtime:toolchain-clang:aarch64 = "${@bb.utils.contains('DISTRO_FEATURES', 'ld-is-lld', ' -fuse-ld=bfd', '', d)}"
+LDFLAGS:remove:pn-go-runtime:toolchain-clang:aarch64 = "${@bb.utils.contains('DISTRO_FEATURES', 'ld-is-lld', '-fuse-ld=lld', '', d)}"
+
 LD:pn-gnu-efi:toolchain-clang = "${@bb.utils.contains('DISTRO_FEATURES', 'ld-is-lld', '${HOST_PREFIX}ld.bfd${TOOLCHAIN_OPTIONS} ${HOST_LD_ARCH}', '${HOST_PREFIX}ld${TOOLCHAIN_OPTIONS} ${HOST_LD_ARCH}', d)}"


### PR DESCRIPTION
go linker is not able to link subsequent binaries e.g. gosu with lld produced libstd.so and crashes. This is just seen on arm64

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
