### PR TITLE
python3: Add clang to rdeps for python3-ptests

### DIFF
--- a/recipes-devtools/python/python3_%.bbappend
+++ b/recipes-devtools/python/python3_%.bbappend
@@ -1,5 +1,9 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
+# tests need compiler on target and they need the compiler which was
+# used to build python
+RDEPENDS:${PN}-ptest:append:toolchain-clang = " clang"
+
 do_configure:prepend:class-target:toolchain-clang() {
     # We do not need --print-multiarch with clang since it prints wrong value
     sed -i -e 's#\[MULTIARCH=$($CC --print-multiarch 2>/dev/null)\]#\[MULTIARCH=""\]#g' ${S}/configure.ac


### PR DESCRIPTION
cppext test needs full toolchain as it tries to build an extention with C, using clang ensures that a function
compiler bits are pulled into ptest image when using TOOLCHAIN = "clang"

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
