### PR TITLE
clang: ToolChains/Gnu.cpp: search also in lib32

### DIFF
--- a/recipes-devtools/clang/clang/0006-clang-driver-Check-sysroot-for-ldso-path.patch
+++ b/recipes-devtools/clang/clang/0006-clang-driver-Check-sysroot-for-ldso-path.patch
@@ -1,4 +1,4 @@
-From 710a936d66011859cb3995f42a5b9e962db01f0e Mon Sep 17 00:00:00 2001
+From 4e8e066b60a00eb10c70ef9523c55cfc7ab536f8 Mon Sep 17 00:00:00 2001
 From: Dan McGregor <dan.mcgregor@usask.ca>
 Date: Wed, 26 Apr 2017 20:29:41 -0600
 Subject: [PATCH] clang: driver: Check sysroot for ldso path
@@ -11,14 +11,27 @@ Upstream-Status: Pending
 Signed-off-by: Dan McGregor <dan.mcgregor@usask.ca>
 Signed-off-by: Khem Raj <raj.khem@gmail.com>
 ---
- clang/lib/Driver/ToolChains/Linux.cpp | 16 ++++++++++++++++
- 1 file changed, 16 insertions(+)
+ clang/lib/Driver/ToolChains/Linux.cpp | 22 +++++++++++++++++++++-
+ 1 file changed, 21 insertions(+), 1 deletion(-)
 
 diff --git a/clang/lib/Driver/ToolChains/Linux.cpp b/clang/lib/Driver/ToolChains/Linux.cpp
-index c6fb290ffdb4..2a58f876a68d 100644
+index c6fb290ffdb4..897a2da73d54 100644
 --- a/clang/lib/Driver/ToolChains/Linux.cpp
 +++ b/clang/lib/Driver/ToolChains/Linux.cpp
-@@ -518,11 +518,19 @@ std::string Linux::getDynamicLinker(const ArgList &Args) const {
+@@ -463,7 +463,11 @@ std::string Linux::getDynamicLinker(const ArgList &Args) const {
+         Triple.getEnvironment() == llvm::Triple::GNUEABIHF ||
+         tools::arm::getARMFloatABI(*this, Args) == tools::arm::FloatABI::Hard;
+ 
+-    LibDir = "lib";
++    LibDir = "lib32";
++    if (!getVFS().exists(getDriver().SysRoot + "/" + LibDir + "/" + Loader) &&
++         getVFS().exists(getDriver().SysRoot + "/lib/" + Loader)) {
++        LibDir = "lib";
++    }
+     Loader = HF ? "ld-linux-armhf.so.3" : "ld-linux.so.3";
+     break;
+   }
+@@ -518,11 +522,19 @@ std::string Linux::getDynamicLinker(const ArgList &Args) const {
      LibDir = "lib64";
      Loader =
          (tools::ppc::hasPPCAbiArg(Args, "elfv2")) ? "ld64.so.2" : "ld64.so.1";
@@ -38,7 +51,7 @@ index c6fb290ffdb4..2a58f876a68d 100644
      break;
    case llvm::Triple::riscv32: {
      StringRef ABIName = tools::riscv::getRISCVABI(Args, Triple);
-@@ -544,6 +552,10 @@ std::string Linux::getDynamicLinker(const ArgList &Args) const {
+@@ -544,6 +556,10 @@ std::string Linux::getDynamicLinker(const ArgList &Args) const {
    case llvm::Triple::sparcv9:
      LibDir = "lib64";
      Loader = "ld-linux.so.2";
@@ -49,7 +62,7 @@ index c6fb290ffdb4..2a58f876a68d 100644
      break;
    case llvm::Triple::systemz:
      LibDir = "lib";
-@@ -558,6 +570,10 @@ std::string Linux::getDynamicLinker(const ArgList &Args) const {
+@@ -558,6 +574,10 @@ std::string Linux::getDynamicLinker(const ArgList &Args) const {
  
      LibDir = X32 ? "libx32" : "lib64";
      Loader = X32 ? "ld-linux-x32.so.2" : "ld-linux-x86-64.so.2";

--- a/recipes-devtools/clang/clang/0017-clang-driver-Add-dyld-prefix-when-checking-sysroot-f.patch
+++ b/recipes-devtools/clang/clang/0017-clang-driver-Add-dyld-prefix-when-checking-sysroot-f.patch
@@ -1,4 +1,4 @@
-From a1fdade00611749a75b958e1010db68d4cefff95 Mon Sep 17 00:00:00 2001
+From a85573b9e7e939b0ab1738dd3b3cc999b7de1547 Mon Sep 17 00:00:00 2001
 From: Oleksandr Ocheretnyi <oocheret@cisco.com>
 Date: Wed, 15 Apr 2020 00:08:39 +0300
 Subject: [PATCH] clang: driver: Add dyld-prefix when checking sysroot for ldso
@@ -15,14 +15,25 @@ Upstream-Status: Pending
 Signed-off-by: Oleksandr Ocheretnyi <oocheret@cisco.com>
 Signed-off-by: Khem Raj <raj.khem@gmail.com>
 ---
- clang/lib/Driver/ToolChains/Linux.cpp | 16 ++++++++--------
- 1 file changed, 8 insertions(+), 8 deletions(-)
+ clang/lib/Driver/ToolChains/Linux.cpp | 20 ++++++++++----------
+ 1 file changed, 10 insertions(+), 10 deletions(-)
 
 diff --git a/clang/lib/Driver/ToolChains/Linux.cpp b/clang/lib/Driver/ToolChains/Linux.cpp
-index c68a842b45e0..ca9f5f2e4f74 100644
+index de0d5950d2ee..c6acfc8924c9 100644
 --- a/clang/lib/Driver/ToolChains/Linux.cpp
 +++ b/clang/lib/Driver/ToolChains/Linux.cpp
-@@ -518,8 +518,8 @@ std::string Linux::getDynamicLinker(const ArgList &Args) const {
+@@ -464,8 +464,8 @@ std::string Linux::getDynamicLinker(const ArgList &Args) const {
+         tools::arm::getARMFloatABI(*this, Args) == tools::arm::FloatABI::Hard;
+ 
+     LibDir = "lib32";
+-    if (!getVFS().exists(getDriver().SysRoot + "/" + LibDir + "/" + Loader) &&
+-         getVFS().exists(getDriver().SysRoot + "/lib/" + Loader)) {
++    if (!getVFS().exists(getDriver().SysRoot + getDriver().DyldPrefix + "/" + LibDir + "/" + Loader) &&
++         getVFS().exists(getDriver().SysRoot + getDriver().DyldPrefix + "/lib/" + Loader)) {
+         LibDir = "lib";
+     }
+     Loader = HF ? "ld-linux-armhf.so.3" : "ld-linux.so.3";
+@@ -522,8 +522,8 @@ std::string Linux::getDynamicLinker(const ArgList &Args) const {
      LibDir = "lib64";
      Loader =
          (tools::ppc::hasPPCAbiArg(Args, "elfv2")) ? "ld64.so.2" : "ld64.so.1";
@@ -33,7 +44,7 @@ index c68a842b45e0..ca9f5f2e4f74 100644
          LibDir = "lib";
      }
      break;
-@@ -527,8 +527,8 @@ std::string Linux::getDynamicLinker(const ArgList &Args) const {
+@@ -531,8 +531,8 @@ std::string Linux::getDynamicLinker(const ArgList &Args) const {
      LibDir = "lib64";
      Loader =
          (tools::ppc::hasPPCAbiArg(Args, "elfv1")) ? "ld64.so.1" : "ld64.so.2";
@@ -44,7 +55,7 @@ index c68a842b45e0..ca9f5f2e4f74 100644
          LibDir = "lib";
      }
      break;
-@@ -552,8 +552,8 @@ std::string Linux::getDynamicLinker(const ArgList &Args) const {
+@@ -556,8 +556,8 @@ std::string Linux::getDynamicLinker(const ArgList &Args) const {
    case llvm::Triple::sparcv9:
      LibDir = "lib64";
      Loader = "ld-linux.so.2";
@@ -55,7 +66,7 @@ index c68a842b45e0..ca9f5f2e4f74 100644
          LibDir = "lib";
      }
      break;
-@@ -570,8 +570,8 @@ std::string Linux::getDynamicLinker(const ArgList &Args) const {
+@@ -574,8 +574,8 @@ std::string Linux::getDynamicLinker(const ArgList &Args) const {
  
      LibDir = X32 ? "libx32" : "lib64";
      Loader = X32 ? "ld-linux-x32.so.2" : "ld-linux-x86-64.so.2";

--- a/recipes-devtools/clang/clang/0040-ToolChains-Gnu.cpp-ARMLibDirs-search-also-in-lib32.patch
+++ b/recipes-devtools/clang/clang/0040-ToolChains-Gnu.cpp-ARMLibDirs-search-also-in-lib32.patch
@@ -1,0 +1,80 @@
+From 0f5f2e8e84d37e94aad0a6bf90bb3406e289b5e5 Mon Sep 17 00:00:00 2001
+From: Martin Jansa <Martin.Jansa@gmail.com>
+Date: Thu, 31 Aug 2023 18:14:47 +0200
+Subject: [PATCH] ToolChains/Gnu.cpp: ARMLibDirs search also in lib32
+
+* in some strange multilib configs we build lib32-image where
+  32bit libs are in /usr/lib32 and 64bit in /usr/lib64 but in such
+  setup the clang search for GCC candidate installation doesn't
+  check lib32 directory in sysroot and fails to find the installation
+
+  X86LibDirs was already searching in lib32 for very long time:
+  https://github.com/llvm/llvm-project/commit/621fed5f5a051a0333415aaed75b8f2ed2350dbd
+  but ARMLibDirs didn't include it for some reason.
+
+* if we don't add lib32 for arm in getOSLibDir(), then it will
+  find -lgcc, crtbeginS.o, crtendS.o, but still fail to find
+  -lgcc_s, -lc, Scrt1.o, crti.o, crtn.o
+
+* fixes lib32-compiler-rt build failure:
+
+-- Configuring incomplete, errors occurred!
+CMake Error at TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/recipe-sysroot-native/usr/share/cmake-3.26/Modules/CMakeTestCCompiler.cmake:67 (message):
+  The C compiler
+
+    "TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/recipe-sysroot-native/usr/bin/arm-oemllib32-linux-gnueabi/arm-oemllib32-linux-gnueabi-clang"
+
+  is not able to compile a simple test program.
+
+  It fails with the following output:
+
+    Change Dir: TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/build/CMakeFiles/CMakeScratch/TryCompile-rWXyQZ
+
+    Run Build Command(s):ninja -v cmTC_84d18 && [1/2] TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/recipe-sysroot-native/usr/bin/arm-oemllib32-linux-gnueabi/arm-oemllib32-linux-gnueabi-clang --target=arm-oemllib32-linux-gnueabi --sysroot=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/lib32-recipe-sysroot   -target arm-oemllib32-linux-gnueabi  -march=armv7ve -mthumb -mfpu=neon-vfpv4 -mfloat-abi=softfp -mlittle-endian --dyld-prefix=/usr -Qunused-arguments -funwind-tables -fstack-protector-strong  -O2 -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Werror=format-security -Werror=return-type -D_TIME_BITS=64 -D_FILE_OFFSET_BITS=64  --sysroot=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/lib32-recipe-sysroot  -O2 -pipe -g -feliminate-unused-debug-types   -fmacro-prefix-map=TOPDIR/BUILD/work-shared/llvm-project-source-16.0.6-r0/git=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fdebug-prefix-map=TOPDIR/BUILD/work-shared/llvm-project-source-16.0.6-r0/git=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fmacro-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/build=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fdebug-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/build=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fdebug-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/lib32-recipe-sysroot=  -fmacro-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/lib32-recipe-sysroot=  -fdebug-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/recipe-sysroot-native=    -fPIE -MD -MT CMakeFiles/cmTC_84d18.dir/testCCompiler.c.o -MF CMakeFiles/cmTC_84d18.dir/testCCompiler.c.o.d -o CMakeFiles/cmTC_84d18.dir/testCCompiler.c.o -c TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/build/CMakeFiles/CMakeScratch/TryCompile-rWXyQZ/testCCompiler.c
+    [2/2] : && TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/recipe-sysroot-native/usr/bin/arm-oemllib32-linux-gnueabi/arm-oemllib32-linux-gnueabi-clang --target=arm-oemllib32-linux-gnueabi --sysroot=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/lib32-recipe-sysroot -target arm-oemllib32-linux-gnueabi  -march=armv7ve -mthumb -mfpu=neon-vfpv4 -mfloat-abi=softfp -mlittle-endian --dyld-prefix=/usr -Qunused-arguments -funwind-tables -fstack-protector-strong  -O2 -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Werror=format-security -Werror=return-type -D_TIME_BITS=64 -D_FILE_OFFSET_BITS=64  --sysroot=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/lib32-recipe-sysroot  -O2 -pipe -g -feliminate-unused-debug-types   -fmacro-prefix-map=TOPDIR/BUILD/work-shared/llvm-project-source-16.0.6-r0/git=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fdebug-prefix-map=TOPDIR/BUILD/work-shared/llvm-project-source-16.0.6-r0/git=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fmacro-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/build=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fdebug-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/build=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fdebug-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/lib32-recipe-sysroot=  -fmacro-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/lib32-recipe-sysroot=  -fdebug-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/recipe-sysroot-native= -target arm-oemllib32-linux-gnueabi  -march=armv7ve -mthumb -mfpu=neon-vfpv4 -mfloat-abi=softfp -mlittle-endian --dyld-prefix=/usr -Qunused-arguments -funwind-tables -fstack-protector-strong  -O2 -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Werror=format-security -Werror=return-type -D_TIME_BITS=64 -D_FILE_OFFSET_BITS=64  --sysroot=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/lib32-recipe-sysroot  -Wl,-O1 -Wl,--hash-style=gnu -Wl,--as-needed   -fmacro-prefix-map=TOPDIR/BUILD/work-shared/llvm-project-source-16.0.6-r0/git=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fdebug-prefix-map=TOPDIR/BUILD/work-shared/llvm-project-source-16.0.6-r0/git=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fmacro-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/build=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fdebug-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/build=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fdebug-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/lib32-recipe-sysroot=  -fmacro-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/lib32-recipe-sysroot=  -fdebug-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/recipe-sysroot-native=  -Wl,-z,relro,-z,now -unwindlib=libgcc -rtlib=libgcc -stdlib=libstdc++   -fuse-ld=lld -Wl,-O1 -Wl,--hash-style=gnu -Wl,--as-needed   -fmacro-prefix-map=TOPDIR/BUILD/work-shared/llvm-project-source-16.0.6-r0/git=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fdebug-prefix-map=TOPDIR/BUILD/work-shared/llvm-project-source-16.0.6-r0/git=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fmacro-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/build=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fdebug-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/build=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fdebug-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/lib32-recipe-sysroot=  -fmacro-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/lib32-recipe-sysroot=  -fdebug-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/recipe-sysroot-native=  -Wl,-z,relro,-z,now -unwindlib=libgcc -rtlib=libgcc -stdlib=libstdc++   -fuse-ld=lld CMakeFiles/cmTC_84d18.dir/testCCompiler.c.o -o cmTC_84d18   && :
+    FAILED: cmTC_84d18
+    : && TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/recipe-sysroot-native/usr/bin/arm-oemllib32-linux-gnueabi/arm-oemllib32-linux-gnueabi-clang --target=arm-oemllib32-linux-gnueabi --sysroot=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/lib32-recipe-sysroot -target arm-oemllib32-linux-gnueabi  -march=armv7ve -mthumb -mfpu=neon-vfpv4 -mfloat-abi=softfp -mlittle-endian --dyld-prefix=/usr -Qunused-arguments -funwind-tables -fstack-protector-strong  -O2 -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Werror=format-security -Werror=return-type -D_TIME_BITS=64 -D_FILE_OFFSET_BITS=64  --sysroot=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/lib32-recipe-sysroot  -O2 -pipe -g -feliminate-unused-debug-types   -fmacro-prefix-map=TOPDIR/BUILD/work-shared/llvm-project-source-16.0.6-r0/git=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fdebug-prefix-map=TOPDIR/BUILD/work-shared/llvm-project-source-16.0.6-r0/git=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fmacro-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/build=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fdebug-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/build=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fdebug-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/lib32-recipe-sysroot=  -fmacro-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/lib32-recipe-sysroot=  -fdebug-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/recipe-sysroot-native= -target arm-oemllib32-linux-gnueabi  -march=armv7ve -mthumb -mfpu=neon-vfpv4 -mfloat-abi=softfp -mlittle-endian --dyld-prefix=/usr -Qunused-arguments -funwind-tables -fstack-protector-strong  -O2 -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Werror=format-security -Werror=return-type -D_TIME_BITS=64 -D_FILE_OFFSET_BITS=64  --sysroot=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/lib32-recipe-sysroot  -Wl,-O1 -Wl,--hash-style=gnu -Wl,--as-needed   -fmacro-prefix-map=TOPDIR/BUILD/work-shared/llvm-project-source-16.0.6-r0/git=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fdebug-prefix-map=TOPDIR/BUILD/work-shared/llvm-project-source-16.0.6-r0/git=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fmacro-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/build=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fdebug-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/build=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fdebug-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/lib32-recipe-sysroot=  -fmacro-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/lib32-recipe-sysroot=  -fdebug-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/recipe-sysroot-native=  -Wl,-z,relro,-z,now -unwindlib=libgcc -rtlib=libgcc -stdlib=libstdc++   -fuse-ld=lld -Wl,-O1 -Wl,--hash-style=gnu -Wl,--as-needed   -fmacro-prefix-map=TOPDIR/BUILD/work-shared/llvm-project-source-16.0.6-r0/git=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fdebug-prefix-map=TOPDIR/BUILD/work-shared/llvm-project-source-16.0.6-r0/git=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fmacro-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/build=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fdebug-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/build=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fdebug-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/lib32-recipe-sysroot=  -fmacro-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/lib32-recipe-sysroot=  -fdebug-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/recipe-sysroot-native=  -Wl,-z,relro,-z,now -unwindlib=libgcc -rtlib=libgcc -stdlib=libstdc++   -fuse-ld=lld CMakeFiles/cmTC_84d18.dir/testCCompiler.c.o -o cmTC_84d18   && :
+    arm-oemllib32-linux-gnueabi-ld.lld: error: cannot open Scrt1.o: No such file or directory
+    arm-oemllib32-linux-gnueabi-ld.lld: error: cannot open crti.o: No such file or directory
+    arm-oemllib32-linux-gnueabi-ld.lld: error: cannot open crtbeginS.o: No such file or directory
+    arm-oemllib32-linux-gnueabi-ld.lld: error: unable to find library -lgcc
+    arm-oemllib32-linux-gnueabi-ld.lld: error: unable to find library -lgcc_s
+    arm-oemllib32-linux-gnueabi-ld.lld: error: unable to find library -lc
+    arm-oemllib32-linux-gnueabi-ld.lld: error: unable to find library -lgcc
+    arm-oemllib32-linux-gnueabi-ld.lld: error: unable to find library -lgcc_s
+    arm-oemllib32-linux-gnueabi-ld.lld: error: cannot open crtendS.o: No such file or directory
+    arm-oemllib32-linux-gnueabi-ld.lld: error: cannot open crtn.o: No such file or directory
+    clang-16: error: linker command failed with exit code 1 (use -v to see invocation)
+    ninja: build stopped: subcommand failed.
+
+Upstream-Status: Pending
+Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>
+---
+ clang/lib/Driver/ToolChains/Gnu.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/clang/lib/Driver/ToolChains/Gnu.cpp b/clang/lib/Driver/ToolChains/Gnu.cpp
+index 0ec2dadafc05..a67e87365a7a 100644
+--- a/clang/lib/Driver/ToolChains/Gnu.cpp
++++ b/clang/lib/Driver/ToolChains/Gnu.cpp
+@@ -2241,7 +2241,7 @@ void Generic_GCC::GCCInstallationDetector::AddDefaultGCCPrefixes(
+   static const char *const AArch64beTriples[] = {"aarch64_be-none-linux-gnu",
+                                                  "aarch64_be-linux-gnu"};
+ 
+-  static const char *const ARMLibDirs[] = {"/lib"};
++  static const char *const ARMLibDirs[] = {"/lib", "/lib32"};
+   static const char *const ARMTriples[] = {"arm-linux-gnueabi"};
+   static const char *const ARMHFTriples[] = {"arm-linux-gnueabihf",
+                                              "armv7hl-redhat-linux-gnueabi",
+diff --git a/clang/lib/Driver/ToolChains/Linux.cpp b/clang/lib/Driver/ToolChains/Linux.cpp
+index c6fb290ffdb4..82acaf8a4bfd 100644
+--- a/clang/lib/Driver/ToolChains/Linux.cpp
++++ b/clang/lib/Driver/ToolChains/Linux.cpp
+@@ -166,6 +166,7 @@ static StringRef getOSLibDir(const llvm::Triple &Triple, const ArgList &Args) {
+   // reasoning about oslibdir spellings with the lib dir spellings in the
+   // GCCInstallationDetector, but that is a more significant refactoring.
+   if (Triple.getArch() == llvm::Triple::x86 || Triple.isPPC32() ||
++      Triple.getArch() == llvm::Triple::arm || Triple.getArch() == llvm::Triple::thumb ||
+       Triple.getArch() == llvm::Triple::sparc)
+     return "lib32";
+ 

--- a/recipes-devtools/clang/common.inc
+++ b/recipes-devtools/clang/common.inc
@@ -49,6 +49,7 @@ SRC_URI = "\
     file://0037-Call-printName-to-get-name-of-Decl.patch \
     file://0038-Apply-fmacro-prefix-map-to-anonymous-tags-in-templat.patch \
     file://0039-lld-RISCV-Handle-relaxation-reductions-of-more-than-.patch \
+    file://0040-ToolChains-Gnu.cpp-ARMLibDirs-search-also-in-lib32.patch \
     "
 # Fallback to no-PIE if not set
 GCCPIE ??= ""


### PR DESCRIPTION
* in some strange multilib configs we build lib32-image where 32bit libs are in /usr/lib32 and 64bit in /usr/lib64 but in such setup the clang search for GNU candidate installation doesn't check lib32 directory in sysroot and fails to find the installation there resulting in

  lib32-compiler-rt build failure:
```
-- Configuring incomplete, errors occurred!
CMake Error at TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/recipe-sysroot-native/usr/share/cmake-3.26/Modules/CMakeTestCCompiler.cmake:67 (message):
  The C compiler

    "TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/recipe-sysroot-native/usr/bin/arm-oemllib32-linux-gnueabi/arm-oemllib32-linux-gnueabi-clang"

  is not able to compile a simple test program.

  It fails with the following output:

    Change Dir: TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/build/CMakeFiles/CMakeScratch/TryCompile-rWXyQZ

    Run Build Command(s):ninja -v cmTC_84d18 && [1/2] TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/recipe-sysroot-native/usr/bin/arm-oemllib32-linux-gnueabi/arm-oemllib32-linux-gnueabi-clang --target=arm-oemllib32-linux-gnueabi --sysroot=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/lib32-recipe-sysroot   -target arm-oemllib32-linux-gnueabi  -march=armv7ve -mthumb -mfpu=neon-vfpv4 -mfloat-abi=softfp -mlittle-endian --dyld-prefix=/usr -Qunused-arguments -funwind-tables -fstack-protector-strong  -O2 -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Werror=format-security -Werror=return-type -D_TIME_BITS=64 -D_FILE_OFFSET_BITS=64  --sysroot=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/lib32-recipe-sysroot  -O2 -pipe -g -feliminate-unused-debug-types   -fmacro-prefix-map=TOPDIR/BUILD/work-shared/llvm-project-source-16.0.6-r0/git=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fdebug-prefix-map=TOPDIR/BUILD/work-shared/llvm-project-source-16.0.6-r0/git=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fmacro-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/build=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fdebug-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/build=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fdebug-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/lib32-recipe-sysroot=  -fmacro-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/lib32-recipe-sysroot=  -fdebug-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/recipe-sysroot-native=    -fPIE -MD -MT CMakeFiles/cmTC_84d18.dir/testCCompiler.c.o -MF CMakeFiles/cmTC_84d18.dir/testCCompiler.c.o.d -o CMakeFiles/cmTC_84d18.dir/testCCompiler.c.o -c TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/build/CMakeFiles/CMakeScratch/TryCompile-rWXyQZ/testCCompiler.c
    [2/2] : && TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/recipe-sysroot-native/usr/bin/arm-oemllib32-linux-gnueabi/arm-oemllib32-linux-gnueabi-clang --target=arm-oemllib32-linux-gnueabi --sysroot=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/lib32-recipe-sysroot -target arm-oemllib32-linux-gnueabi  -march=armv7ve -mthumb -mfpu=neon-vfpv4 -mfloat-abi=softfp -mlittle-endian --dyld-prefix=/usr -Qunused-arguments -funwind-tables -fstack-protector-strong  -O2 -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Werror=format-security -Werror=return-type -D_TIME_BITS=64 -D_FILE_OFFSET_BITS=64  --sysroot=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/lib32-recipe-sysroot  -O2 -pipe -g -feliminate-unused-debug-types   -fmacro-prefix-map=TOPDIR/BUILD/work-shared/llvm-project-source-16.0.6-r0/git=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fdebug-prefix-map=TOPDIR/BUILD/work-shared/llvm-project-source-16.0.6-r0/git=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fmacro-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/build=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fdebug-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/build=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fdebug-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/lib32-recipe-sysroot=  -fmacro-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/lib32-recipe-sysroot=  -fdebug-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/recipe-sysroot-native= -target arm-oemllib32-linux-gnueabi  -march=armv7ve -mthumb -mfpu=neon-vfpv4 -mfloat-abi=softfp -mlittle-endian --dyld-prefix=/usr -Qunused-arguments -funwind-tables -fstack-protector-strong  -O2 -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Werror=format-security -Werror=return-type -D_TIME_BITS=64 -D_FILE_OFFSET_BITS=64  --sysroot=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/lib32-recipe-sysroot  -Wl,-O1 -Wl,--hash-style=gnu -Wl,--as-needed   -fmacro-prefix-map=TOPDIR/BUILD/work-shared/llvm-project-source-16.0.6-r0/git=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fdebug-prefix-map=TOPDIR/BUILD/work-shared/llvm-project-source-16.0.6-r0/git=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fmacro-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/build=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fdebug-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/build=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fdebug-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/lib32-recipe-sysroot=  -fmacro-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/lib32-recipe-sysroot=  -fdebug-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/recipe-sysroot-native=  -Wl,-z,relro,-z,now -unwindlib=libgcc -rtlib=libgcc -stdlib=libstdc++   -fuse-ld=lld -Wl,-O1 -Wl,--hash-style=gnu -Wl,--as-needed   -fmacro-prefix-map=TOPDIR/BUILD/work-shared/llvm-project-source-16.0.6-r0/git=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fdebug-prefix-map=TOPDIR/BUILD/work-shared/llvm-project-source-16.0.6-r0/git=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fmacro-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/build=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fdebug-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/build=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fdebug-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/lib32-recipe-sysroot=  -fmacro-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/lib32-recipe-sysroot=  -fdebug-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/recipe-sysroot-native=  -Wl,-z,relro,-z,now -unwindlib=libgcc -rtlib=libgcc -stdlib=libstdc++   -fuse-ld=lld CMakeFiles/cmTC_84d18.dir/testCCompiler.c.o -o cmTC_84d18   && :
    FAILED: cmTC_84d18
    : && TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/recipe-sysroot-native/usr/bin/arm-oemllib32-linux-gnueabi/arm-oemllib32-linux-gnueabi-clang --target=arm-oemllib32-linux-gnueabi --sysroot=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/lib32-recipe-sysroot -target arm-oemllib32-linux-gnueabi  -march=armv7ve -mthumb -mfpu=neon-vfpv4 -mfloat-abi=softfp -mlittle-endian --dyld-prefix=/usr -Qunused-arguments -funwind-tables -fstack-protector-strong  -O2 -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Werror=format-security -Werror=return-type -D_TIME_BITS=64 -D_FILE_OFFSET_BITS=64  --sysroot=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/lib32-recipe-sysroot  -O2 -pipe -g -feliminate-unused-debug-types   -fmacro-prefix-map=TOPDIR/BUILD/work-shared/llvm-project-source-16.0.6-r0/git=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fdebug-prefix-map=TOPDIR/BUILD/work-shared/llvm-project-source-16.0.6-r0/git=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fmacro-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/build=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fdebug-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/build=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fdebug-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/lib32-recipe-sysroot=  -fmacro-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/lib32-recipe-sysroot=  -fdebug-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/recipe-sysroot-native= -target arm-oemllib32-linux-gnueabi  -march=armv7ve -mthumb -mfpu=neon-vfpv4 -mfloat-abi=softfp -mlittle-endian --dyld-prefix=/usr -Qunused-arguments -funwind-tables -fstack-protector-strong  -O2 -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Werror=format-security -Werror=return-type -D_TIME_BITS=64 -D_FILE_OFFSET_BITS=64  --sysroot=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/lib32-recipe-sysroot  -Wl,-O1 -Wl,--hash-style=gnu -Wl,--as-needed   -fmacro-prefix-map=TOPDIR/BUILD/work-shared/llvm-project-source-16.0.6-r0/git=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fdebug-prefix-map=TOPDIR/BUILD/work-shared/llvm-project-source-16.0.6-r0/git=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fmacro-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/build=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fdebug-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/build=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fdebug-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/lib32-recipe-sysroot=  -fmacro-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/lib32-recipe-sysroot=  -fdebug-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/recipe-sysroot-native=  -Wl,-z,relro,-z,now -unwindlib=libgcc -rtlib=libgcc -stdlib=libstdc++   -fuse-ld=lld -Wl,-O1 -Wl,--hash-style=gnu -Wl,--as-needed   -fmacro-prefix-map=TOPDIR/BUILD/work-shared/llvm-project-source-16.0.6-r0/git=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fdebug-prefix-map=TOPDIR/BUILD/work-shared/llvm-project-source-16.0.6-r0/git=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fmacro-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/build=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fdebug-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/build=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fdebug-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/lib32-recipe-sysroot=  -fmacro-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/lib32-recipe-sysroot=  -fdebug-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/recipe-sysroot-native=  -Wl,-z,relro,-z,now -unwindlib=libgcc -rtlib=libgcc -stdlib=libstdc++   -fuse-ld=lld CMakeFiles/cmTC_84d18.dir/testCCompiler.c.o -o cmTC_84d18   && :
    arm-oemllib32-linux-gnueabi-ld.lld: error: cannot open Scrt1.o: No such file or directory
    arm-oemllib32-linux-gnueabi-ld.lld: error: cannot open crti.o: No such file or directory
    arm-oemllib32-linux-gnueabi-ld.lld: error: cannot open crtbeginS.o: No such file or directory
    arm-oemllib32-linux-gnueabi-ld.lld: error: unable to find library -lgcc
    arm-oemllib32-linux-gnueabi-ld.lld: error: unable to find library -lgcc_s
    arm-oemllib32-linux-gnueabi-ld.lld: error: unable to find library -lc
    arm-oemllib32-linux-gnueabi-ld.lld: error: unable to find library -lgcc
    arm-oemllib32-linux-gnueabi-ld.lld: error: unable to find library -lgcc_s
    arm-oemllib32-linux-gnueabi-ld.lld: error: cannot open crtendS.o: No such file or directory
    arm-oemllib32-linux-gnueabi-ld.lld: error: cannot open crtn.o: No such file or directory
    clang-16: error: linker command failed with exit code 1 (use -v to see invocation)
    ninja: build stopped: subcommand failed.
```

Draft, because this is still just part of the fix, now the GCC installation is found, but the default libdir still doesn't allow to find Scrt1.o or libgcc_s.so.

```
    FAILED: cmTC_7752d 
    : && /OE/lge/build/apollo/nanbield/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/recipe-sysroot-native/usr/bin/arm-oemllib32-linux-gnueabi/arm-oemllib32-linux-gnueabi-clang --target=arm-oemllib32-linux-gnueabi --sysroot=/OE/lge/build/apollo/nanbield/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/lib32-recipe-sysroot -target arm-oemllib32-linux-gnueabi  -march=armv7ve -mthumb -mfpu=neon-vfpv4 -mfloat-abi=softfp -mlittle-endian --dyld-prefix=/usr -Qunused-arguments -funwind-tables -fstack-protector-strong  -O2 -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Werror=format-security -Werror=return-type -D_TIME_BITS=64 -D_FILE_OFFSET_BITS=64  --sysroot=/OE/lge/build/apollo/nanbield/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/lib32-recipe-sysroot  -O2 -pipe -g -feliminate-unused-debug-types   -fmacro-prefix-map=/OE/lge/build/apollo/nanbield/BUILD/work-shared/llvm-project-source-16.0.6-r0/git=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fdebug-prefix-map=/OE/lge/build/apollo/nanbield/BUILD/work-shared/llvm-project-source-16.0.6-r0/git=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fmacro-prefix-map=/OE/lge/build/apollo/nanbield/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/build=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fdebug-prefix-map=/OE/lge/build/apollo/nanbield/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/build=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fdebug-prefix-map=/OE/lge/build/apollo/nanbield/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/lib32-recipe-sysroot=  -fmacro-prefix-map=/OE/lge/build/apollo/nanbield/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/lib32-recipe-sysroot=  -fdebug-prefix-map=/OE/lge/build/apollo/nanbield/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/recipe-sysroot-native= -target arm-oemllib32-linux-gnueabi  -march=armv7ve -mthumb -mfpu=neon-vfpv4 -mfloat-abi=softfp -mlittle-endian --dyld-prefix=/usr -Qunused-arguments -funwind-tables -fstack-protector-strong  -O2 -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Werror=format-security -Werror=return-type -D_TIME_BITS=64 -D_FILE_OFFSET_BITS=64  --sysroot=/OE/lge/build/apollo/nanbield/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/lib32-recipe-sysroot  -Wl,-O1 -Wl,--hash-style=gnu -Wl,--as-needed   -fmacro-prefix-map=/OE/lge/build/apollo/nanbield/BUILD/work-shared/llvm-project-source-16.0.6-r0/git=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fdebug-prefix-map=/OE/lge/build/apollo/nanbield/BUILD/work-shared/llvm-project-source-16.0.6-r0/git=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fmacro-prefix-map=/OE/lge/build/apollo/nanbield/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/build=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fdebug-prefix-map=/OE/lge/build/apollo/nanbield/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/build=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fdebug-prefix-map=/OE/lge/build/apollo/nanbield/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/lib32-recipe-sysroot=  -fmacro-prefix-map=/OE/lge/build/apollo/nanbield/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/lib32-recipe-sysroot=  -fdebug-prefix-map=/OE/lge/build/apollo/nanbield/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/recipe-sysroot-native=  -Wl,-z,relro,-z,now -unwindlib=libgcc -rtlib=libgcc -stdlib=libstdc++   -fuse-ld=lld -Wl,-O1 -Wl,--hash-style=gnu -Wl,--as-needed   -fmacro-prefix-map=/OE/lge/build/apollo/nanbield/BUILD/work-shared/llvm-project-source-16.0.6-r0/git=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fdebug-prefix-map=/OE/lge/build/apollo/nanbield/BUILD/work-shared/llvm-project-source-16.0.6-r0/git=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fmacro-prefix-map=/OE/lge/build/apollo/nanbield/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/build=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fdebug-prefix-map=/OE/lge/build/apollo/nanbield/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/build=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fdebug-prefix-map=/OE/lge/build/apollo/nanbield/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/lib32-recipe-sysroot=  -fmacro-prefix-map=/OE/lge/build/apollo/nanbield/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/lib32-recipe-sysroot=  -fdebug-prefix-map=/OE/lge/build/apollo/nanbield/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/recipe-sysroot-native=  -Wl,-z,relro,-z,now -unwindlib=libgcc -rtlib=libgcc -stdlib=libstdc++   -fuse-ld=lld CMakeFiles/cmTC_7752d.dir/testCCompiler.c.o -o cmTC_7752d   && :
    arm-oemllib32-linux-gnueabi-ld.lld: error: cannot open Scrt1.o: No such file or directory
    arm-oemllib32-linux-gnueabi-ld.lld: error: cannot open crti.o: No such file or directory
    arm-oemllib32-linux-gnueabi-ld.lld: error: unable to find library -lgcc_s
    arm-oemllib32-linux-gnueabi-ld.lld: error: unable to find library -lc
    arm-oemllib32-linux-gnueabi-ld.lld: error: unable to find library -lgcc_s
    arm-oemllib32-linux-gnueabi-ld.lld: error: cannot open crtn.o: No such file or directory
    clang-16: error: linker command failed with exit code 1 (use -v to see invocation)
    ninja: build stopped: subcommand failed.
```

I've tried to add:
```
-DLLVM_LIBDIR_SUFFIX=${@d.getVar('BASELIB').replace('lib', '')}
```
because of:
```
clang/CMakeLists.txt:set(CLANG_LIBDIR_SUFFIX "${LLVM_LIBDIR_SUFFIX}")
clang/CMakeLists.txt:set(CLANG_INSTALL_LIBDIR_BASENAME "lib${CLANG_LIBDIR_SUFFIX}")
```
which seems to be added to default search paths in most places.

I've added it to native build as well (it was only in target build - just to verify, because we don't want to have different clang-native for different MACHINEs with different BASELIB (lowercase baselib is set to "lib" in native.bbclass).

But that also doesn't work well:
```
    FAILED: CMakeFiles/cmTC_640df.dir/testCCompiler.c.o 
    /OE/lge/build/apollo/nanbield/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/recipe-sysroot-native/usr/bin/arm-oemllib32-linux-gnueabi/arm-oemllib32-linux-gnueabi-clang   -target arm-oemllib32-linux-gnueabi  -march=armv7ve -mthumb -mfpu=neon-vfpv4 -mfloat-abi=softfp -mlittle-endian --dyld-prefix=/usr -Qunused-arguments -funwind-tables -fstack-protector-strong  -O2 -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Werror=format-security -Werror=return-type -D_TIME_BITS=64 -D_FILE_OFFSET_BITS=64  --sysroot=/OE/lge/build/apollo/nanbield/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/lib32-recipe-sysroot  -O2 -pipe -g -feliminate-unused-debug-types   -fmacro-prefix-map=/OE/lge/build/apollo/nanbield/BUILD/work-shared/llvm-project-source-16.0.6-r0/git=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fdebug-prefix-map=/OE/lge/build/apollo/nanbield/BUILD/work-shared/llvm-project-source-16.0.6-r0/git=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fmacro-prefix-map=/OE/lge/build/apollo/nanbield/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/build=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fdebug-prefix-map=/OE/lge/build/apollo/nanbield/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/build=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fdebug-prefix-map=/OE/lge/build/apollo/nanbield/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/lib32-recipe-sysroot=  -fmacro-prefix-map=/OE/lge/build/apollo/nanbield/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/lib32-recipe-sysroot=  -fdebug-prefix-map=/OE/lge/build/apollo/nanbield/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/recipe-sysroot-native= -o CMakeFiles/cmTC_640df.dir/testCCompiler.c.o -c /OE/lge/build/apollo/nanbield/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/build/CMakeFiles/CMakeScratch/TryCompile-ZZX0oo/testCCompiler.c
    /OE/lge/build/apollo/nanbield/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/recipe-sysroot-native/usr/bin/arm-oemllib32-linux-gnueabi/arm-oemllib32-linux-gnueabi-clang: error while loading shared libraries: libclang-cpp.so.16: cannot open shared object file: No such file or directory
    ninja: build stopped: subcommand failed.
```


