### PR TITLE
nonclangable: Adjust for glibc-tests -> glibc-y2038-tests rename

### DIFF
--- a/conf/nonclangable.conf
+++ b/conf/nonclangable.conf
@@ -32,7 +32,7 @@ TOOLCHAIN:pn-glibc-locale = "gcc"
 TOOLCHAIN:pn-glibc-mtrace = "gcc"
 TOOLCHAIN:pn-glibc-scripts = "gcc"
 TOOLCHAIN:pn-glibc-testsuite = "gcc"
-TOOLCHAIN:pn-glibc-tests = "gcc"
+TOOLCHAIN:pn-glibc-y2038-tests = "gcc"
 
 #| prelink-rtld: error while loading shared libraries: ld.so.1
 #| /lib64/ld.so.1: No such file or directory


### PR DESCRIPTION
This recipe got renamed in oe-core, it still is glibc based and can not be built with clang yet

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
