### PR TITLE
libcgroup: Use --undefined-version with lld on sysvinit

### DIFF
--- a/conf/nonclangable.conf
+++ b/conf/nonclangable.conf
@@ -568,6 +568,7 @@ LDFLAGS:append:pn-libffi:x86:toolchain-clang = "${@bb.utils.contains('DISTRO_FEA
 LDFLAGS:append:pn-libffi:arm:toolchain-clang = "${@bb.utils.contains('DISTRO_FEATURES', 'ld-is-lld', ' -Wl,--undefined-version', '', d)}"
 LDFLAGS:append:pn-elfutils:toolchain-clang = "${@bb.utils.contains('DISTRO_FEATURES', 'ld-is-lld', ' -Wl,--undefined-version', '', d)}"
 LDFLAGS:append:pn-pmdk:toolchain-clang = "${@bb.utils.contains('DISTRO_FEATURES', 'ld-is-lld', ' -Wl,--undefined-version', '', d)}"
+LDFLAGS:append:pn-libcgroup:toolchain-clang = "${@bb.utils.contains('DISTRO_FEATURES', 'ld-is-lld sysvinit', ' -Wl,--undefined-version', '', d)}"
 
 # Avoid's go linker crash as reported in https://github.com/golang/go/issues/61872
 # it happens when libstd.so is linked with lld for aarch64


### PR DESCRIPTION
These functions are unconditionally added to libcgroup.map Fixes
aarch64-yoe-linux-musl-ld.lld: error: version script assignment of 'CGROUP_3.0' to symbol 'cgroup_create_scope' failed: symbol not defined aarch64-yoe-linux-musl-ld.lld: error: version script assignment of 'CGROUP_3.0' to symbol 'cgroup_set_default_scope_opts' failed: symbol not defined aarch64-yoe-linux-musl-ld.lld: error: version script assignment of 'CGROUP_3.0' to symbol 'cgroup_create_scope2' failed: symbol not defined aarch64-yoe-linux-musl-ld.lld: error: version script assignment of 'CGROUP_3.0' to symbol 'cgroup_write_systemd_default_cgroup' failed: symbol not defined

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
