### PR TITLE
Backporting spdx fixes

### DIFF
--- a/recipes-devtools/clang/common-source.inc
+++ b/recipes-devtools/clang/common-source.inc
@@ -9,3 +9,9 @@ SRC_URI = ""
 
 do_configure[depends] += "llvm-project-source-${PV}:do_patch"
 do_populate_lic[depends] += "llvm-project-source-${PV}:do_unpack"
+do_create_spdx[depends] += "llvm-project-source-${PV}:do_patch"
+
+# spdx shared workdir detection fails as not WORKDIR is altered but S and B
+# return always true to fix that
+def is_work_shared_spdx(d):
+    return True

--- a/recipes-devtools/clang/llvm-project-source.inc
+++ b/recipes-devtools/clang/llvm-project-source.inc
@@ -54,3 +54,5 @@ python add_distro_vendor() {
 }
 
 do_patch[postfuncs] += "add_distro_vendor"
+do_create_spdx[depends] += "${PN}:do_patch"
+

--- a/recipes-devtools/clang/nativesdk-clang-glue.bb
+++ b/recipes-devtools/clang/nativesdk-clang-glue.bb
@@ -31,3 +31,5 @@ deltask do_compile
 deltask do_patch
 deltask do_fetch
 deltask do_unpack
+deltask do_create_spdx
+deltask do_create_runtime_spdx


### PR DESCRIPTION
Backport commits from master fixing the circular dependency problem when using spdx bbclass.

- [nativesdk-clang-glue: delete spdx tasks](https://github.com/kraj/meta-clang/commit/43b8519600c9e08bcbd921569c8533151f630bd6)
- [llvm-project-source: fix create-spdx handling](https://github.com/kraj/meta-clang/commit/509be6044027806d87f0b1c0aa02fcbab2642023)
- [common-source: fix create-spdx handling](https://github.com/kraj/meta-clang/commit/49b5b74bddb0b68edbfaf76d9ad99e086b3782de)