### PR TITLE
nonclangable: Make tegra specific packages only for tegra

### DIFF
--- a/conf/nonclangable.conf
+++ b/conf/nonclangable.conf
@@ -181,13 +181,13 @@ TOOLCHAIN:pn-frr:riscv64 = "gcc"
 TOOLCHAIN:pn-frr:riscv32 = "gcc"
 
 # Tegra stuff
-TOOLCHAIN:pn-standalone-mm-optee-tegra = "gcc"
-TOOLCHAIN:pn-edk2-firmware-tegra = "gcc"
-TOOLCHAIN:pn-optee-os-tadevkit = "gcc"
-TOOLCHAIN:pn-optee-nvsamples = "gcc"
-TOOLCHAIN:pn-optee-os = "gcc"
-TOOLCHAIN:pn-libgcc-for-nvcc = "gcc"
-TOOLCHAIN:pn-gcc-for-nvcc-runtime = "gcc"
+TOOLCHAIN:pn-standalone-mm-optee-tegra:tegra = "gcc"
+TOOLCHAIN:pn-edk2-firmware-tegra:tegra = "gcc"
+TOOLCHAIN:pn-optee-os-tadevkit:tegra = "gcc"
+TOOLCHAIN:pn-optee-nvsamples:tegra = "gcc"
+TOOLCHAIN:pn-optee-os:tegra = "gcc"
+TOOLCHAIN:pn-libgcc-for-nvcc:tegra = "gcc"
+TOOLCHAIN:pn-gcc-for-nvcc-runtime:tegra = "gcc"
 
 CFLAGS:append:pn-liboil:toolchain-clang:x86-64 = " -fheinous-gnu-extensions "
 


### PR DESCRIPTION
The optee-os and optee-os-tadevkit are available not only for tegra so it should be better to use a `:tegra` machine override there for all of the them.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
