### PR TITLE
Revert "cmake-native.bbclass: Add ubfs specific variable to ignore list"

### DIFF
--- a/classes/cmake-native.bbclass
+++ b/classes/cmake-native.bbclass
@@ -53,6 +53,4 @@ list(APPEND CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES ${STAGING_INCDIR_NATIVE})
 EOF
 }
 
-do_generate_native_toolchain_file[vardepsexclude] += "MKUBIFS_ARGS_128kbpeb MKUBIFS_ARGS_256kbpeb UBINIZE_ARGS_128kbpeb UBINIZE_ARGS_256kbpeb"
-
 addtask generate_native_toolchain_file after do_patch before do_configure


### PR DESCRIPTION
The problem is in BSP layer [1], these variable should not be exported universally moreover its not needed as well.

[1] https://github.com/varigit/meta-variscite-bsp-imx/pull/36 This reverts commit 288f752445d3783dbaf06a60919a2b35b14e3a62.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
