### PR TITLE
bpftrace: Replace python with python3 in ptest

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-devtools/bpftrace/bpftrace/0001-replace-python-with-python3-in-the-test.patch
+++ b/dynamic-layers/openembedded-layer/recipes-devtools/bpftrace/bpftrace/0001-replace-python-with-python3-in-the-test.patch
@@ -1,0 +1,53 @@
+From f2a61d19d8432a220184c4eed7c39eb042d0dfff Mon Sep 17 00:00:00 2001
+From: Wentao Zhang <wentao.zhang@windriver.com>
+Date: Tue, 15 Aug 2023 11:18:36 +0800
+Subject: [PATCH] replace python with python3 in the test
+
+"runtime:call" in ptest gets the following FAILED:
+python: No such file or directory
+replace python with python3 in the test scripts.
+
+$export BPFTRACE_RUNTIME_TEST_EXECUTABLE=/usr/bin
+$cd /usr/lib/bpftrace/ptest/tests
+$python3 runtime/engine/main.py --filter="call.*"
+***
+[ RUN      ] call.strftime_microsecond_extension_rollover
+[  FAILED  ] call.strftime_microsecond_extension_rollover
+	Command: /usr/bin/bpftrace -e 'BEGIN { printf("%s - %s\n", strftime
+    ("1%f", 1000000123000), strftime("1%f", 0)); exit(); }' | tail -n
+    +2 | xargs -I{} python -c "print({})"
+	Unclean exit code: 127
+	Output: __BPFTRACE_NOTIFY_PROBES_ATTACHED\nxargs: python: No such
+    file or directory\n
+***
+
+Upstream-Status: Inappropriate [oe specific]
+
+Signed-off-by: Wentao Zhang <wentao.zhang@windriver.com>
+---
+ tests/runtime/call | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/tests/runtime/call b/tests/runtime/call
+index 36f5d9af..3a938f49 100644
+--- a/tests/runtime/call
++++ b/tests/runtime/call
+@@ -294,13 +294,13 @@ TIMEOUT 5
+ #
+ # Note we add a `1` before the timestamp b/c leading zeros (eg `0123`) is invalid integer in python.
+ NAME strftime_microsecond_extension
+-RUN {{BPFTRACE}} -e 'BEGIN { printf("%s - %s\n", strftime("1%f", 1000123000), strftime("1%f", 0)); exit(); }' | tail -n +2 | xargs -I{} python -c "print({})"
++RUN {{BPFTRACE}} -e 'BEGIN { printf("%s - %s\n", strftime("1%f", 1000123000), strftime("1%f", 0)); exit(); }' | tail -n +2 | xargs -I{} python3 -c "print({})"
+ EXPECT 123
+ TIMEOUT 1
+ 
+ # Similar to above test but test that rolling over past 1s works as expected
+ NAME strftime_microsecond_extension_rollover
+-RUN {{BPFTRACE}} -e 'BEGIN { printf("%s - %s\n", strftime("1%f", 1000000123000), strftime("1%f", 0)); exit(); }' | tail -n +2 | xargs -I{} python -c "print({})"
++RUN {{BPFTRACE}} -e 'BEGIN { printf("%s - %s\n", strftime("1%f", 1000000123000), strftime("1%f", 0)); exit(); }' | tail -n +2 | xargs -I{} python3 -c "print({})"
+ EXPECT 123
+ TIMEOUT 1
+ 
+-- 
+2.25.1
+

--- a/dynamic-layers/openembedded-layer/recipes-devtools/bpftrace/bpftrace_0.18.0.bb
+++ b/dynamic-layers/openembedded-layer/recipes-devtools/bpftrace/bpftrace_0.18.0.bb
@@ -20,6 +20,7 @@ RDEPENDS:${PN} += "bash python3 xz"
 SRC_URI = "git://github.com/iovisor/bpftrace;branch=master;protocol=https \
            file://0001-cmake-Raise-max-llvm-major-version-to-16.patch \
            file://0001-Adjust-to-build-with-llvm-17.patch \
+           file://0001-replace-python-with-python3-in-the-test.patch \
            file://run-ptest \
 "
 SRCREV = "e199c7e73da84bff9fe744d1e3402c2b505aa5a2"


### PR DESCRIPTION
"runtime:call" in ptest gets the following FAILED: | python: No such file or directory
Replace python with python3 in this ptest item.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ x] Changes have been tested
- [ x] `Signed-off-by` is present
- [ x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
