### PR TITLE
llvm-config: update following the oe-core script

### DIFF
--- a/recipes-devtools/clang/clang/llvm-config
+++ b/recipes-devtools/clang/clang/llvm-config
@@ -17,36 +17,36 @@ if [[ $# == 0 ]]; then
   exec "$NEXT_LLVM_CONFIG"
 fi
 
-if [[ $1 == "--libs" ]]; then
-  exec "$NEXT_LLVM_CONFIG" $@
-fi
-
-if [[ $1 == "--bindir" ]]; then
-  unset YOCTO_ALTERNATE_EXE_PATH
-  exec "$NEXT_LLVM_CONFIG" $@
-fi
-
-if [[ $1 == "--libfiles" ]]; then
-  exec "$NEXT_LLVM_CONFIG" $@
-fi
-
-
+remain=""
+output=""
 for arg in "$@"; do
   case "$arg" in
     --cppflags)
-      echo $CPPFLAGS
+      output="${output} ${CPPFLAGS}"
       ;;
     --cflags)
-      echo $CFLAGS
+      output="${output} ${CFLAGS}"
       ;;
     --cxxflags)
-      echo $CXXFLAGS
+      output="${output} ${CXXFLAGS}"
       ;;
     --ldflags)
-      echo $LDFLAGS
+      output="${output} ${LDFLAGS}"
+      ;;
+    --shared-mode)
+      output="${output} shared"
+      ;;
+    --link-shared)
+      break
       ;;
     *)
-      echo "$("$NEXT_LLVM_CONFIG" "$arg")"
+      remain="${remain} ${arg}"
       ;;
   esac
 done
+
+if [ "${remain}" != "" ]; then
+      output="${output} "$("$NEXT_LLVM_CONFIG" ${remain})
+fi
+
+echo "${output}"


### PR DESCRIPTION
The Mesa Clover meson.build script passes two options to llvm-config script, --libs --ldflags. The script from meta-clang passes control to the native llvm-config script, which unfortunately results in the native dynamic linker option leaking to the cross build. Fix that by adopting the approach from OE-core and filter known options before calling into the native llvm-config.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [X] Changes have been tested
- [X] `Signed-off-by` is present
- [X] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
