### PR TITLE
kirkstone: Fix libclang package files list

### DIFF
--- a/recipes-devtools/clang/clang_git.bb
+++ b/recipes-devtools/clang/clang_git.bb
@@ -307,7 +307,7 @@ FILES:${PN}-libllvm =+ "\
 "
 
 FILES:libclang = "\
-  ${libdir}/libclang.so.13 \
+  ${libdir}/libclang.so.* \
 "
 
 FILES:${PN}-dev += "\


### PR DESCRIPTION
Commit 79169d9 fixed non existing libclang package, but only libclang symlink was packaged. Use `libclang.so.*` wildcard to also include the shared library without hardcoding its version.

Before:
```
$ dpkg -c ./tmp/deploy/ipk/cortexa57/libclang_14.0.6-r0_cortexa57.ipk
drwxr-xr-x root/root         0 2011-04-06 01:00 ./usr/
drwxr-xr-x root/root         0 2011-04-06 01:00 ./usr/lib/
lrwxrwxrwx root/root         0 2011-04-06 01:00 ./usr/lib/libclang.so.13 -> libclang.so.14.0.6
```
After:
```
$ dpkg -c ./tmp/deploy/ipk/cortexa57/libclang13_14.0.6-r0_cortexa57.ipk
drwxr-xr-x root/root         0 2011-04-06 01:00 ./usr/
drwxr-xr-x root/root         0 2011-04-06 01:00 ./usr/lib/
lrwxrwxrwx root/root         0 2011-04-06 01:00 ./usr/lib/libclang.so.13 -> libclang.so.14.0.6
-rwxr-xr-x root/root  29451416 2011-04-06 01:00 ./usr/lib/libclang.so.14.0.6
```

Closes: https://github.com/kraj/meta-clang/issues/893

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
