### PR TITLE
bpftrace: Do not strip uprobe_test

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-devtools/bpftrace/bpftrace_0.18.0.bb
+++ b/dynamic-layers/openembedded-layer/recipes-devtools/bpftrace/bpftrace_0.18.0.bb
@@ -57,3 +57,7 @@ EXTRA_OECMAKE = " \
 
 COMPATIBLE_HOST = "(x86_64.*|aarch64.*|powerpc64.*|riscv64.*)-linux"
 COMPATIBLE_HOST:libc-musl = "null"
+
+INHIBIT_PACKAGE_STRIP_FILES += "\
+    ${PKGD}${PTEST_PATH}/tests/testprogs/uprobe_test \
+"


### PR DESCRIPTION
"runtime:regression" in ptest gets the following FAILED: | nm: ./testprogs/uprobe_test: no symbols
Keep the debug info of uprobe_test to pass this ptest item.

the steps to repruduce:
$export BPFTRACE_RUNTIME_TEST_EXECUTABLE=/usr/bin
$cd /usr/lib/bpftrace/ptest/tests
$python3 runtime/engine/main.py --filter="regression.*" ***
| [  FAILED  ] regression.address_probe_invalid_expansion | 	Command: /usr/bin/bpftrace -e "uprobe:./testprogs/uprobe_test:0x$
|           (nm ./testprogs/uprobe_test | awk '$3 == "function1"
|           {print $1}') { @[probe] = count(); exit() }"
| 	Unclean exit code: 1
| 	Output: nm: ./testprogs/uprobe_test: no symbols\nNo probes to attach\n
***

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ x] Changes have been tested
- [ x] `Signed-off-by` is present
- [ x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
