### PR TITLE
valgrind: Cover do_install_ptest bbappend under clang override

### DIFF
--- a/recipes-devtools/valgrind/valgrind_%.bbappend
+++ b/recipes-devtools/valgrind/valgrind_%.bbappend
@@ -2,7 +2,7 @@
 # Remove tests when using clang since, clang generates debug info
 # for asm files too, like freebsd outputs but we are on linux
 # and valgrind tests think its always using gcc on linux
-do_install_ptest:append () {
+do_install_ptest:append:toolchain-clang () {
     if [ "${@bb.utils.contains('TC_CXX_RUNTIME', 'llvm', 'True', 'False', d)}" ]
     then
         rm ${D}${PTEST_PATH}/memcheck/tests/gone_abrt_xml.vgtest


### PR DESCRIPTION
This should fix the layer check runs.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
