### PR TITLE
bcc: drop python3-distutils runtime dependency

### DIFF
--- a/dynamic-layers/meta-python/recipes-devtools/bcc/bcc_0.28.0.bb
+++ b/dynamic-layers/meta-python/recipes-devtools/bcc/bcc_0.28.0.bb
@@ -22,7 +22,7 @@ LUAJIT:powerpc64 = ""
 LUAJIT:riscv64 = ""
 
 RDEPENDS:${PN} += "bash python3 python3-core python3-setuptools xz"
-RDEPENDS:${PN}-ptest = "cmake python3 python3-distutils python3-netaddr python3-pyroute2"
+RDEPENDS:${PN}-ptest = "cmake python3 python3-netaddr python3-pyroute2"
 
 SRC_URI = "gitsm://github.com/iovisor/bcc;branch=master;protocol=https \
            file://0001-python-CMakeLists.txt-Remove-check-for-host-etc-debi.patch \


### PR DESCRIPTION
distutils package no longer exists after python 3.12 upgrade.

I haven't run ptest for this, but at least it will parse well now instead of:
ERROR: Nothing RPROVIDES 'python3-distutils' (but meta-clang/dynamic-layers/meta-python/recipes-devtools/bcc/bcc_0.28.0.bb RDEPENDS on or otherwise requires it)