### PR TITLE
compiler-rt-sanitizers: Build fixes

### DIFF
--- a/recipes-devtools/clang/compiler-rt-sanitizers_git.bb
+++ b/recipes-devtools/clang/compiler-rt-sanitizers_git.bb
@@ -15,7 +15,7 @@ LIC_FILES_CHKSUM = "file://compiler-rt/LICENSE.TXT;md5=d846d1d65baf322d4c485d6ee
 
 TUNE_CCARGS:remove = "-no-integrated-as"
 
-DEPENDS += "ninja-native virtual/crypt"
+DEPENDS += "ninja-native virtual/crypt compiler-rt"
 DEPENDS:append:class-native = " clang-native libxcrypt-native"
 DEPENDS:append:class-nativesdk = " clang-native clang-crosssdk-${SDK_ARCH} nativesdk-libxcrypt"
 

--- a/recipes-devtools/clang/compiler-rt-sanitizers_git.bb
+++ b/recipes-devtools/clang/compiler-rt-sanitizers_git.bb
@@ -74,7 +74,7 @@ do_install:append () {
         mv ${D}${libdir}/clang/${MAJOR_VER} ${D}${libdir}/clang/${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}
     fi
     # Already shipped with compile-rt Orc support
-    rm -rf ${D}${nonarch_libdir}/clang/${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}/lib/linux/libclang_rt.orc-*.a
+    rm -rf ${D}${nonarch_libdir}/clang/${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}/lib/linux/liborc_rt-*.a
     rm -rf ${D}${nonarch_libdir}/clang/${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}/include/orc/
 }
 


### PR DESCRIPTION
While building compiler-rt-sanitizers I encountered some build and packaging issues. I am not certain why the missing `compiler-rt` dependency was not observed before but the configuration failure is reproducible in a clean Yocto build which merely includes the `meta-clang` layer without making any further configuration adaptations.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
