### PR TITLE
Use gcc for rpm and fix dav1d on rv64

### DIFF
--- a/conf/nonclangable.conf
+++ b/conf/nonclangable.conf
@@ -475,6 +475,9 @@ DEPENDS:append:pn-pixman:mips:toolchain-clang = " openmp"
 #| .endfunc
 #| ^
 CFLAGS:append:pn-pixman:arm:toolchain-clang = " -no-integrated-as"
+# <instantiation>:98:23: error: operand must be e[8|16|32|64|128|256|512|1024],m[1|2|4|8|f2|f4|f8],[ta|tu],[ma|mu]
+#  vsetvli zero, zero, e16, m1
+CFLAGS:append:pn-dav1d:riscv64:toolchain-clang = " -no-integrated-as"
 
 # ERROR: babeltrace2-2.0.5-r0 do_package_qa: QA Issue: babeltrace2: ELF binary /usr/lib/babeltrace2/plugins/babeltrace-plugin-ctf.so has relocations in .text
 INSANE_SKIP:append:pn-babeltrace2:toolchain-clang = "${@bb.utils.contains('DISTRO_FEATURES', 'ld-is-lld', ' textrel', '', d)}"

--- a/recipes-devtools/rpm/rpm_%.bbappend
+++ b/recipes-devtools/rpm/rpm_%.bbappend
@@ -1,6 +1,7 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
-DEPENDS:append:toolchain-clang = " openmp"
+# Set until https://github.com/llvm/llvm-project/issues/82541 is fixed
+#DEPENDS:append:toolchain-clang = " openmp"
 DEPENDS:remove:toolchain-clang:riscv32 = "openmp"
 DEPENDS:remove:toolchain-clang:mipsarch = "openmp"
 DEPENDS:remove:toolchain-clang:powerpc = "openmp"
@@ -9,3 +10,6 @@ DEPENDS:remove:toolchain-clang:powerpc = "openmp"
 TOOLCHAIN:riscv32 = "gcc"
 TOOLCHAIN:mipsarch = "gcc"
 TOOLCHAIN:powerpc = "gcc"
+# Set until https://github.com/llvm/llvm-project/issues/82541 is fixed
+TOOLCHAIN = "gcc"
+LDFLAGS:remove = "-fuse-ld=lld"


### PR DESCRIPTION
---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
