### PR TITLE
openldap: Fix build with lld linker

### DIFF
--- a/conf/nonclangable.conf
+++ b/conf/nonclangable.conf
@@ -592,6 +592,7 @@ LDFLAGS:append:pn-elfutils:toolchain-clang = "${@bb.utils.contains('DISTRO_FEATU
 LDFLAGS:append:pn-pmdk:toolchain-clang = "${@bb.utils.contains('DISTRO_FEATURES', 'ld-is-lld', ' -Wl,--undefined-version', '', d)}"
 LDFLAGS:append:pn-libcgroup:toolchain-clang = "${@bb.utils.contains('DISTRO_FEATURES', 'ld-is-lld sysvinit', ' -Wl,--undefined-version', '', d)}"
 LDFLAGS:append:pn-kernel-selftest:toolchain-clang = "${@bb.utils.contains('DISTRO_FEATURES', 'ld-is-lld', ' -Wl,--undefined-version', '', d)}"
+LDFLAGS:append:pn-openldap:toolchain-clang = "${@bb.utils.contains('DISTRO_FEATURES', 'ld-is-lld', ' -Wl,--undefined-version', '', d)}"
 TUNE_CCARGS:remove:pn-kernel-selftest:toolchain-clang = "-mfpmath=sse"
 
 # Avoid's go linker crash as reported in https://github.com/golang/go/issues/61872


### PR DESCRIPTION
Fixes
    aarch64-yoe-linux-ld.lld: error: version script assignment of 'OPENLDAP_2.200' to symbol 'ldap_host_connected_to' failed: symbol not defined /error:       [1/17]

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
