### PR TITLE
bcc: remove LUAJIT setting and related examples

### DIFF
--- a/dynamic-layers/meta-python/recipes-devtools/bcc/bcc_0.29.1.bb
+++ b/dynamic-layers/meta-python/recipes-devtools/bcc/bcc_0.29.1.bb
@@ -10,16 +10,10 @@ DEPENDS += "bison-native \
             zip-native \
             flex \
             elfutils \
-            ${LUAJIT} \
             clang \
             libbpf \
             python3-setuptools-native \
             "
-
-LUAJIT ?= "luajit"
-LUAJIT:powerpc64le = ""
-LUAJIT:powerpc64 = ""
-LUAJIT:riscv64 = ""
 
 RDEPENDS:${PN} += "bash python3 python3-core python3-setuptools xz"
 RDEPENDS:${PN}-ptest = "cmake python3 python3-netaddr python3-pyroute2"
@@ -57,6 +51,7 @@ do_install:append() {
             -i $(find ${D}${datadir}/${PN} -type f)
         sed -e 's@#!/usr/bin/python.*@#!/usr/bin/env python3@g' \
             -i $(find ${D}${datadir}/${PN} -type f)
+        rm -rf ${D}${datadir}/bcc/examples/lua
 }
 
 do_install_ptest() {


### PR DESCRIPTION
Current LUAJIT actually not works, below is snip of src/lua/CMakeLists.txt
[snip]
find_package(LuaJIT)
find_program(LUAJIT luajit)

if (LUAJIT_LIBRARIES AND LUAJIT)
	FILE(GLOB_RECURSE SRC_LUA
		${CMAKE_CURRENT_SOURCE_DIR}/bcc/*.lua
		${CMAKE_CURRENT_SOURCE_DIR}/bcc/vendor/*.lua
		${CMAKE_CURRENT_SOURCE_DIR}/bpf/*.lua)

	ADD_CUSTOM_COMMAND(
		OUTPUT bcc.lua
		COMMAND ${LUAJIT} ${CMAKE_CURRENT_SOURCE_DIR}/src/squish.lua ${CMAKE_CURRENT_SOURCE_DIR}
		DEPENDS ${SRC_LUA} ${CMAKE_CURRENT_SOURCE_DIR}/squishy
	)

	ADD_CUSTOM_COMMAND(
		OUTPUT bcc.o
		COMMAND ${LUAJIT} -bg bcc.lua bcc.o
		DEPENDS bcc.lua
	)
[snip]

LUAJIT will be set when luajit is found. For oe, maybe we need to
DEPENDS on luajit-native. But there are still 2 problems after I change
DEPENDS from luajit to luajit-native and export
LUA_PATH="${RECIPE_SYSROOT_NATIVE}/usr/share/luajit-2.1/?.lua"

1. luajit seems not support cross compile, if our target arch is
different with build host, from above snip, luajit will compile out
bcc.o with host arch, int this way, compile will failed with below
error: "error adding symbols: file in wrong format".

Refer [1],  seems like option "-a" can used to generate other arch
object. But luajit-native don't have this option:
cortexa57-wrs-linux/bcc/0.29.1/recipe-sysroot-native/usr/bin/luajit [options]... [script [args]...].
Available options are:
-e chunk Execute string 'chunk'.
-l name Require library 'name'.
-b ... Save or list bytecode.
-j cmd Perform LuaJIT control command.
-O[opt] Control LuaJIT optimizations.
-i Enter interactive mode after executing 'script'.
-v Show version information.
-E Ignore environment variables.
– Stop handling options.

2. if target arch is the same as build host(my test env is x86-64),
bcc-lua is built out, but still have 2 problems, first, "bcc-lua
/usr/share/bcc/examples/lua/bashreadline.lua" has a runtime error [2].
second, bcc-lua may try to find modules on host path:

root@qemux86-64:/usr/share/bcc/examples/lua# bcc-lua ./kprobe-latency.lua
bcc-lua: bcc.lua:3052: module 'syscall' not found:
no field package.preload['syscall']
no file './syscall.lua'
no file '/build/tmp-glibc/work/x86_64-linux/luajit-native/2.1/recipe-sysroot-native/usr/share/luaj'
no file '/usr/local/share/lua/5.1/syscall.lua'
no file '/usr/local/share/lua/5.1/syscall/init.lua'
no file '/build/tmp-glibc/work/x86_64-linux/luajit-native/2.1/recipe-sysroot-native/usr/share/lua/'
no file '/build/tmp-glibc/work/x86_64-linux/luajit-native/2.1/recipe-sysroot-native/usr/share/lua/'
no file './syscall.so'
no file '/usr/local/lib/lua/5.1/syscall.so'
no file '/build/tmp-glibc/work/x86_64-linux/luajit-native/2.1/recipe-sysroot-native/usr/lib/lua/5.'
no file '/usr/local/lib/lua/5.1/loadall.so'

so remove LUAJIT setting and related examples first

[1] https://luajit.org/running.html
[2] https://github.com/iovisor/bcc/issues/1621