### PR TITLE
layer.conf: Mark it scarthgap compatible

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -7,7 +7,7 @@ BBFILES += "${LAYERDIR}/recipes*/*/*.bb ${LAYERDIR}/recipes*/*/*.bbappend"
 BBFILE_COLLECTIONS += "clang-layer"
 BBFILE_PATTERN_clang-layer := "^${LAYERDIR}/"
 BBFILE_PRIORITY_clang-layer = "7"
-LAYERSERIES_COMPAT_clang-layer = "mickledore nanbield"
+LAYERSERIES_COMPAT_clang-layer = "mickledore nanbield scarthgap"
 LAYERDEPENDS_clang-layer = "core"
 
 BBFILES_DYNAMIC += " \


### PR DESCRIPTION
Downstream projects need time to switch to opaque
pointers in llvm16 which requires in some cases
significant effort.

