### PR TITLE
Revert "nonclangable: elfuitls: add unused-const-variable fix"

### DIFF
--- a/conf/nonclangable.conf
+++ b/conf/nonclangable.conf
@@ -20,8 +20,6 @@ TOOLCHAIN:pn-grub:aarch64 = "gcc"
 TOOLCHAIN:pn-crash = "gcc"
 # See https://github.com/llvm/llvm-project/issues/71925
 LIBCPLUSPLUS:pn-elfutils:toolchain-clang = "-stdlib=libstdc++"
-# Remove it once https://lore.kernel.org/openembedded-core/20240319104830.1685335-1-jose.quaresma@foundries.io/T/#u is merged
-CXXFLAGS:append:pn-elfutils:toolchain-clang = " -Wno-error=unused-const-variable"
 #| erl_bits.c:(.text+0xc2a): undefined reference to `__extendhfsf2'
 #| erl_bits.c:(.text+0x1bfa): undefined reference to `__truncsfhf2'
 #| clang-15: error: linker command failed with exit code 1 (use -v to see invocation)


### PR DESCRIPTION
This reverts commit 81e5f4eef93b5e1d6507daaf74fce28a2ccd7cf7.

It is merged in oe-core master

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
