### PR TITLE
qt6/qttools: remove bbappend

### DIFF
--- a/dynamic-layers/qt6-layer/recipes-qt/qt6/qttools_%.bbappend
+++ b/dynamic-layers/qt6-layer/recipes-qt/qt6/qttools_%.bbappend
@@ -1,1 +1,0 @@
-PACKAGECONFIG:append = " clang"


### PR DESCRIPTION
clang dependency is already added in meta-qt6 recipe.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
