### PR TITLE
Update clang to 18.1.2 release

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -33,7 +33,7 @@ INHERIT += "clang"
 # Do not include clang in SDK unless user wants to
 CLANGSDK ??= "0"
 
-LLVMVERSION = "18.1.1"
+LLVMVERSION = "18.1.2"
 
 require conf/nonclangable.conf
 require conf/nonscanable.conf

--- a/recipes-devtools/clang/clang.inc
+++ b/recipes-devtools/clang/clang.inc
@@ -6,10 +6,10 @@ LLVM_GIT_PROTOCOL ?= "https"
 
 MAJOR_VER = "18"
 MINOR_VER = "1"
-PATCH_VER = "1"
+PATCH_VER = "2"
 # could be 'rcX' or 'git' or empty ( for release )
 VER_SUFFIX = ""
-SRCREV ?= "dba2a75e9c7ef81fe84774ba5eee5e67e01d801a"
+SRCREV ?= "26a1d6601d727a96f4301d0d8647b5a42760ae0c"
 
 PV = "${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}${VER_SUFFIX}"
 BRANCH = "release/18.x"

--- a/recipes-devtools/clang/clang/0001-libcxxabi-Find-libunwind-headers-when-LIBCXXABI_LIBU.patch
+++ b/recipes-devtools/clang/clang/0001-libcxxabi-Find-libunwind-headers-when-LIBCXXABI_LIBU.patch
@@ -1,4 +1,4 @@
-From 7065ef64c066b9dadf7e751f72e85232d729e225 Mon Sep 17 00:00:00 2001
+From ec5bd3bfc9f682c90ceba06f2d76aa5234a9c846 Mon Sep 17 00:00:00 2001
 From: Khem Raj <raj.khem@gmail.com>
 Date: Sun, 27 Aug 2017 10:37:49 -0700
 Subject: [PATCH] libcxxabi: Find libunwind headers when

--- a/recipes-devtools/clang/clang/0002-compiler-rt-support-a-new-embedded-linux-target.patch
+++ b/recipes-devtools/clang/clang/0002-compiler-rt-support-a-new-embedded-linux-target.patch
@@ -1,4 +1,4 @@
-From 7ca2a8c8590e99cb9edb36e378db39df21c3b0ed Mon Sep 17 00:00:00 2001
+From ac1643e6e68697e6ee374535dd98413c92224076 Mon Sep 17 00:00:00 2001
 From: Khem Raj <raj.khem@gmail.com>
 Date: Sun, 19 Apr 2015 15:16:23 -0700
 Subject: [PATCH] compiler-rt: support a new embedded linux target

--- a/recipes-devtools/clang/clang/0003-compiler-rt-Simplify-cross-compilation.-Don-t-use-na.patch
+++ b/recipes-devtools/clang/clang/0003-compiler-rt-Simplify-cross-compilation.-Don-t-use-na.patch
@@ -1,4 +1,4 @@
-From f69ce2c951a5346127517715681e2dd47d33cf65 Mon Sep 17 00:00:00 2001
+From 3d969ae73698da3518f3230f9e40cb7bd6f2e6c3 Mon Sep 17 00:00:00 2001
 From: Khem Raj <raj.khem@gmail.com>
 Date: Thu, 19 May 2016 23:11:45 -0700
 Subject: [PATCH] compiler-rt: Simplify cross-compilation. Don't use

--- a/recipes-devtools/clang/clang/0004-llvm-TargetLibraryInfo-Undefine-libc-functions-if-th.patch
+++ b/recipes-devtools/clang/clang/0004-llvm-TargetLibraryInfo-Undefine-libc-functions-if-th.patch
@@ -1,4 +1,4 @@
-From f01b464943203b0094bc8b76794e93afc35d912a Mon Sep 17 00:00:00 2001
+From df831369b91c38565d73b56d452186eff0a63dd4 Mon Sep 17 00:00:00 2001
 From: Khem Raj <raj.khem@gmail.com>
 Date: Sat, 21 May 2016 00:33:20 +0000
 Subject: [PATCH] llvm: TargetLibraryInfo: Undefine libc functions if they are

--- a/recipes-devtools/clang/clang/0005-llvm-allow-env-override-of-exe-and-libdir-path.patch
+++ b/recipes-devtools/clang/clang/0005-llvm-allow-env-override-of-exe-and-libdir-path.patch
@@ -1,4 +1,4 @@
-From 6543b333f413bc906c8a3577266f1ff6561b2e05 Mon Sep 17 00:00:00 2001
+From a160c086ee25bb5db31bc497e910c3615681e948 Mon Sep 17 00:00:00 2001
 From: Martin Kelly <mkelly@xevo.com>
 Date: Fri, 19 May 2017 00:22:57 -0700
 Subject: [PATCH] llvm: allow env override of exe and libdir path

--- a/recipes-devtools/clang/clang/0006-clang-driver-Check-sysroot-for-ldso-path.patch
+++ b/recipes-devtools/clang/clang/0006-clang-driver-Check-sysroot-for-ldso-path.patch
@@ -1,4 +1,4 @@
-From ac8010d0f42375b862be8d020b39862dde2d3739 Mon Sep 17 00:00:00 2001
+From af511db3b78d27f21af09877c1c188b1c0c2ce0a Mon Sep 17 00:00:00 2001
 From: Dan McGregor <dan.mcgregor@usask.ca>
 Date: Wed, 26 Apr 2017 20:29:41 -0600
 Subject: [PATCH] clang: driver: Check sysroot for ldso path

--- a/recipes-devtools/clang/clang/0007-clang-Driver-tools.cpp-Add-lssp_nonshared-on-musl.patch
+++ b/recipes-devtools/clang/clang/0007-clang-Driver-tools.cpp-Add-lssp_nonshared-on-musl.patch
@@ -1,4 +1,4 @@
-From fbf2696149ab70f296b6a36e1867ee487bb5b3d4 Mon Sep 17 00:00:00 2001
+From a842a494f82f68c92a562aa40e6861f792d5b703 Mon Sep 17 00:00:00 2001
 From: Khem Raj <raj.khem@gmail.com>
 Date: Thu, 19 May 2016 21:11:06 -0700
 Subject: [PATCH] clang: Driver/tools.cpp: Add -lssp_nonshared on musl

--- a/recipes-devtools/clang/clang/0008-clang-Prepend-trailing-to-sysroot.patch
+++ b/recipes-devtools/clang/clang/0008-clang-Prepend-trailing-to-sysroot.patch
@@ -1,4 +1,4 @@
-From 32028d3635b5f5f00a538e60d7fc89a3576d1d1f Mon Sep 17 00:00:00 2001
+From 53b47e96f7c69bea46d16489dd6887561245c23f Mon Sep 17 00:00:00 2001
 From: Khem Raj <raj.khem@gmail.com>
 Date: Thu, 16 Mar 2017 09:02:13 -0700
 Subject: [PATCH] clang: Prepend trailing '/' to sysroot

--- a/recipes-devtools/clang/clang/0009-clang-Look-inside-the-target-sysroot-for-compiler-ru.patch
+++ b/recipes-devtools/clang/clang/0009-clang-Look-inside-the-target-sysroot-for-compiler-ru.patch
@@ -1,4 +1,4 @@
-From 5a2e2c7600e855782be747d28b16377f7d3354a8 Mon Sep 17 00:00:00 2001
+From fd99d9521a7f9ce8c8de7c05a9636efa5a5c34e2 Mon Sep 17 00:00:00 2001
 From: Khem Raj <raj.khem@gmail.com>
 Date: Thu, 16 Mar 2017 19:06:26 -0700
 Subject: [PATCH] clang: Look inside the target sysroot for compiler runtime

--- a/recipes-devtools/clang/clang/0010-clang-Define-releative-gcc-installation-dir.patch
+++ b/recipes-devtools/clang/clang/0010-clang-Define-releative-gcc-installation-dir.patch
@@ -1,4 +1,4 @@
-From 840960c4a146a90a1e9b8d381b1bab64701650a2 Mon Sep 17 00:00:00 2001
+From a310e5638205777893228a1c0853bd5494e7d02c Mon Sep 17 00:00:00 2001
 From: Khem Raj <raj.khem@gmail.com>
 Date: Sat, 20 Mar 2021 16:09:16 -0700
 Subject: [PATCH] clang: Define / releative gcc installation dir

--- a/recipes-devtools/clang/clang/0011-clang-Add-lpthread-and-ldl-along-with-lunwind-for-st.patch
+++ b/recipes-devtools/clang/clang/0011-clang-Add-lpthread-and-ldl-along-with-lunwind-for-st.patch
@@ -1,4 +1,4 @@
-From 702335a68f81dfa1ac89b759846faa8a479bdec7 Mon Sep 17 00:00:00 2001
+From bc21d17ff434af5efdb2fac86392862230c6f9e6 Mon Sep 17 00:00:00 2001
 From: Khem Raj <raj.khem@gmail.com>
 Date: Wed, 31 Jul 2019 22:51:39 -0700
 Subject: [PATCH] clang: Add -lpthread and -ldl along with -lunwind for static

--- a/recipes-devtools/clang/clang/0012-Pass-PYTHON_EXECUTABLE-when-cross-compiling-for-nati.patch
+++ b/recipes-devtools/clang/clang/0012-Pass-PYTHON_EXECUTABLE-when-cross-compiling-for-nati.patch
@@ -1,4 +1,4 @@
-From b0132d5b8f5b92f66087fe11713885d8916554c2 Mon Sep 17 00:00:00 2001
+From a48c97d8a0f5eee9729cad03eac5be677c9963e8 Mon Sep 17 00:00:00 2001
 From: Anuj Mittal <anuj.mittal@intel.com>
 Date: Thu, 26 Dec 2019 12:56:16 -0800
 Subject: [PATCH] Pass PYTHON_EXECUTABLE when cross compiling for native build

--- a/recipes-devtools/clang/clang/0013-Check-for-atomic-double-intrinsics.patch
+++ b/recipes-devtools/clang/clang/0013-Check-for-atomic-double-intrinsics.patch
@@ -1,4 +1,4 @@
-From b2ed6b57edd6afd6f2a5376a0bdea36d017fc95f Mon Sep 17 00:00:00 2001
+From 4e96e75d77d0d59399f0b8ad7aa0555e39e7b5cc Mon Sep 17 00:00:00 2001
 From: Khem Raj <raj.khem@gmail.com>
 Date: Mon, 18 Nov 2019 17:00:29 -0800
 Subject: [PATCH] Check for atomic<double> intrinsics

--- a/recipes-devtools/clang/clang/0014-libcxx-Add-compiler-runtime-library-to-link-step-for.patch
+++ b/recipes-devtools/clang/clang/0014-libcxx-Add-compiler-runtime-library-to-link-step-for.patch
@@ -1,4 +1,4 @@
-From 762c7af55064261f061fcd5ce0bd2eb93cbd425b Mon Sep 17 00:00:00 2001
+From c0a66d4f358b24bf3acd89910e0f7fc780d16a11 Mon Sep 17 00:00:00 2001
 From: Jeremy Puhlman <jpuhlman@mvista.com>
 Date: Thu, 16 Jan 2020 21:16:10 +0000
 Subject: [PATCH] libcxx: Add compiler runtime library to link step for libcxx
@@ -14,7 +14,7 @@ Signed-off-by: Khem Raj <raj.khem@gmail.com>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/libcxx/src/CMakeLists.txt b/libcxx/src/CMakeLists.txt
-index 44a088663463..2a8546165f44 100644
+index 1b80625304a4..fe706c9e920f 100644
 --- a/libcxx/src/CMakeLists.txt
 +++ b/libcxx/src/CMakeLists.txt
 @@ -198,7 +198,7 @@ if (LIBCXX_ENABLE_SHARED)

--- a/recipes-devtools/clang/clang/0015-clang-llvm-cmake-Fix-configure-for-packages-using-fi.patch
+++ b/recipes-devtools/clang/clang/0015-clang-llvm-cmake-Fix-configure-for-packages-using-fi.patch
@@ -1,4 +1,4 @@
-From e6592691f3f5b13785adfa7cfca938742a35fb29 Mon Sep 17 00:00:00 2001
+From aab6a666bf1094d9750a10e547ebd6fe093af513 Mon Sep 17 00:00:00 2001
 From: Ovidiu Panait <ovidiu.panait@windriver.com>
 Date: Fri, 31 Jan 2020 10:56:11 +0200
 Subject: [PATCH] clang,llvm: cmake: Fix configure for packages using

--- a/recipes-devtools/clang/clang/0016-clang-Fix-resource-dir-location-for-cross-toolchains.patch
+++ b/recipes-devtools/clang/clang/0016-clang-Fix-resource-dir-location-for-cross-toolchains.patch
@@ -1,4 +1,4 @@
-From cc868200402deee5203b498d72dc26f944f10a55 Mon Sep 17 00:00:00 2001
+From 58cae5f6f4df0e6fd8529f99f940984e770f4c84 Mon Sep 17 00:00:00 2001
 From: Jim Broadus <jbroadus@xevo.com>
 Date: Thu, 26 Mar 2020 16:05:53 -0700
 Subject: [PATCH] clang: Fix resource dir location for cross toolchains

--- a/recipes-devtools/clang/clang/0017-clang-driver-Add-dyld-prefix-when-checking-sysroot-f.patch
+++ b/recipes-devtools/clang/clang/0017-clang-driver-Add-dyld-prefix-when-checking-sysroot-f.patch
@@ -1,4 +1,4 @@
-From c6d4b091b470d6a6cff90f19416c990be8b08319 Mon Sep 17 00:00:00 2001
+From 6c83a2e75b42eff98975bebacd446455d60cb128 Mon Sep 17 00:00:00 2001
 From: Oleksandr Ocheretnyi <oocheret@cisco.com>
 Date: Wed, 15 Apr 2020 00:08:39 +0300
 Subject: [PATCH] clang: driver: Add dyld-prefix when checking sysroot for ldso

--- a/recipes-devtools/clang/clang/0018-clang-Use-python3-in-python-scripts.patch
+++ b/recipes-devtools/clang/clang/0018-clang-Use-python3-in-python-scripts.patch
@@ -1,4 +1,4 @@
-From 376554f8f40211f36444a23011e80ad950274723 Mon Sep 17 00:00:00 2001
+From 5a572d401005fb992b421d65628267e49d70ee74 Mon Sep 17 00:00:00 2001
 From: Khem Raj <raj.khem@gmail.com>
 Date: Wed, 14 Oct 2020 22:19:57 -0700
 Subject: [PATCH] clang: Use python3 in python scripts

--- a/recipes-devtools/clang/clang/0019-For-x86_64-set-Yocto-based-GCC-install-search-path.patch
+++ b/recipes-devtools/clang/clang/0019-For-x86_64-set-Yocto-based-GCC-install-search-path.patch
@@ -1,4 +1,4 @@
-From fc730bc3b01378f457f43d5c684bc4cee818abc3 Mon Sep 17 00:00:00 2001
+From b928740f3def5353a779859c0454666cae1f7d61 Mon Sep 17 00:00:00 2001
 From: Hongxu Jia <hongxu.jia@windriver.com>
 Date: Mon, 25 Jan 2021 16:14:35 +0800
 Subject: [PATCH] For x86_64, set Yocto based GCC install search path

--- a/recipes-devtools/clang/clang/0020-llvm-Do-not-use-find_library-for-ncurses.patch
+++ b/recipes-devtools/clang/clang/0020-llvm-Do-not-use-find_library-for-ncurses.patch
@@ -1,4 +1,4 @@
-From ce223c530a076c7e41b1ea23c747d12dde9e1120 Mon Sep 17 00:00:00 2001
+From 07e74b7f5147d5da67b46067df5d26090a3bb96b Mon Sep 17 00:00:00 2001
 From: Khem Raj <raj.khem@gmail.com>
 Date: Sun, 7 Feb 2021 23:58:41 -0800
 Subject: [PATCH] llvm: Do not use find_library for ncurses

--- a/recipes-devtools/clang/clang/0021-llvm-Insert-anchor-for-adding-OE-distro-vendor-names.patch
+++ b/recipes-devtools/clang/clang/0021-llvm-Insert-anchor-for-adding-OE-distro-vendor-names.patch
@@ -1,4 +1,4 @@
-From 1cf1458650a3cfed4bab56ca0fb026d091ab725b Mon Sep 17 00:00:00 2001
+From a3dbd6b6c8bfab6877632ec7a1e981aaa2883d90 Mon Sep 17 00:00:00 2001
 From: Khem Raj <raj.khem@gmail.com>
 Date: Thu, 11 Feb 2021 16:42:49 -0800
 Subject: [PATCH] llvm: Insert anchor for adding OE distro vendor names

--- a/recipes-devtools/clang/clang/0022-compiler-rt-Do-not-use-backtrace-APIs-on-non-glibc-l.patch
+++ b/recipes-devtools/clang/clang/0022-compiler-rt-Do-not-use-backtrace-APIs-on-non-glibc-l.patch
@@ -1,4 +1,4 @@
-From 30bc9fac3220d919a3e94b14b47250247e5686e4 Mon Sep 17 00:00:00 2001
+From afed95c05037559e53d9a60b8520b372d54b467d Mon Sep 17 00:00:00 2001
 From: Khem Raj <raj.khem@gmail.com>
 Date: Wed, 19 May 2021 17:32:13 -0700
 Subject: [PATCH] compiler-rt: Do not use backtrace APIs on non-glibc linux

--- a/recipes-devtools/clang/clang/0023-clang-Fix-x86-triple-for-non-debian-multiarch-linux-.patch
+++ b/recipes-devtools/clang/clang/0023-clang-Fix-x86-triple-for-non-debian-multiarch-linux-.patch
@@ -1,4 +1,4 @@
-From 1cca5d6c319fb2ebff798882d6f7cf55ae225d8e Mon Sep 17 00:00:00 2001
+From 25434c45f0c7079e9171b5ef4027626a64d3e50b Mon Sep 17 00:00:00 2001
 From: Khem Raj <raj.khem@gmail.com>
 Date: Wed, 19 May 2021 17:56:03 -0700
 Subject: [PATCH] clang: Fix x86 triple for non-debian multiarch linux distros

--- a/recipes-devtools/clang/clang/0024-libunwind-Added-unw_backtrace-method.patch
+++ b/recipes-devtools/clang/clang/0024-libunwind-Added-unw_backtrace-method.patch
@@ -1,4 +1,4 @@
-From 391c312f710887305d6b91c2c5e8d26536ff1328 Mon Sep 17 00:00:00 2001
+From c4ec538a1e00eb60ad890df51401f27484b349d9 Mon Sep 17 00:00:00 2001
 From: Maksim Kita <maksim-kita@yandex-team.ru>
 Date: Sun, 23 May 2021 10:27:29 +0000
 Subject: [PATCH] libunwind: Added unw_backtrace method

--- a/recipes-devtools/clang/clang/0025-clang-Do-not-use-install-relative-libc-headers.patch
+++ b/recipes-devtools/clang/clang/0025-clang-Do-not-use-install-relative-libc-headers.patch
@@ -1,4 +1,4 @@
-From 75fba7350f0b161254994279d26ba720dde270ee Mon Sep 17 00:00:00 2001
+From b759741be82cc87406f5b7ece236617ad5450e78 Mon Sep 17 00:00:00 2001
 From: Khem Raj <raj.khem@gmail.com>
 Date: Wed, 11 Aug 2021 18:37:11 -0700
 Subject: [PATCH] clang: Do not use install relative libc++ headers

--- a/recipes-devtools/clang/clang/0026-clang-Fix-how-driver-finds-GCC-installation-path-on-.patch
+++ b/recipes-devtools/clang/clang/0026-clang-Fix-how-driver-finds-GCC-installation-path-on-.patch
@@ -1,4 +1,4 @@
-From 9a0b3da700e6e7b4045e310555de9cc55a8fdb98 Mon Sep 17 00:00:00 2001
+From c95b551389ae1622faf630be3ddaf0dc62892595 Mon Sep 17 00:00:00 2001
 From: David Abdurachmanov <david.abdurachmanov@sifive.com>
 Date: Wed, 20 Oct 2021 17:30:36 -0700
 Subject: [PATCH] clang: Fix how driver finds GCC installation path on

--- a/recipes-devtools/clang/clang/0027-Fix-lib-paths-for-OpenEmbedded-Host.patch
+++ b/recipes-devtools/clang/clang/0027-Fix-lib-paths-for-OpenEmbedded-Host.patch
@@ -1,4 +1,4 @@
-From f9eb5c0b5e69cba7aea90d7bb84f3cb39f889329 Mon Sep 17 00:00:00 2001
+From 93855bad691059a81906ab632830239039527c6c Mon Sep 17 00:00:00 2001
 From: Changqing Li <changqing.li@windriver.com>
 Date: Tue, 7 Dec 2021 04:08:22 +0000
 Subject: [PATCH] Fix lib paths for OpenEmbedded Host

--- a/recipes-devtools/clang/clang/0028-Correct-library-search-path-for-OpenEmbedded-Host.patch
+++ b/recipes-devtools/clang/clang/0028-Correct-library-search-path-for-OpenEmbedded-Host.patch
@@ -1,4 +1,4 @@
-From aeb8e9d7234b6aca328ed9666a139bb1f5d00bdc Mon Sep 17 00:00:00 2001
+From 42bf038560a9b0bf688b0a85cbd444445e1c26dc Mon Sep 17 00:00:00 2001
 From: Changqing Li <changqing.li@windriver.com>
 Date: Tue, 7 Dec 2021 04:55:48 +0000
 Subject: [PATCH] Correct library search path for OpenEmbedded Host

--- a/recipes-devtools/clang/clang/0029-lldb-Link-with-libatomic-on-x86.patch
+++ b/recipes-devtools/clang/clang/0029-lldb-Link-with-libatomic-on-x86.patch
@@ -1,4 +1,4 @@
-From 9132301a280a8c60e18ab4299bd55f9beb869fac Mon Sep 17 00:00:00 2001
+From 0e9dd56bafb1273c784d357fca86a09f9ce02af2 Mon Sep 17 00:00:00 2001
 From: Khem Raj <raj.khem@gmail.com>
 Date: Tue, 8 Feb 2022 01:31:26 -0800
 Subject: [PATCH] lldb: Link with libatomic on x86

--- a/recipes-devtools/clang/clang/0030-compiler-rt-Enable-__int128-for-ppc32.patch
+++ b/recipes-devtools/clang/clang/0030-compiler-rt-Enable-__int128-for-ppc32.patch
@@ -1,4 +1,4 @@
-From 9decd876cd8352fac84aafe740a142f20b0f78fa Mon Sep 17 00:00:00 2001
+From 8ff4e362a824257f89cb77119fe8206667dd88ff Mon Sep 17 00:00:00 2001
 From: Khem Raj <raj.khem@gmail.com>
 Date: Wed, 9 Mar 2022 16:28:16 -0800
 Subject: [PATCH] compiler-rt: Enable __int128 for ppc32
@@ -59,7 +59,7 @@ index 28ded8766f25..08495c491f08 100644
        endif()
  
 diff --git a/compiler-rt/lib/builtins/int_types.h b/compiler-rt/lib/builtins/int_types.h
-index 7624c7280615..a45bf13f770e 100644
+index ca97391fc284..6fa1dac2325f 100644
 --- a/compiler-rt/lib/builtins/int_types.h
 +++ b/compiler-rt/lib/builtins/int_types.h
 @@ -64,7 +64,7 @@ typedef union {

--- a/recipes-devtools/clang/clang/0031-llvm-Do-not-use-cmake-infra-to-detect-libzstd.patch
+++ b/recipes-devtools/clang/clang/0031-llvm-Do-not-use-cmake-infra-to-detect-libzstd.patch
@@ -1,4 +1,4 @@
-From bfadfbccf990c2768d18dc8d7fc756aa59e4964c Mon Sep 17 00:00:00 2001
+From 39e87eabd251d5086ef14305a36134053af09ae5 Mon Sep 17 00:00:00 2001
 From: Khem Raj <raj.khem@gmail.com>
 Date: Fri, 12 Aug 2022 11:50:57 -0700
 Subject: [PATCH] llvm: Do not use cmake infra to detect libzstd

--- a/recipes-devtools/clang/clang/0032-compiler-rt-Fix-stat-struct-s-size-for-O32-ABI.patch
+++ b/recipes-devtools/clang/clang/0032-compiler-rt-Fix-stat-struct-s-size-for-O32-ABI.patch
@@ -1,4 +1,4 @@
-From f42372b9a89b494573bcc8a9c2dd05c168ccdd54 Mon Sep 17 00:00:00 2001
+From 7e735f7b956eca38c2d882f3630af9bfd215f652 Mon Sep 17 00:00:00 2001
 From: Khem Raj <raj.khem@gmail.com>
 Date: Tue, 3 Jan 2023 18:44:34 -0800
 Subject: [PATCH] compiler-rt: Fix stat struct's size for O32 ABI

--- a/recipes-devtools/clang/clang/0033-compiler-rt-Undef-_TIME_BITS-along-with-_FILE_OFFSET.patch
+++ b/recipes-devtools/clang/clang/0033-compiler-rt-Undef-_TIME_BITS-along-with-_FILE_OFFSET.patch
@@ -1,4 +1,4 @@
-From a6132924c06b4662eaed9820a13b63131ff8d4ff Mon Sep 17 00:00:00 2001
+From cfeae6f76bbfc62bffca278aa8d58db3981ca100 Mon Sep 17 00:00:00 2001
 From: Khem Raj <raj.khem@gmail.com>
 Date: Tue, 21 Feb 2023 12:46:10 -0800
 Subject: [PATCH] compiler-rt: Undef _TIME_BITS along with _FILE_OFFSET_BITS in

--- a/recipes-devtools/clang/clang/0034-ToolChains-Gnu.cpp-ARMLibDirs-search-also-in-lib32.patch
+++ b/recipes-devtools/clang/clang/0034-ToolChains-Gnu.cpp-ARMLibDirs-search-also-in-lib32.patch
@@ -1,4 +1,4 @@
-From 6021f23b2ce3166b2eb63fe48db71e6c593e1ac5 Mon Sep 17 00:00:00 2001
+From 3d2fdb0ab98f479679231435cb3247cfbf9dfaab Mon Sep 17 00:00:00 2001
 From: Martin Jansa <Martin.Jansa@gmail.com>
 Date: Thu, 31 Aug 2023 18:14:47 +0200
 Subject: [PATCH] ToolChains/Gnu.cpp: ARMLibDirs search also in lib32

--- a/recipes-devtools/clang/clang/0035-compiler-rt-Fix-cmake-check-for-_Float16-and-__bf16.patch
+++ b/recipes-devtools/clang/clang/0035-compiler-rt-Fix-cmake-check-for-_Float16-and-__bf16.patch
@@ -1,4 +1,4 @@
-From b44db6645cb65d060970b2535d372d6380d633f3 Mon Sep 17 00:00:00 2001
+From 34a65a1f0ff8bb2d41f32c229dc6b309a7566ecd Mon Sep 17 00:00:00 2001
 From: Khem Raj <raj.khem@gmail.com>
 Date: Fri, 1 Mar 2024 16:47:46 -0800
 Subject: [PATCH] compiler-rt: Fix cmake check for _Float16 and __bf16


### PR DESCRIPTION
Brings these changes

* 26a1d6601d72 [X86] Add missing subvector_subreg_lowering for BF16 (#83720)
* 0bf7ff1028fb [C++20] [Moduls] Avoid computing odr hash for functions from comparing constraint expression
* a2c93b34dfdf [RISCV] Fix mgather -> riscv.masked.strided.load combine not extending indices (#82506)
* a9d4ed71707d [RISCV] Adjust test case to show wrong stride. NFC
* 42f511c95c6f [RISCV] Add test case for miscompile in gather -> strided load combine. NFC
* 53ea0de61dcd [TSan] Fix atomicrmw xchg with pointer and floats (#85228)
* fd9f1faf8fcb [AVR] Remove earlyclobber from LDDRdPtrQ (#85277)
* 2d35ba4a8577 Revert "release/18.x: [openmp] __kmp_x86_cpuid fix for i386/PIC builds. (#846…"
* df20f2fc9998 [PowerPC] Update chain uses when emitting lxsizx (#84892)
* c09f6f6f4341 [llvm-shlib] Fix the version naming style of libLLVM for Windows (#85710)
* cba6ebf0d0ab [llvm-shlib] Fix libLLVM-18 symlink on mingw (#85554)
* bcf98bd84199 llvm-shlib: Fix libLLVM-${MAJOR}.so symlink on MacOS (#85163)
* b1f1effacf32 [WebAssembly] Change the default linker for `wasm32-wasip2` (#84569)
* ecc22d27e5b8 workflows: Fix baseline version for llvm abi checks (#85166)
* 7fd9979eb9cf [InstCombine] Drop UB-implying attrs/metadata after speculating an instruction (#85542)
* edbe7fa5fef9 [lld][LoongArch] Fix handleUleb128
* b95ea2e51bdf [lld][test] Fix sanitizer buildbot failure
* 2f640ad26d17 Remove support for EXPORTAS in def files to maintain ABI compatibility for COFFShortExport
* 207ecd684cc6 [Arm64EC] Copy import descriptors to the EC Map (#84834)
* 79bc8b32c6ed [llvm-lib][Object] Add support for EC importlib symbols. (#81059)
* 76e1800f3565 [llvm-lib][llvm-dlltool][Object] Add support for EXPORTAS name types. (#78772)
* 77e1992e89d3 [llvm-readobj][Object][COFF] Print COFF import library symbol export name. (#78769)
* 3a06861272d8 [libc++] Use clang-tidy version that matches the compiler we use in the CI (#85305)
* 0c1dcd675291 [clangd] [HeuristicResolver] Protect against infinite recursion on DependentNameTypes (#83542)
* a649e0a6e80f [clang][modules] giving the __stddef_ headers their own modules can cause redeclaration errors with -fbuiltin-headers-in-system-modules (#84127)
* 12a3bf351575 workflows: Add workaround for lld failures on MacOS (#85021) (#85110)
* 9b3edb592deb release/18.x: [openmp] __kmp_x86_cpuid fix for i386/PIC builds. (#84626) (#85053)
* 600f7f2ba28f [clangd] Add clangd 18 release notes (#84436)
* bb83f055091c [runtimes] Prefer -fvisibility-global-new-delete=force-hidden (#84917)
* 122ba9f10070 [ELF] Eliminate symbols demoted due to /DISCARD/ discarded sections (#85167)
* 33c6b2027698 SystemZ release notes for 18.x. (#84560)
* 8c6015db5912 [X86][Inline] Skip inline asm in inlining target feature check (#83820)
* 38cf35dee880 [Inline] Add test for #67054 (NFC)
* c7eb919d2cbe [ValueTracking] Treat phi as underlying obj when not decomposing further (#84339)
* b01c3dcf2eb5 [LAA] Add test case for #82665.
* 159969b3880b [Release] Install compiler-rt builtins during Phase 1 on AIX (#81485)
* 7b61ddefc28a [ArgPromotion] Remove incorrect TranspBlocks set for loads. (#84835)
* 25a989ce8bf3 [ArgPromotion] Add test case for #84807.
* 2fc8bea42f99 [LLD] [COFF] Set the right alignment for DelayDirectoryChunk (#84697)
* fcc33dca02d1 [X86] combineAndShuffleNot - ensure the type is legal before create X86ISD::ANDNP target nodes
* 39e3ba8a383e [DSE] Remove malloc from EarliestEscapeInfo before removing. (#84157)
* 3f8711fc5e01 [InstCombine] Fix miscompilation in PR83947 (#83993)
* 9b9aee16d4dc [Clang][LoongArch] Fix wrong return value type of __iocsrrd_h (#84100)
* a9ba36c7e7d7 [Clang][LoongArch] Precommit test for fix wrong return value type of __iocsrrd_h. NFC
* d77c5c3830d9 [LoongArch] Make sure that the LoongArchISD::BSTRINS node uses the correct `MSB` value (#84454)
* 1de8ea75d9b3 [analyzer] Fix crash on dereference invalid return value of getAdjustedParameterIndex() (#83585)
* c14bf0a13d42 [libc++] Enable availability based on the compiler instead of __has_extension (#84065)
* 55193c2ba53f [InstCombine] Handle scalable splat in `getFlippedStrictnessPredicateAndConstant`
* 78859f118a6b [lld][LoongArch] Support the R_LARCH_{ADD,SUB}_ULEB128 relocation types (#81133)
* d8352e93c1c8 [Clang] [Sema] Handle placeholders in '.*' expressions (#83103)
* eb9bc02b06cb [RISCV] Fix crash when unrolling loop containing vector instructions (#83384)
* c3721c1dcff5 [ELF] Internalize enum
* c14879562f46 Unbreak *tf builtins for hexfloat (#82208)
* 89d543227a32 [AArch64] Skip over shadow space for ARM64EC entry thunk variadic calls (#80994)
* 42c599ab365b [AArch64] Fix generated types for ARM64EC variadic entry thunk targets (#80595)
* d7a9810f9c14 [AArch64] Fix variadic tail-calls on ARM64EC (#79774)
* ea6c457b8dd2 [LoongArch] Override LoongArchTargetLowering::getExtendForAtomicCmpSwapArg (#83656)
* 69d9b15fe872 [TableGen] Fix wrong codegen of BothFusionPredicateWithMCInstPredicate (#83990)
* a91b9bd9c750 [OpenMP] fix endianness dependent definitions in OMP headers for MSVC (#84540)
* 7cb67530d2e9 ReleaseNotes for LLVM binary utilities (#83751)
* 94d8f150ed8b [InstCombine] Fix infinite loop in select equivalence fold (#84036)
* 4c36ecbe0e16  [InstCombine] Fix shift calculation in InstCombineCasts (#84027)
* e90bfdb4ddce [test] Make two sanitize-coverage tests pass with glibc 2.39+
* bf45c3a07918 [DSE] Delay deleting non-memory-defs until end of DSE. (#83411)
* 16ab0812d201 [clang][fat-lto-objects] Make module flags match non-FatLTO pipelines (#83159)
* 267d9b1a74c4 Allow .alt_entry symbols to pass the .cfi nesting check (#82268)
* 340ba4588c80 MIPS: fix emitDirectiveCpsetup on N32 (#80534)
* 439e6f81e772 [libc++][modules] Fixes naming inconsistency. (#83036)
* 2ad8fbdbca06 Bump version to 18.1.2 (#84655)

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
