### PR TITLE
clang: Upgrade to 18.1.5

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -33,7 +33,7 @@ INHERIT += "clang"
 # Do not include clang in SDK unless user wants to
 CLANGSDK ??= "0"
 
-LLVMVERSION = "18.1.4"
+LLVMVERSION = "18.1.5"
 
 require conf/nonclangable.conf
 require conf/nonscanable.conf

--- a/recipes-devtools/clang/clang.inc
+++ b/recipes-devtools/clang/clang.inc
@@ -6,10 +6,10 @@ LLVM_GIT_PROTOCOL ?= "https"
 
 MAJOR_VER = "18"
 MINOR_VER = "1"
-PATCH_VER = "4"
+PATCH_VER = "5"
 # could be 'rcX' or 'git' or empty ( for release )
 VER_SUFFIX = ""
-SRCREV ?= "e6c3289804a67ea0bb6a86fadbe454dd93b8d855"
+SRCREV ?= "617a15a9eac96088ae5e9134248d8236e34b91b1"
 
 PV = "${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}${VER_SUFFIX}"
 BRANCH = "release/18.x"


### PR DESCRIPTION
Brings

* 617a15a9eac9 [clang codegen] Fix MS ABI detection of user-provided constructors. (#90151)
* 20b9ed64ea07 [RISCV][ISel] Fix types in `tryFoldSelectIntoOp` (#90659)
* ece9d35f1a70 [GlobalISel] Fix store merging incorrectly classifying an unknown index expr as 0. (#90375)
* a7b8b890600a [X86] Enable EVEX512 when host CPU has AVX512 (#90479)
* 4da5b1417493 [GlobalISel] Don't form anyextending atomic loads.
* a96b04442c9f [AArch64] Remove invalid uabdl patterns. (#89272)
* aea091b70eda [clang][CoverageMapping] do not emit a gap region when either end doesn't have valid source locations (#89564)
* 58648f334d62 [X86][EVEX512] Check hasEVEX512 for canExtendTo512DQ (#90390)
* 6350acdb134d  [CGP] Drop poison-generating flags after hoisting (#90382)
* f341c76b9461 [Clang] Handle structs with inner structs and no fields (#89126)
* abf6b13085fb [IRCE] Skip icmp ptr in `InductiveRangeCheck::parseRangeCheckICmp` (#89967)
* ee5bb0c95667 Fix Objective-C++ Sret of non-trivial data types on Windows ARM64 (#88671)
* 6dbaa89433f7 [clang-format] Fix a regression in ContinuationIndenter (#88414)
* 51ff7f38b633 [clang-format] Fix a regression in annotating TrailingReturnArrow (#86624)
* b544217fb31f [AMDGPU] Fix setting nontemporal in memory legalizer (#83815)
* 78b99c73ee4b [DAGCombiner] Fix miscompile bug in combineShiftOfShiftedLogic (#89616)
* 1aa91720cc4f [DAGCombiner] Pre-commit test case for miscompile bug in combineShiftOfShiftedLogic
* 35fea1032741 release/18.x: [clang-format] Correctly annotate braces in macros (#87953)
* b9b73814ad8a [libcxx] [modules] Add _LIBCPP_USING_IF_EXISTS on aligned_alloc (#89827)
* c0b48372d82a release/18.x: [clang-format] Revert breaking stream operators to previous default (#89016)
* 3b4ba7277bd7 [analyzer] Fix performance of getTaintedSymbolsImpl() (#89606)
* 7699b341b763 release/18.x: [clang-format] Fix a regression in annotating BK_BracedInit (#87450)
* fb865928c8e0 [GlobalISel] Fix fewerElementsVectorPhi to insert after G_PHIs (#87927)
* 111ae4509c96 [X86] Fix miscompile in combineShiftRightArithmetic
* 76cbd417af50 [X86] Pre-commit tests (NFC)
* e7c816b3cd3e  [InstCombine] Fix unexpected overwriting in `foldSelectWithSRem` (#89539)
* 3685a599c866 ReleaseNote: Mention SpecialCaseList change (#89141)
* a981a4f7653c [X86] Always use 64-bit relocations in no-PIC large code model (#89101)
* 4ddac856c55f [analyzer] Fix a security.cert.env.InvalidPtr crash
* c6d63d4fc555 Bump version to 18.1.5 (#89291)

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
