### PR TITLE
frame: Use --undefined-version with lld

### DIFF
--- a/conf/nonclangable.conf
+++ b/conf/nonclangable.conf
@@ -613,6 +613,7 @@ LDFLAGS:append:pn-libcgroup:toolchain-clang = "${@bb.utils.contains('DISTRO_FEAT
 LDFLAGS:append:pn-kernel-selftest:toolchain-clang = "${@bb.utils.contains('DISTRO_FEATURES', 'ld-is-lld', ' -Wl,--undefined-version', '', d)}"
 LDFLAGS:append:pn-openldap:toolchain-clang = "${@bb.utils.contains('DISTRO_FEATURES', 'ld-is-lld', ' -Wl,--undefined-version', '', d)}"
 LDFLAGS:append:pn-liburing:toolchain-clang = "${@bb.utils.contains('DISTRO_FEATURES', 'ld-is-lld', ' -Wl,--undefined-version', '', d)}"
+LDFLAGS:append:pn-frame:toolchain-clang = "${@bb.utils.contains('DISTRO_FEATURES', 'ld-is-lld', ' -Wl,--undefined-version', '', d)}"
 # | x86_64-yoe-linux-musl-ld.lld: error: version script assignment of 'global' to symbol 'pam_sm_chauthtok' failed: symbol not defined
 LDFLAGS:append:pn-wtmpdb:toolchain-clang = "${@bb.utils.contains('DISTRO_FEATURES', 'ld-is-lld', ' -Wl,--undefined-version', '', d)}"
 TUNE_CCARGS:remove:pn-kernel-selftest:toolchain-clang = "-mfpmath=sse"


### PR DESCRIPTION
symbol version script adds some X11 symbols which lld complains about since default is to report undefined symbols with lld.

Fixes
| x86_64-yoe-linux-ld.lld: error: version script assignment of 'FRAME_2.2' to symbol 'frame_x11_new' failed: symbol not defined | x86_64-yoe-linux-ld.lld: error: version script assignment of 'FRAME_2.2' to symbol 'frame_x11_delete' failed: symbol not defined | x86_64-yoe-linux-ld.lld: error: version script assignment of 'FRAME_2.2' to symbol 'frame_x11_process_event' failed: symbol not defined | x86_64-yoe-linux-ld.lld: error: version script assignment of 'FRAME_2.2' to symbol 'frame_x11_accept_touch' failed: symbol not defined | x86_64-yoe-linux-ld.lld: error: version script assignment of 'FRAME_2.2' to symbol 'frame_x11_reject_touch' failed: symbol not defined | x86_64-yoe-linux-ld.lld: error: version script assignment of 'FRAME_2.2' to symbol 'frame_x11_get_window_id' failed: symbol not defined | x86_64-yoe-linux-ld.lld: error: version script assignment of 'FRAME_2.2' to symbol 'frame_x11_create_window_id' failed: symbol not defined | x86_64-yoe-linux-ld.lld: error: version script assignment of 'FRAME_2.2' to symbol 'frame_x11_get_touch_id' failed: symbol not defined | x86_64-yoe-linux-ld.lld: error: version script assignment of 'FRAME_2.2' to symbol 'frame_x11_create_touch_id' failed: symbol not defined

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
