### PR TITLE
spirv-llvm-translator: Bump spirv-headers to matching tag

### DIFF
--- a/recipes-devtools/spirv-llvm-translator/spirv-llvm-translator_git.bb
+++ b/recipes-devtools/spirv-llvm-translator/spirv-llvm-translator_git.bb
@@ -8,7 +8,7 @@ SRC_URI = "git://github.com/KhronosGroup/SPIRV-LLVM-Translator;protocol=https;br
 
 PV = "18.1.0"
 SRCREV = "ad99707fd80189dca0ca76ed89946ae383e9a030"
-SRCREV_headers = "d3c2a6fa95ad463ca8044d7fc45557db381a6a64"
+SRCREV_headers = "1c6bb2743599e6eb6f37b2969acc0aef812e32e3"
 
 SRCREV_FORMAT = "default_headers"
 


### PR DESCRIPTION
This brings specifically this commit

Remove dependency on SPIRV-Headers for SPV_INTEL_maximum_registers

Which is needed to fix build errors with bump to 18.1.0

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
