### PR TITLE
spirv-llvm-translator: bump SRCREV to fix the build

### DIFF
--- a/recipes-devtools/spirv-llvm-translator/spirv-llvm-translator_git.bb
+++ b/recipes-devtools/spirv-llvm-translator/spirv-llvm-translator_git.bb
@@ -6,8 +6,8 @@ SRC_URI = "git://github.com/KhronosGroup/SPIRV-LLVM-Translator;protocol=https;br
            git://github.com/KhronosGroup/SPIRV-Headers;protocol=https;destsuffix=git/SPIRV-Headers;name=headers;branch=main \
           "
 
-PV = "18.1.0"
-SRCREV = "ad99707fd80189dca0ca76ed89946ae383e9a030"
+PV = "18.1.0+git"
+SRCREV = "16b2900747a3cc7993eeb39d4a8442b432a3fda0"
 SRCREV_headers = "1c6bb2743599e6eb6f37b2969acc0aef812e32e3"
 
 SRCREV_FORMAT = "default_headers"


### PR DESCRIPTION
* just one extra commit:

  spirv-llvm-translator-native/18.1.0/git $ git log --oneline ad99707fd80189dca0ca76ed89946ae383e9a030..16b2900747a3cc7993eeb39d4a8442b432a3fda0
  16b29007 [LLVM-18] Remove dependency on SPIRV-Headers for SPV_INTEL_maximum_registers (#2434)

* fixes: http://errors.yoctoproject.org/Errors/Build/185272/

  spirv-llvm-translator-native/18.1.0/git/lib/SPIRV/libSPIRV/SPIRVEnum.h:295:17: error: ‘CapabilityRegisterLimitsINTEL’ was not declared in this scope
    295 |                {CapabilityRegisterLimitsINTEL});
        |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~