### PR TITLE
bpftrace: fix CVE-2024-2313.patches via upload

### DIFF
--- a/0001-bpftrace-fix-CVE-2024-2313.patch
+++ b/0001-bpftrace-fix-CVE-2024-2313.patch
@@ -1,0 +1,157 @@
+From f77ff583d0580ad57bb8742edad034b5877b1afe Mon Sep 17 00:00:00 2001
+From: Meenali Gupta <meenali.gupta@windriver.com>
+Date: Thu, 6 Jun 2024 04:37:47 +0000
+Subject: [meta-clang][kirkstone][PATCH 1/1] bpftrace: fix CVE-2024-2313
+
+If kernel headers need to be extracted, bpftrace will attempt to load them from a temporary directory.
+An unprivileged attacker could use this to force bcc to load compromised linux headers.
+Linux distributions which provide kernel headers by default are not affected by default.
+
+References:
+https://nvd.nist.gov/vuln/detail/CVE-2024-2313
+
+Signed-off-by: Meenali Gupta <meenali.gupta@windriver.com>
+---
+ .../bpftrace/bpftrace/CVE-2024-2313.patch     | 117 ++++++++++++++++++
+ .../bpftrace/bpftrace_0.16.0.bb               |   1 +
+ 2 files changed, 118 insertions(+)
+ create mode 100644 dynamic-layers/openembedded-layer/recipes-devtools/bpftrace/bpftrace/CVE-2024-2313.patch
+
+diff --git a/dynamic-layers/openembedded-layer/recipes-devtools/bpftrace/bpftrace/CVE-2024-2313.patch b/dynamic-layers/openembedded-layer/recipes-devtools/bpftrace/bpftrace/CVE-2024-2313.patch
+new file mode 100644
+index 0000000..2129324
+--- /dev/null
++++ b/dynamic-layers/openembedded-layer/recipes-devtools/bpftrace/bpftrace/CVE-2024-2313.patch
+@@ -0,0 +1,117 @@
++From 4be4b7191acb8218240e6b7178c30fa8c9b59998 Mon Sep 17 00:00:00 2001
++From: Jordan Rome <jordalgo@meta.com>
++Date: Wed, 6 Mar 2024 13:59:05 -0500
++Subject: [PATCH] Fix security hole checking unpacked kernel headers (#3033)
++Make sure to check that the unpacked kheaders tar is owned by root to prevent
++bpftrace from loading compromised linux headers.
++
++Co-authored-by: Jordan Rome <jordalgo@fedoraproject.org>
++
++CVE:CVE-2024-2313
++Upstream-Status: Backport [https://github.com/bpftrace/bpftrace/commit/4be4b7191acb8218240e6b7178c30fa8c9b59998]
++
++Signed-off-by: Meenali Gupta <meenali.gupta@windriver.com>
++---
++ src/utils.cpp   | 21 ++++++++++++++++++---
++ src/utils.h     |  1 +
++ tests/utils.cpp | 21 +++++++++++++++++++++
++ 3 files changed, 40 insertions(+), 3 deletions(-)
++
++diff --git a/src/utils.cpp b/src/utils.cpp
++index f54c99e5..7fde8c31 100644
++--- a/src/utils.cpp
+++++ b/src/utils.cpp
++@@ -112,6 +112,8 @@ const struct vmlinux_location vmlinux_locs[] = {
++   { nullptr, false },
++ };
++
+++constexpr std::string_view PROC_KHEADERS_PATH = "/sys/kernel/kheaders.tar.xz";
+++
++ static bool pid_in_different_mountns(int pid);
++ static std::vector<std::string>
++ resolve_binary_path(const std::string &cmd, const char *env_paths, int pid);
++@@ -510,6 +512,20 @@ bool is_dir(const std::string& path)
++   return std_filesystem::is_directory(buf, ec);
++ }
++
+++bool file_exists_and_ownedby_root(const char *f)
+++{
+++  struct stat st;
+++  if (stat(f, &st) == 0) {
+++    if (st.st_uid != 0) {
+++      LOG(ERROR) << "header file ownership expected to be root: "
+++                 << std::string(f);
+++      return false;
+++    }
+++    return true;
+++  }
+++  return false;
+++}
+++
++ namespace {
++   struct KernelHeaderTmpDir {
++     KernelHeaderTmpDir(const std::string& prefix) : path{prefix + "XXXXXX"}
++@@ -542,15 +558,14 @@ namespace {
++   {
++     std::error_code ec;
++     std_filesystem::path path_prefix{ "/tmp" };
++-    std_filesystem::path path_kheaders{ "/sys/kernel/kheaders.tar.xz" };
+++    std_filesystem::path path_kheaders{ PROC_KHEADERS_PATH };
++     if (const char* tmpdir = ::getenv("TMPDIR")) {
++       path_prefix = tmpdir;
++     }
++     path_prefix /= "kheaders-";
++     std_filesystem::path shared_path{ path_prefix.string() + utsname.release };
++
++-    if (std_filesystem::exists(shared_path, ec))
++-    {
+++    if (file_exists_and_ownedby_root(shared_path.c_str())) {
++       // already unpacked
++       return shared_path.string();
++     }
++diff --git a/src/utils.h b/src/utils.h
++index 9b96be9f..e1a5cf7d 100644
++--- a/src/utils.h
+++++ b/src/utils.h
++@@ -155,6 +155,7 @@ std::vector<std::string> get_wildcard_tokens(const std::string &input,
++                                              bool &end_wildcard);
++ std::vector<int> get_online_cpus();
++ std::vector<int> get_possible_cpus();
+++bool file_exists_and_ownedby_root(const char *f);
++ bool is_dir(const std::string &path);
++ std::tuple<std::string, std::string> get_kernel_dirs(
++     const struct utsname &utsname,
++diff --git a/tests/utils.cpp b/tests/utils.cpp
++index 9ca4ace5..dc71afa9 100644
++--- a/tests/utils.cpp
+++++ b/tests/utils.cpp
++@@ -222,6 +222,27 @@ TEST(utils, get_cgroup_path_in_hierarchy)
++   }
++ }
++
+++EST(utils, file_exists_and_ownedby_root)
+++{
+++  std::string tmpdir = "/tmp/bpftrace-test-utils-XXXXXX";
+++  std::string file1 = "/ownedby-user";
+++  std::string file2 = "/no-exists";
+++  if (::mkdtemp(tmpdir.data()) == nullptr) {
+++    throw std::runtime_error("creating temporary path for tests failed");
+++  }
+++
+++  int fd;
+++  fd = open((tmpdir + file1).c_str(), O_CREAT, S_IRUSR);
+++  close(fd);
+++  ASSERT_GE(fd, 0);
+++
+++  EXPECT_FALSE(file_exists_and_ownedby_root((tmpdir + file1).c_str()));
+++  EXPECT_FALSE(file_exists_and_ownedby_root((tmpdir + file2).c_str()));
+++  EXPECT_TRUE(file_exists_and_ownedby_root("/proc/1/maps"));
+++
+++  EXPECT_GT(std_filesystem::remove_all(tmpdir), 0);
+++}
+++
++ } // namespace utils
++ } // namespace test
++ } // namespace bpftrace
++--
++2.40.0
+diff --git a/dynamic-layers/openembedded-layer/recipes-devtools/bpftrace/bpftrace_0.16.0.bb b/dynamic-layers/openembedded-layer/recipes-devtools/bpftrace/bpftrace_0.16.0.bb
+index 2c03ad3..ef4a1a8 100644
+--- a/dynamic-layers/openembedded-layer/recipes-devtools/bpftrace/bpftrace_0.16.0.bb
++++ b/dynamic-layers/openembedded-layer/recipes-devtools/bpftrace/bpftrace_0.16.0.bb
+@@ -23,6 +23,7 @@ SRC_URI = "git://github.com/iovisor/bpftrace;branch=master;protocol=https \
+            file://0001-replace-python-with-python3-in-the-test.patch \
+            file://0001-tools-undump-rely-on-BTF-instead-of-header-files.patch \
+            file://0001-tcpdrop-Fix-ERROR-Error-attaching-probe-kprobe-tcp_d.patch \
++           file://CVE-2024-2313.patch \
+ "
+ SRCREV = "a277ec42102c463d656df8f64eb2f7e87e322210"
+ 
+-- 
+2.40.0
+


### PR DESCRIPTION
If kernel headers need to be extracted, bpftrace will attempt to load them from a temporary directory. An unprivileged attacker could use this to force bcc to load compromised linux headers. Linux distributions which provide kernel headers by default are not affected by default.
