### PR TITLE
clang: Disable unused-command-line-argument warning for debug builds

### DIFF
--- a/recipes-devtools/clang/clang_git.bb
+++ b/recipes-devtools/clang/clang_git.bb
@@ -15,6 +15,9 @@ BUILD_CXX:class-nativesdk = "clang++"
 BUILD_AR:class-nativesdk = "llvm-ar"
 BUILD_RANLIB:class-nativesdk = "llvm-ranlib"
 BUILD_NM:class-nativesdk = "llvm-nm"
+
+BUILDSDK_CPPFLAGS:append:class-nativesdk = "${@oe.utils.vartrue('DEBUG_BUILD', ' -Wno-error=unused-command-line-argument', '', d)}"
+
 LDFLAGS:remove:class-nativesdk = "-fuse-ld=lld"
 
 LDFLAGS:append:class-target:riscv32 = " -Wl,--no-as-needed -latomic -Wl,--as-needed"


### PR DESCRIPTION
This ensures that nativesdk compiler can be built when DEBUG_BUILD = "1"

Fixes https://github.com/kraj/meta-clang/issues/932

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
