### PR TITLE
clang: Upgrade to 18.1.8

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -33,7 +33,7 @@ INHERIT += "clang"
 # Do not include clang in SDK unless user wants to
 CLANGSDK ??= "0"
 
-LLVMVERSION = "18.1.7"
+LLVMVERSION = "18.1.8"
 
 require conf/nonclangable.conf
 require conf/nonscanable.conf

--- a/recipes-devtools/clang/clang.inc
+++ b/recipes-devtools/clang/clang.inc
@@ -5,7 +5,7 @@ LLVM_HTTP ?= "https://github.com/llvm"
 
 MAJOR_VER = "18"
 MINOR_VER = "1"
-PATCH_VER = "7"
+PATCH_VER = "8"
 # could be 'rcX' or 'git' or empty ( for release )
 VER_SUFFIX = ""
 

--- a/recipes-devtools/clang/common.inc
+++ b/recipes-devtools/clang/common.inc
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://llvm/LICENSE.TXT;md5=${LLVMMD5SUM} \
 LICENSE = "Apache-2.0-with-LLVM-exception"
 
 BASEURI = "${LLVM_HTTP}/llvm-project/releases/download/llvmorg-${PV}/llvm-project-${PV}.src.tar.xz"
-SRC_URI[sha256sum] = "74446ab6943f686391954cbda0d77ae92e8a60c432eff437b8666e121d748ec4"
+SRC_URI[sha256sum] = "0b58557a6d32ceee97c8d533a59b9212d87e0fc4d2833924eb6c611247db2f2a"
 
 SRC_URI = "\
     ${BASEURI} \


### PR DESCRIPTION
Brings
* 3b5b5c1ec4a3 [libcxx] Align `__recommend() + 1`  by __endian_factor (#90292)
* 72c9425a79fd [libc++][NFC] Rewrite function call on two lines for clarity (#79141)
* 443e23eed24d Bump version to 18.1.8 (#95458)

Release announcement [1]
[1] https://discourse.llvm.org/t/18-1-8-released/79725/1

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
