### PR TITLE
clang: Package docs related to clang-doc tool

### DIFF
--- a/recipes-devtools/clang/clang_git.bb
+++ b/recipes-devtools/clang/clang_git.bb
@@ -403,6 +403,7 @@ FILES:${PN}-dev += "\
   ${nonarch_libdir}/libear \
   ${nonarch_libdir}/${BPN}/*.la \
 "
+FILES:${PN}-doc += "${datadir}/clang-doc"
 
 FILES:${PN}-staticdev += "${nonarch_libdir}/${BPN}/*.a"
 


### PR DESCRIPTION
Fixes
ERROR: clang-19.0.0-r0 do_package: QA Issue: clang: Files/directories were installed but not shipped in any package:
  /usr/share/clang-doc
  /usr/share/clang-doc/clang-doc-default-stylesheet.css
  /usr/share/clang-doc/index.js

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
