### PR TITLE
python-bcrypt: Do not use lld when building with ptests on.

### DIFF
--- a/conf/nonclangable.conf
+++ b/conf/nonclangable.conf
@@ -635,5 +635,6 @@ LDFLAGS:remove:pn-aufs-util:toolchain-clang = "${@bb.utils.contains('DISTRO_FEAT
 # | arm-yoe-linux-gnueabi-ld.lld: error: version script assignment of 'global' to symbol 'pam_sm_chauthtok' failed: symbol not defined
 LDFLAGS:append:pn-lastlog2:toolchain-clang = "${@bb.utils.contains('DISTRO_FEATURES', 'ld-is-lld', ' -fuse-ld=bfd', '', d)}"
 LDFLAGS:remove:pn-lastlog2:toolchain-clang = "${@bb.utils.contains('DISTRO_FEATURES', 'ld-is-lld', '-fuse-ld=lld', '', d)}"
+LDFLAGS:remove:pn-python3-bcrypt:toolchain-clang = "${@bb.utils.contains('DISTRO_FEATURES', 'ld-is-lld ptest', '-fuse-ld=lld', '', d)}"
 
 LD:pn-gnu-efi:toolchain-clang = "${@bb.utils.contains('DISTRO_FEATURES', 'ld-is-lld', '${HOST_PREFIX}ld.bfd${TOOLCHAIN_OPTIONS} ${HOST_LD_ARCH}', '${HOST_PREFIX}ld${TOOLCHAIN_OPTIONS} ${HOST_LD_ARCH}', d)}"


### PR DESCRIPTION
Somehow linker/lld here fails to link ptests with cargo, therefore workaround it by disabling lld when ptest feature is on.

Fixes errors like
note: riscv64-yoe-linux-ld.lld: error: undefined symbol: PyExc_ValueError\nreferenced by bcrypt_rust.a93ef5fbf090e743-cgu.0

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
