### PR TITLE
kirkstone[backport] libcxx: Do not induce -mbranch-protection externally on arm64

### DIFF
--- a/recipes-devtools/clang/libcxx_git.bb
+++ b/recipes-devtools/clang/libcxx_git.bb
@@ -41,6 +41,7 @@ BUILD_CXXFLAGS += "-stdlib=libstdc++"
 BUILD_LDFLAGS += "-unwindlib=libgcc -rtlib=libgcc -stdlib=libstdc++"
 BUILD_CPPFLAGS:remove = "-stdlib=libc++"
 BUILD_LDFLAGS:remove = "-stdlib=libc++ -lc++abi"
+TUNE_CCARGS:remove = "-mbranch-protection=standard"
 
 INHIBIT_DEFAULT_DEPS = "1"
 


### PR DESCRIPTION
Backport https://github.com/kraj/meta-clang/pull/968

On arm64 OE-Core has moved the gcc default configuration done with --enable-standard-branch-protection to be a CFLAGS option which is appended to CC variable, this means that this option can override the package's default to not use it e.g. libunwind where the library has to be built without it.

Fixes https://github.com/kraj/meta-clang/issues/963

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
