### PR TITLE
bluez5: Use BFD linker

### DIFF
--- a/conf/nonclangable.conf
+++ b/conf/nonclangable.conf
@@ -510,7 +510,6 @@ LDFLAGS:append:pn-libgcrypt:toolchain-clang = "${@bb.utils.contains('DISTRO_FEAT
 LDFLAGS:append:pn-libxml2:toolchain-clang = "${@bb.utils.contains('DISTRO_FEATURES', 'ld-is-lld', ' -Wl,--undefined-version', '', d)}"
 LDFLAGS:append:pn-binutils:toolchain-clang = "${@bb.utils.contains('DISTRO_FEATURES', 'ld-is-lld', ' -Wl,--undefined-version', '', d)}"
 LDFLAGS:append:pn-libnss-mdns:toolchain-clang = "${@bb.utils.contains('DISTRO_FEATURES', 'ld-is-lld', ' -Wl,--undefined-version', '', d)}"
-LDFLAGS:append:pn-bluez5:toolchain-clang = "${@bb.utils.contains('DISTRO_FEATURES', 'ld-is-lld', ' -Wl,--undefined-version', '', d)}"
 LDFLAGS:append:pn-pulseaudio:toolchain-clang = "${@bb.utils.contains('DISTRO_FEATURES', 'ld-is-lld', ' -Wl,--undefined-version', '', d)}"
 LDFLAGS:append:pn-mesa:toolchain-clang = "${@bb.utils.contains('DISTRO_FEATURES', 'ld-is-lld', ' -Wl,--undefined-version', '', d)}"
 LDFLAGS:append:pn-mesa-gl:toolchain-clang = "${@bb.utils.contains('DISTRO_FEATURES', 'ld-is-lld', ' -Wl,--undefined-version', '', d)}"
@@ -636,5 +635,7 @@ LDFLAGS:remove:pn-aufs-util:toolchain-clang = "${@bb.utils.contains('DISTRO_FEAT
 LDFLAGS:append:pn-lastlog2:toolchain-clang = "${@bb.utils.contains('DISTRO_FEATURES', 'ld-is-lld', ' -fuse-ld=bfd', '', d)}"
 LDFLAGS:remove:pn-lastlog2:toolchain-clang = "${@bb.utils.contains('DISTRO_FEATURES', 'ld-is-lld', '-fuse-ld=lld', '', d)}"
 LDFLAGS:remove:pn-python3-bcrypt:toolchain-clang = "${@bb.utils.contains('DISTRO_FEATURES', 'ld-is-lld ptest', '-fuse-ld=lld', '', d)}"
+LDFLAGS:remove:pn-bluez5:toolchain-clang = "${@bb.utils.contains('DISTRO_FEATURES', 'ld-is-lld', '-fuse-ld=lld', '', d)}"
+LDFLAGS:append:pn-bluez5:toolchain-clang = "${@bb.utils.contains('DISTRO_FEATURES', 'ld-is-lld', ' -fuse-ld=bfd', '', d)}"
 
 LD:pn-gnu-efi:toolchain-clang = "${@bb.utils.contains('DISTRO_FEATURES', 'ld-is-lld', '${HOST_PREFIX}ld.bfd${TOOLCHAIN_OPTIONS} ${HOST_LD_ARCH}', '${HOST_PREFIX}ld${TOOLCHAIN_OPTIONS} ${HOST_LD_ARCH}', d)}"


### PR DESCRIPTION
Some ptests do not build with LLD on RISCV64

| riscv64-yoe-linux-ld: error: undefined symbol: __stop___debug | >>> referenced by log.c:168 (/usr/src/debug/bluez5/5.76/../bluez-5.76/src/log.c:168)
| >>>               src/log.o:(__btd_log_init)
|
| riscv64-yoe-linux-ld: error: undefined symbol: __start___debug
| >>> referenced by log.c:168 (/usr/src/debug/bluez5/5.76/../bluez-5.76/src/log.c:168)
| >>>               src/log.o:(__btd_log_init)
| >>> the encapsulation symbol needs to be retained under --gc-sections properly; consider -z nostart-stop-gc (see https://lld.llvm.org/ELF/start-stop-gc)

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
