### PR TITLE
Fix the build of bpftrace ptest failed

### DIFF
--- a/recipes-devtools/llvm/llvm_%.bbappend
+++ b/recipes-devtools/llvm/llvm_%.bbappend
@@ -1,0 +1,1 @@
+PACKAGECONFIG:append:class-native = " ${@bb.utils.contains('PTEST_ENABLED', '1', 'libllvm', '', d)}"


### PR DESCRIPTION
…t failed

Due to commit [1][2], llvm-native was added to bpftrace to provide llvm-objcopy for the ptest.

But because of commit [3], llvm-native requires opengl in DISTRO_FEATURES to support libllvm.

In order to make the build of bpftrace ptest work, explicitly add libllvm to PACKAGECONFIG for llvm-native if ptest enabled.

According to [2][3], bpftrace used llvm-objcopy to generate BTF data for unit tests, regardless opengl in DISTRO_FEATURES, enable accelerated software renderer or not does not have side effect on bpftrace

[1] https://github.com/kraj/meta-clang/commit/bf6c02a47fb2ffec735df6c7dd642432f3681337
[2] https://github.com/bpftrace/bpftrace/commit/6cc531e35cd3bf77aa2a30cef3e3481c9c53042e
[3] https://git.openembedded.org/openembedded-core/commit/?id=ec22bfa67f6f1766102501d4593ce29aafe8c166

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
