### PR TITLE
qt6/qtbase: Always use lld linker with clang

### DIFF
--- a/dynamic-layers/qt6-layer/recpes-qt/qt6/qtbase_%.bbappend
+++ b/dynamic-layers/qt6-layer/recpes-qt/qt6/qtbase_%.bbappend
@@ -1,0 +1,1 @@
+PACKAGECONFIG:append:toolchain-clang = " use-lld-linker"


### PR DESCRIPTION
chromium has certain options e.g. -Wl,-mllvm,xxx
assumed when compiler chosen is clang. These options are not understood by GNU linker, therefore force
using LLD when clang toolchain is used to compile
QT6 components.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
