### PR TITLE
include-what-you-use: new recipe

### DIFF
--- a/recipes-devtools/include-what-you-use/include-what-you-use_0.22.bb
+++ b/recipes-devtools/include-what-you-use/include-what-you-use_0.22.bb
@@ -1,0 +1,22 @@
+SUMMARY = "Include What You Use (IWYU) - Clang based checker for C/C++ header includes"
+DESCRIPTION = "For every symbol (type, function, variable, or macro) that you \
+               use in foo.cc (or foo.cpp), either foo.cc or foo.h should \
+               include a .h file that exports the declaration of that symbol."
+HOMEPAGE = "https://include-what-you-use.org"
+BUGTRACKER = "https://github.com/include-what-you-use/include-what-you-use/issues"
+LICENSE = "NCSA"
+LIC_FILES_CHKSUM = "file://LICENSE.TXT;md5=59d01ad98720f3c50d6a8a0ef3108c88 \
+                    file://iwyu-check-license-header.py;md5=7bdb749831163fbe9232b3cb7186116f"
+
+DEPENDS = "clang"
+
+SRC_URI = "git://github.com/include-what-you-use/include-what-you-use.git;protocol=https;branch=clang_18"
+SRCREV = "377eaef70cdda47368939f4d9beabfabe3f628f0"
+
+S = "${WORKDIR}/git"
+
+inherit cmake python3native
+
+FILES:${PN} += "${datadir}/${BPN}"
+
+BBCLASSEXTEND = "nativesdk"


### PR DESCRIPTION
Clang based checker for C/C++ header includes. "Experimental software, as of June 2024.", but definitely very useful.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
