### PR TITLE
clang: improve reproducibility

### DIFF
--- a/recipes-devtools/clang/clang_git.bb
+++ b/recipes-devtools/clang/clang_git.bb
@@ -203,12 +203,21 @@ RRECOMMENDS:${PN} = "binutils"
 RRECOMMENDS:${PN}:append:class-target = " libcxx-dev"
 
 # patch out build host paths for reproducibility
-do_compile:prepend:class-target() {
-    sed -i -e "s,${STAGING_DIR_NATIVE},,g" \
-        -e "s,${STAGING_DIR_TARGET},,g" \
-        -e "s,${S},,g"  \
+reproducible_build_variables() {
+    sed -i -e "s,${DEBUG_PREFIX_MAP},,g" \
+        -e "s,--sysroot=${RECIPE_SYSROOT},,g" \
+        -e "s,${STAGING_DIR_HOST},,g" \
+        -e "s,${S}/llvm,,g"  \
         -e "s,${B},,g" \
         ${B}/tools/llvm-config/BuildVariables.inc
+}
+
+do_configure:append:class-target() {
+    reproducible_build_variables
+}
+
+do_configure:append:class-nativesdk() {
+    reproducible_build_variables
 }
 
 do_install:append() {
@@ -276,6 +285,9 @@ do_install:append:class-nativesdk () {
     ln -sf llvm-config ${D}${bindir}/llvm-config${PV}
     rm -rf ${D}${datadir}/llvm/cmake
     rm -rf ${D}${datadir}/llvm
+
+    #reproducibility
+    sed -i -e 's,${B},,g' ${D}${libdir}/cmake/llvm/LLVMConfig.cmake
 }
 
 PACKAGES =+ "${PN}-libllvm ${PN}-lldb-python ${PN}-libclang-cpp ${PN}-tidy ${PN}-format ${PN}-tools \


### PR DESCRIPTION
Currently, class-target is reproducible, but class-nativesdk is not. What I did:

- noticed that BuildVariables.inc contains meaningless path fragments after running sed, so I adjusted sed commands to remove the rest of paths as well;
- moved common code into a function, which is then called twice;
- changed do_compile:prepend into do_configure:append, this is more conventional and intuitive;
- verified that the resulting code works for both target and nativesdk after these changes.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
