### PR TITLE
Add back older clang versions: 15 and 16 (nanbield)

### DIFF
--- a/classes/clang15-native.bbclass
+++ b/classes/clang15-native.bbclass
@@ -1,0 +1,23 @@
+# inherit this class if you would like to use clang 15 to compile the native
+# version of your recipes instead of system compiler ( which is normally gcc )
+# on build machines
+# to use it add
+#
+# inherit clang15-native
+#
+# to the concerned recipe via a bbappend or directly to recipe file
+#
+DEPENDS:append:runtime-llvm = " clang15-native compiler-rt15-native libcxx15-initial-native"
+# Use libcxx headers for native parts
+CXXFLAGS:append:runtime-llvm = " -stdlib=libc++"
+BUILD_CXXFLAGS:append:runtime-llvm = " -isysroot=${STAGING_DIR_NATIVE} -stdlib=libc++"
+# Use libgcc for native parts
+LDFLAGS:append:runtime-llvm = " -stdlib=libc++ -rtlib=libgcc -unwindlib=libgcc"
+BUILD_LDFLAGS:append:runtime-llvm = " -stdlib=libc++ -rtlib=libgcc -unwindlib=libgcc"
+BUILD_CC:runtime-llvm  = "${CCACHE}clang -isysroot=${STAGING_DIR_NATIVE}"
+BUILD_CXX:runtime-llvm = "${CCACHE}clang++ -isysroot=${STAGING_DIR_NATIVE}"
+BUILD_CPP:runtime-llvm = "${CCACHE}clang -isysroot=${STAGING_DIR_NATIVE} -E"
+BUILD_CCLD:runtime-llvm = "${CCACHE}clang"
+BUILD_RANLIB:runtime-llvm = "llvm-ranlib"
+BUILD_AR:runtime-llvm = "llvm-ar"
+BUILD_NM:runtime-llvm = "llvm-nm"

--- a/classes/clang15.bbclass
+++ b/classes/clang15.bbclass
@@ -1,0 +1,159 @@
+# Add the necessary override
+CCACHE_COMPILERCHECK:toolchain-clang15 ?= "%compiler% -v"
+HOST_CC_ARCH:prepend:toolchain-clang15 = "-target ${HOST_SYS} "
+CC:toolchain-clang15  = "${CCACHE}${HOST_PREFIX}clang ${HOST_CC_ARCH}${TOOLCHAIN_OPTIONS}"
+CXX:toolchain-clang15 = "${CCACHE}${HOST_PREFIX}clang++ ${HOST_CC_ARCH}${TOOLCHAIN_OPTIONS}"
+CPP:toolchain-clang15 = "${CCACHE}${HOST_PREFIX}clang ${HOST_CC_ARCH}${TOOLCHAIN_OPTIONS} -E"
+CCLD:toolchain-clang15 = "${CCACHE}${HOST_PREFIX}clang ${HOST_CC_ARCH}${TOOLCHAIN_OPTIONS}"
+RANLIB:toolchain-clang15 = "${HOST_PREFIX}llvm-ranlib"
+AR:toolchain-clang15 = "${HOST_PREFIX}llvm-ar"
+NM:toolchain-clang15 = "${HOST_PREFIX}llvm-nm"
+OBJDUMP:toolchain-clang15 = "${HOST_PREFIX}llvm-objdump"
+OBJCOPY:toolchain-clang15 = "${HOST_PREFIX}llvm-objcopy"
+STRIP:riscv64:toolchain-clang15 = "${HOST_PREFIX}llvm-strip"
+STRIP:riscv32:toolchain-clang15 = "${HOST_PREFIX}llvm-strip"
+STRINGS:toolchain-clang15 = "${HOST_PREFIX}llvm-strings"
+READELF:toolchain-clang15 = "${HOST_PREFIX}llvm-readelf"
+
+LTO:toolchain-clang15 = "${@bb.utils.contains('DISTRO_FEATURES', 'thin-lto', '-flto=thin', '-flto -fuse-ld=lld', d)}"
+
+COMPILER_RT ??= ""
+COMPILER_RT:class-native = "-rtlib=libgcc ${UNWINDLIB}"
+COMPILER_RT:armeb = "-rtlib=libgcc ${UNWINDLIB}"
+COMPILER_RT:libc-klibc = "-rtlib=libgcc ${UNWINDLIB}"
+
+UNWINDLIB ??= ""
+UNWINDLIB:class-native = "--unwindlib=libgcc"
+UNWINDLIB:armeb = "--unwindlib=libgcc"
+UNWINDLIB_libc-klibc = "--unwindlib=libgcc"
+
+LIBCPLUSPLUS ??= ""
+LIBCPLUSPLUS:armv5 = "-stdlib=libstdc++"
+
+CXXFLAGS:append:toolchain-clang15 = " ${LIBCPLUSPLUS}"
+LDFLAGS:append:toolchain-clang15 = " ${COMPILER_RT} ${LIBCPLUSPLUS}"
+
+TUNE_CCARGS:remove:toolchain-clang15 = "-meb"
+TUNE_CCARGS:remove:toolchain-clang15 = "-mel"
+TUNE_CCARGS:append:toolchain-clang15 = "${@bb.utils.contains("TUNE_FEATURES", "bigendian", " -mbig-endian", " -mlittle-endian", d)}"
+
+# Clang does not yet support big.LITTLE performance tunes, so use the LITTLE for tunes
+TUNE_CCARGS:remove:toolchain-clang15 = "-mcpu=cortex-a57.cortex-a53 -mcpu=cortex-a72.cortex-a53 -mcpu=cortex-a15.cortex-a7 -mcpu=cortex-a17.cortex-a7 -mcpu=cortex-a72.cortex-a35 -mcpu=cortex-a73.cortex-a53 -mcpu=cortex-a75.cortex-a55 -mcpu=cortex-a76.cortex-a55"
+TUNE_CCARGS:append:toolchain-clang15 = "${@bb.utils.contains_any("TUNE_FEATURES", "cortexa72-cortexa53 cortexa57-cortexa53 cortexa73-cortexa53", " -mcpu=cortex-a53", "", d)}"
+TUNE_CCARGS:append:toolchain-clang15 = "${@bb.utils.contains_any("TUNE_FEATURES", "cortexa15-cortexa7 cortexa17-cortexa7", " -mcpu=cortex-a7", "", d)}"
+TUNE_CCARGS:append:toolchain-clang15 = "${@bb.utils.contains_any("TUNE_FEATURES", "cortexa72-cortexa35", " -mcpu=cortex-a35", "", d)}"
+TUNE_CCARGS:append:toolchain-clang15 = "${@bb.utils.contains_any("TUNE_FEATURES", "cortexa75-cortexa55 cortexa76-cortexa55", " -mcpu=cortex-a55", "", d)}"
+
+# Clang does not support octeontx2 processor
+TUNE_CCARGS:remove:toolchain-clang15 = "-mcpu=octeontx2"
+
+# Reconcile some ppc anamolies
+TUNE_CCARGS:remove:toolchain-clang15:powerpc = "-mhard-float -mno-spe"
+TUNE_CCARGS:append:toolchain-clang15:libc-musl:powerpc64 = " -mlong-double-64"
+TUNE_CCARGS:append:toolchain-clang15:libc-musl:powerpc64le = " -mlong-double-64"
+TUNE_CCARGS:append:toolchain-clang15:libc-musl:powerpc = " -mlong-double-64"
+# usrmerge workaround
+TUNE_CCARGS:append:toolchain-clang15 = "${@bb.utils.contains("DISTRO_FEATURES", "usrmerge", " --dyld-prefix=/usr", "", d)}"
+
+TUNE_CCARGS:append:toolchain-clang15 = " -Qunused-arguments"
+
+LDFLAGS:append:toolchain-clang15:class-nativesdk:x86-64 = " -Wl,-dynamic-linker,${base_libdir}/ld-linux-x86-64.so.2"
+LDFLAGS:append:toolchain-clang15:class-nativesdk:x86 = " -Wl,-dynamic-linker,${base_libdir}/ld-linux.so.2"
+LDFLAGS:append:toolchain-clang15:class-nativesdk:aarch64 = " -Wl,-dynamic-linker,${base_libdir}/ld-linux-aarch64.so.1"
+
+LDFLAGS:toolchain-clang15:class-nativesdk = "${BUILDSDK_LDFLAGS} \
+                                           -Wl,-rpath-link,${STAGING_LIBDIR}/.. \
+                                           -Wl,-rpath,${libdir}/.. "
+
+# Enable lld globally"
+LDFLAGS:append:toolchain-clang15 = "${@bb.utils.contains('DISTRO_FEATURES', 'ld-is-lld', ' -fuse-ld=lld', '', d)}"
+
+# Remove gcc specific -fcanon-prefix-map option, added in gcc-13+
+# clang does not support it yet
+DEBUG_PREFIX_MAP:remove:toolchain-clang15 = "-fcanon-prefix-map"
+
+# choose between 'gcc' 'clang' an empty '' can be used as well
+TOOLCHAIN ??= "gcc"
+# choose between 'gnu' 'llvm'
+TC_CXX_RUNTIME ??= "gnu"
+# Using gcc or llvm runtime is only available when using clang for compiler
+#TC_CXX_RUNTIME:toolchain-gcc = "gnu"
+TC_CXX_RUNTIME:armeb = "gnu"
+TC_CXX_RUNTIME:armv5 = "gnu"
+
+TOOLCHAIN:class-native = "gcc"
+TOOLCHAIN:class-nativesdk = "gcc"
+TOOLCHAIN:class-cross-canadian = "gcc"
+TOOLCHAIN:class-crosssdk = "gcc"
+TOOLCHAIN:class-cross = "gcc"
+
+OVERRIDES =. "${@['', 'toolchain-${TOOLCHAIN}:']['${TOOLCHAIN}' != '']}"
+OVERRIDES =. "${@['', 'runtime-${TC_CXX_RUNTIME}:']['${TC_CXX_RUNTIME}' != '']}"
+OVERRIDES[vardepsexclude] += "TOOLCHAIN TC_CXX_RUNTIME"
+
+YOCTO_ALTERNATE_EXE_PATH:toolchain-clang15:class-target = "${STAGING_BINDIR}/llvm-config"
+YOCTO_ALTERNATE_LIBDIR:toolchain-clang15:class-target = "/${BASELIB}"
+
+#YOCTO_ALTERNATE_EXE_PATH:toolchain-clang15:class-target[export] = "1"
+#YOCTO_ALTERNATE_LIBDIR:toolchain-clang15:class-target[export] = "1"
+
+#DEPENDS:append:toolchain-clang15:class-target = " clang15-cross-${TARGET_ARCH} "
+#DEPENDS:remove:toolchain-clang15:allarch = "clang15-cross-${TARGET_ARCH}"
+
+def clang_base_deps(d):
+    if not d.getVar('INHIBIT_DEFAULT_DEPS', False):
+        if not oe.utils.inherits(d, 'allarch') :
+            ret = " ${MLPREFIX}clang15-cross-${TARGET_ARCH} virtual/libc "
+            if (d.getVar('TC_CXX_RUNTIME').find('android') != -1):
+                ret += " libcxx15-initial"
+                return ret
+            if (d.getVar('TC_CXX_RUNTIME').find('llvm') != -1):
+                ret += " compiler-rt15"
+            elif (d.getVar('COMPILER_RT').find('-rtlib=compiler-rt') != -1):
+                ret += " compiler-rt15 "
+            else:
+                ret += " libgcc "
+            if (d.getVar('TC_CXX_RUNTIME').find('llvm') != -1):
+                ret += " libcxx15-initial"
+            elif (d.getVar('COMPILER_RT').find('--unwindlib=libunwind') != -1):
+                ret += " libcxx15-initial "
+            elif (d.getVar('LIBCPLUSPLUS').find('-stdlib=libc++') != -1):
+                ret += " libcxx15-initial "
+            else:
+                ret += " virtual/${TARGET_PREFIX}compilerlibs "
+            return ret
+    return ""
+
+BASE_DEFAULT_DEPS:toolchain-clang15:class-target = "${@clang_base_deps(d)}"
+BASE_DEFAULT_DEPS:append:class-native:toolchain-clang15:runtime-llvm = " libcxx15-initial-native compiler-rt15-native"
+BASE_DEFAULT_DEPS:append:class-nativesdk:toolchain-clang15:runtime-llvm = " clang15-native nativesdk-libcxx15-initial nativesdk-compiler-rt15"
+
+# do_populate_sysroot needs STRIP
+POPULATESYSROOTDEPS:toolchain-clang15:class-target = "${MLPREFIX}clang15-cross-${TARGET_ARCH}:do_populate_sysroot"
+
+cmake_do_generate_toolchain_file:append:toolchain-clang15 () {
+    cat >> ${WORKDIR}/toolchain.cmake <<EOF
+set( CMAKE_CLANG_TIDY ${HOST_PREFIX}clang-tidy )
+EOF
+    sed -i 's/ -mmusl / /g' ${WORKDIR}/toolchain.cmake
+}
+
+RECIPESYSROOTFUNCS = ""
+RECIPESYSROOTFUNCS:toolchain-clang15 = "recipe_sysroot_check_ld_is_lld"
+
+recipe_sysroot_check_ld_is_lld () {
+    if ${@bb.utils.contains('DISTRO_FEATURES', 'ld-is-lld', 'true', 'false', d)} &&  \
+        [ -e ${STAGING_BINDIR_TOOLCHAIN}/${TARGET_PREFIX}ld.lld ]; then
+        ln -srf ${STAGING_BINDIR_TOOLCHAIN}/${TARGET_PREFIX}ld.lld ${STAGING_BINDIR_TOOLCHAIN}/${TARGET_PREFIX}ld
+    fi
+}
+do_prepare_recipe_sysroot[postfuncs] += "${RECIPESYSROOTFUNCS}"
+#
+# dump recipes which still use gcc
+#python __anonymous() {
+#    toolchain = d.getVar("TOOLCHAIN")
+#    if not toolchain or toolchain == "clang" or 'class-target' not in d.getVar('OVERRIDES').split(':'):
+#        return
+#    pkgn = d.getVar("PN")
+#    bb.warn("%s - %s" % (pkgn, toolchain))
+#}

--- a/classes/clang16-native.bbclass
+++ b/classes/clang16-native.bbclass
@@ -1,0 +1,23 @@
+# inherit this class if you would like to use clang 16 to compile the native
+# version of your recipes instead of system compiler ( which is normally gcc )
+# on build machines
+# to use it add
+#
+# inherit clang16-native
+#
+# to the concerned recipe via a bbappend or directly to recipe file
+#
+DEPENDS:append:runtime-llvm = " clang16-native compiler-rt16-native libcxx16-initial-native"
+# Use libcxx headers for native parts
+CXXFLAGS:append:runtime-llvm = " -stdlib=libc++"
+BUILD_CXXFLAGS:append:runtime-llvm = " -isysroot=${STAGING_DIR_NATIVE} -stdlib=libc++"
+# Use libgcc for native parts
+LDFLAGS:append:runtime-llvm = " -stdlib=libc++ -rtlib=libgcc -unwindlib=libgcc"
+BUILD_LDFLAGS:append:runtime-llvm = " -stdlib=libc++ -rtlib=libgcc -unwindlib=libgcc"
+BUILD_CC:runtime-llvm  = "${CCACHE}clang -isysroot=${STAGING_DIR_NATIVE}"
+BUILD_CXX:runtime-llvm = "${CCACHE}clang++ -isysroot=${STAGING_DIR_NATIVE}"
+BUILD_CPP:runtime-llvm = "${CCACHE}clang -isysroot=${STAGING_DIR_NATIVE} -E"
+BUILD_CCLD:runtime-llvm = "${CCACHE}clang"
+BUILD_RANLIB:runtime-llvm = "llvm-ranlib"
+BUILD_AR:runtime-llvm = "llvm-ar"
+BUILD_NM:runtime-llvm = "llvm-nm"

--- a/classes/clang16.bbclass
+++ b/classes/clang16.bbclass
@@ -1,0 +1,159 @@
+# Add the necessary override
+CCACHE_COMPILERCHECK:toolchain-clang16 ?= "%compiler% -v"
+HOST_CC_ARCH:prepend:toolchain-clang16 = "-target ${HOST_SYS} "
+CC:toolchain-clang16  = "${CCACHE}${HOST_PREFIX}clang ${HOST_CC_ARCH}${TOOLCHAIN_OPTIONS}"
+CXX:toolchain-clang16 = "${CCACHE}${HOST_PREFIX}clang++ ${HOST_CC_ARCH}${TOOLCHAIN_OPTIONS}"
+CPP:toolchain-clang16 = "${CCACHE}${HOST_PREFIX}clang ${HOST_CC_ARCH}${TOOLCHAIN_OPTIONS} -E"
+CCLD:toolchain-clang16 = "${CCACHE}${HOST_PREFIX}clang ${HOST_CC_ARCH}${TOOLCHAIN_OPTIONS}"
+RANLIB:toolchain-clang16 = "${HOST_PREFIX}llvm-ranlib"
+AR:toolchain-clang16 = "${HOST_PREFIX}llvm-ar"
+NM:toolchain-clang16 = "${HOST_PREFIX}llvm-nm"
+OBJDUMP:toolchain-clang16 = "${HOST_PREFIX}llvm-objdump"
+OBJCOPY:toolchain-clang16 = "${HOST_PREFIX}llvm-objcopy"
+STRIP:riscv64:toolchain-clang16 = "${HOST_PREFIX}llvm-strip"
+STRIP:riscv32:toolchain-clang16 = "${HOST_PREFIX}llvm-strip"
+STRINGS:toolchain-clang16 = "${HOST_PREFIX}llvm-strings"
+READELF:toolchain-clang16 = "${HOST_PREFIX}llvm-readelf"
+
+LTO:toolchain-clang16 = "${@bb.utils.contains('DISTRO_FEATURES', 'thin-lto', '-flto=thin', '-flto -fuse-ld=lld', d)}"
+
+COMPILER_RT ??= ""
+COMPILER_RT:class-native = "-rtlib=libgcc ${UNWINDLIB}"
+COMPILER_RT:armeb = "-rtlib=libgcc ${UNWINDLIB}"
+COMPILER_RT:libc-klibc = "-rtlib=libgcc ${UNWINDLIB}"
+
+UNWINDLIB ??= ""
+UNWINDLIB:class-native = "--unwindlib=libgcc"
+UNWINDLIB:armeb = "--unwindlib=libgcc"
+UNWINDLIB_libc-klibc = "--unwindlib=libgcc"
+
+LIBCPLUSPLUS ??= ""
+LIBCPLUSPLUS:armv5 = "-stdlib=libstdc++"
+
+CXXFLAGS:append:toolchain-clang16 = " ${LIBCPLUSPLUS}"
+LDFLAGS:append:toolchain-clang16 = " ${COMPILER_RT} ${LIBCPLUSPLUS}"
+
+TUNE_CCARGS:remove:toolchain-clang16 = "-meb"
+TUNE_CCARGS:remove:toolchain-clang16 = "-mel"
+TUNE_CCARGS:append:toolchain-clang16 = "${@bb.utils.contains("TUNE_FEATURES", "bigendian", " -mbig-endian", " -mlittle-endian", d)}"
+
+# Clang does not yet support big.LITTLE performance tunes, so use the LITTLE for tunes
+TUNE_CCARGS:remove:toolchain-clang16 = "-mcpu=cortex-a57.cortex-a53 -mcpu=cortex-a72.cortex-a53 -mcpu=cortex-a15.cortex-a7 -mcpu=cortex-a17.cortex-a7 -mcpu=cortex-a72.cortex-a35 -mcpu=cortex-a73.cortex-a53 -mcpu=cortex-a75.cortex-a55 -mcpu=cortex-a76.cortex-a55"
+TUNE_CCARGS:append:toolchain-clang16 = "${@bb.utils.contains_any("TUNE_FEATURES", "cortexa72-cortexa53 cortexa57-cortexa53 cortexa73-cortexa53", " -mcpu=cortex-a53", "", d)}"
+TUNE_CCARGS:append:toolchain-clang16 = "${@bb.utils.contains_any("TUNE_FEATURES", "cortexa15-cortexa7 cortexa17-cortexa7", " -mcpu=cortex-a7", "", d)}"
+TUNE_CCARGS:append:toolchain-clang16 = "${@bb.utils.contains_any("TUNE_FEATURES", "cortexa72-cortexa35", " -mcpu=cortex-a35", "", d)}"
+TUNE_CCARGS:append:toolchain-clang16 = "${@bb.utils.contains_any("TUNE_FEATURES", "cortexa75-cortexa55 cortexa76-cortexa55", " -mcpu=cortex-a55", "", d)}"
+
+# Clang does not support octeontx2 processor
+TUNE_CCARGS:remove:toolchain-clang16 = "-mcpu=octeontx2"
+
+# Reconcile some ppc anamolies
+TUNE_CCARGS:remove:toolchain-clang16:powerpc = "-mhard-float -mno-spe"
+TUNE_CCARGS:append:toolchain-clang16:libc-musl:powerpc64 = " -mlong-double-64"
+TUNE_CCARGS:append:toolchain-clang16:libc-musl:powerpc64le = " -mlong-double-64"
+TUNE_CCARGS:append:toolchain-clang16:libc-musl:powerpc = " -mlong-double-64"
+# usrmerge workaround
+TUNE_CCARGS:append:toolchain-clang16 = "${@bb.utils.contains("DISTRO_FEATURES", "usrmerge", " --dyld-prefix=/usr", "", d)}"
+
+TUNE_CCARGS:append:toolchain-clang16 = " -Qunused-arguments"
+
+LDFLAGS:append:toolchain-clang16:class-nativesdk:x86-64 = " -Wl,-dynamic-linker,${base_libdir}/ld-linux-x86-64.so.2"
+LDFLAGS:append:toolchain-clang16:class-nativesdk:x86 = " -Wl,-dynamic-linker,${base_libdir}/ld-linux.so.2"
+LDFLAGS:append:toolchain-clang16:class-nativesdk:aarch64 = " -Wl,-dynamic-linker,${base_libdir}/ld-linux-aarch64.so.1"
+
+LDFLAGS:toolchain-clang16:class-nativesdk = "${BUILDSDK_LDFLAGS} \
+                                           -Wl,-rpath-link,${STAGING_LIBDIR}/.. \
+                                           -Wl,-rpath,${libdir}/.. "
+
+# Enable lld globally"
+LDFLAGS:append:toolchain-clang16 = "${@bb.utils.contains('DISTRO_FEATURES', 'ld-is-lld', ' -fuse-ld=lld', '', d)}"
+
+# Remove gcc specific -fcanon-prefix-map option, added in gcc-13+
+# clang does not support it yet
+DEBUG_PREFIX_MAP:remove:toolchain-clang16 = "-fcanon-prefix-map"
+
+# choose between 'gcc' 'clang' an empty '' can be used as well
+TOOLCHAIN ??= "gcc"
+# choose between 'gnu' 'llvm'
+TC_CXX_RUNTIME ??= "gnu"
+# Using gcc or llvm runtime is only available when using clang for compiler
+#TC_CXX_RUNTIME:toolchain-gcc = "gnu"
+TC_CXX_RUNTIME:armeb = "gnu"
+TC_CXX_RUNTIME:armv5 = "gnu"
+
+TOOLCHAIN:class-native = "gcc"
+TOOLCHAIN:class-nativesdk = "gcc"
+TOOLCHAIN:class-cross-canadian = "gcc"
+TOOLCHAIN:class-crosssdk = "gcc"
+TOOLCHAIN:class-cross = "gcc"
+
+OVERRIDES =. "${@['', 'toolchain-${TOOLCHAIN}:']['${TOOLCHAIN}' != '']}"
+OVERRIDES =. "${@['', 'runtime-${TC_CXX_RUNTIME}:']['${TC_CXX_RUNTIME}' != '']}"
+OVERRIDES[vardepsexclude] += "TOOLCHAIN TC_CXX_RUNTIME"
+
+YOCTO_ALTERNATE_EXE_PATH:toolchain-clang16:class-target = "${STAGING_BINDIR}/llvm-config"
+YOCTO_ALTERNATE_LIBDIR:toolchain-clang16:class-target = "/${BASELIB}"
+
+#YOCTO_ALTERNATE_EXE_PATH:toolchain-clang16:class-target[export] = "1"
+#YOCTO_ALTERNATE_LIBDIR:toolchain-clang16:class-target[export] = "1"
+
+#DEPENDS:append:toolchain-clang16:class-target = " clang16-cross-${TARGET_ARCH} "
+#DEPENDS:remove:toolchain-clang16:allarch = "clang16-cross-${TARGET_ARCH}"
+
+def clang_base_deps(d):
+    if not d.getVar('INHIBIT_DEFAULT_DEPS', False):
+        if not oe.utils.inherits(d, 'allarch') :
+            ret = " ${MLPREFIX}clang16-cross-${TARGET_ARCH} virtual/libc "
+            if (d.getVar('TC_CXX_RUNTIME').find('android') != -1):
+                ret += " libcxx16-initial"
+                return ret
+            if (d.getVar('TC_CXX_RUNTIME').find('llvm') != -1):
+                ret += " compiler-rt16"
+            elif (d.getVar('COMPILER_RT').find('-rtlib=compiler-rt') != -1):
+                ret += " compiler-rt16 "
+            else:
+                ret += " libgcc "
+            if (d.getVar('TC_CXX_RUNTIME').find('llvm') != -1):
+                ret += " libcxx16-initial"
+            elif (d.getVar('COMPILER_RT').find('--unwindlib=libunwind') != -1):
+                ret += " libcxx16-initial "
+            elif (d.getVar('LIBCPLUSPLUS').find('-stdlib=libc++') != -1):
+                ret += " libcxx16-initial "
+            else:
+                ret += " virtual/${TARGET_PREFIX}compilerlibs "
+            return ret
+    return ""
+
+BASE_DEFAULT_DEPS:append:class-target:toolchain-clang16:class-target = " ${@clang_base_deps(d)}"
+BASE_DEFAULT_DEPS:append:class-native:toolchain-clang16:runtime-llvm = " libcxx16-initial-native compiler-rt16-native"
+BASE_DEFAULT_DEPS:append:class-nativesdk:toolchain-clang16:runtime-llvm = " clang16-native nativesdk-libcxx16-initial nativesdk-compiler-rt16"
+
+# do_populate_sysroot needs STRIP
+POPULATESYSROOTDEPS:toolchain-clang16:class-target = "${MLPREFIX}clang16-cross-${TARGET_ARCH}:do_populate_sysroot"
+
+cmake_do_generate_toolchain_file:append:toolchain-clang16 () {
+    cat >> ${WORKDIR}/toolchain.cmake <<EOF
+set( CMAKE_CLANG_TIDY ${HOST_PREFIX}clang-tidy )
+EOF
+    sed -i 's/ -mmusl / /g' ${WORKDIR}/toolchain.cmake
+}
+
+RECIPESYSROOTFUNCS = ""
+RECIPESYSROOTFUNCS:toolchain-clang16 = "recipe_sysroot_check_ld_is_lld"
+
+recipe_sysroot_check_ld_is_lld () {
+    if ${@bb.utils.contains('DISTRO_FEATURES', 'ld-is-lld', 'true', 'false', d)} &&  \
+        [ -e ${STAGING_BINDIR_TOOLCHAIN}/${TARGET_PREFIX}ld.lld ]; then
+        ln -srf ${STAGING_BINDIR_TOOLCHAIN}/${TARGET_PREFIX}ld.lld ${STAGING_BINDIR_TOOLCHAIN}/${TARGET_PREFIX}ld
+    fi
+}
+do_prepare_recipe_sysroot[postfuncs] += "${RECIPESYSROOTFUNCS}"
+#
+# dump recipes which still use gcc
+#python __anonymous() {
+#    toolchain = d.getVar("TOOLCHAIN")
+#    if not toolchain or toolchain == "clang" or 'class-target' not in d.getVar('OVERRIDES').split(':'):
+#        return
+#    pkgn = d.getVar("PN")
+#    bb.warn("%s - %s" % (pkgn, toolchain))
+#}

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -34,6 +34,7 @@ INHERIT += "clang"
 CLANGSDK ??= "0"
 
 LLVMVERSION = "17.0.4"
+LLVM15VERSION = "15.0.7"
 
 require conf/nonclangable.conf
 require conf/nonscanable.conf

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -34,6 +34,7 @@ INHERIT += "clang"
 CLANGSDK ??= "0"
 
 LLVMVERSION = "17.0.4"
+LLVM16VERSION = "16.0.6"
 LLVM15VERSION = "15.0.7"
 
 require conf/nonclangable.conf

--- a/recipes-devtools/clang15/clang.inc
+++ b/recipes-devtools/clang15/clang.inc
@@ -1,0 +1,35 @@
+LLVM_GIT ?= "git://github.com/llvm"
+LLVM_GIT_PROTOCOL ?= "https"
+
+MAJOR_VER = "15"
+MINOR_VER = "0"
+PATCH_VER = "7"
+
+LLVM_RELEASE = "${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}"
+LLVM_DIR = "llvm${LLVM_RELEASE}"
+
+SRCREV ?= "8dfdcc7b7bf66834a761bd8de445840ef68e4d1a"
+
+PV = "${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}"
+BRANCH = "release/15.x"
+
+LLVMMD5SUM = "8a15a0759ef07f2682d2ba4b893c9afe"
+CLANGMD5SUM = "ff42885ed2ab98f1ecb8c1fc41205343"
+LLDMD5SUM = "ae7dc7c027b1fa89b5b013d391d3ee2b"
+LLDBMD5SUM = "2e0d44968471fcde980034dbb826bea9"
+
+LLVM_LIBDIR_SUFFIX="${@d.getVar('baselib').replace('lib', '')}"
+
+# Counteract the instructions given in README.md
+PREFERRED_PROVIDER_llvm = "clang15"
+PREFERRED_PROVIDER_llvm-native = "clang15-native"
+PREFERRED_PROVIDER_nativesdk-llvm = "nativesdk-clang15"
+
+# Don't include these recipes in "bitbake world"
+# as clang15 conflicts with clang.
+EXCLUDE_FROM_WORLD = "1"
+
+# set the default pigz thread
+export PIGZ = "-p ${@oe.utils.cpu_count(at_least=2)}"
+
+require common.inc

--- a/recipes-devtools/clang15/clang/0001-libcxxabi-Find-libunwind-headers-when-LIBCXXABI_LIBU.patch
+++ b/recipes-devtools/clang15/clang/0001-libcxxabi-Find-libunwind-headers-when-LIBCXXABI_LIBU.patch
@@ -1,0 +1,57 @@
+From f37af7da6832c871007bebe4927f0fc739ae5ad6 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Sun, 27 Aug 2017 10:37:49 -0700
+Subject: [PATCH] libcxxabi: Find libunwind headers when
+ LIBCXXABI_LIBUNWIND_INCLUDES is set
+
+Currently, when LIBCXXABI_LIBUNWIND_INCLUDES is set via CMake arguments
+then it ends up not searching the specified dir and unwind.h is not found
+especially for ARM targets
+
+This patch makes the searching synthesized directories and then set
+LIBCXXABI_LIBUNWIND_INCLUDES if its there in environment
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ libcxxabi/CMakeLists.txt | 16 +++++++++++-----
+ 1 file changed, 11 insertions(+), 5 deletions(-)
+
+diff --git a/libcxxabi/CMakeLists.txt b/libcxxabi/CMakeLists.txt
+index b8326d08d23a..cb16b5d4238b 100644
+--- a/libcxxabi/CMakeLists.txt
++++ b/libcxxabi/CMakeLists.txt
+@@ -474,7 +474,7 @@ set(LIBCXXABI_LIBUNWIND_PATH "${LIBCXXABI_LIBUNWIND_PATH}" CACHE PATH
+     "Specify path to libunwind source." FORCE)
+ 
+ if (LIBCXXABI_USE_LLVM_UNWINDER OR LLVM_NATIVE_ARCH MATCHES ARM)
+-  find_path(LIBCXXABI_LIBUNWIND_INCLUDES_INTERNAL libunwind.h
++  find_path(LIBCXXABI_LIBUNWIND_INCLUDES libunwind.h
+     PATHS ${LIBCXXABI_LIBUNWIND_INCLUDES}
+           ${LIBCXXABI_LIBUNWIND_PATH}/include
+           ${CMAKE_BINARY_DIR}/${LIBCXXABI_LIBUNWIND_INCLUDES}
+@@ -485,15 +485,21 @@ if (LIBCXXABI_USE_LLVM_UNWINDER OR LLVM_NATIVE_ARCH MATCHES ARM)
+     NO_CMAKE_FIND_ROOT_PATH
+   )
+ 
+-  if (LIBCXXABI_LIBUNWIND_INCLUDES_INTERNAL STREQUAL "LIBCXXABI_LIBUNWIND_INCLUDES_INTERNAL-NOTFOUND")
+-    set(LIBCXXABI_LIBUNWIND_INCLUDES_INTERNAL "")
++  if (LIBCXXABI_LIBUNWIND_INCLUDES STREQUAL "LIBCXXABI_LIBUNWIND_INCLUDES-NOTFOUND")
++    set(LIBCXXABI_LIBUNWIND_INCLUDES "")
+   endif()
+ 
+-  if (NOT LIBCXXABI_LIBUNWIND_INCLUDES_INTERNAL STREQUAL "")
+-    include_directories("${LIBCXXABI_LIBUNWIND_INCLUDES_INTERNAL}")
++  if (NOT LIBCXXABI_LIBUNWIND_INCLUDES STREQUAL "")
++    include_directories("${LIBCXXABI_LIBUNWIND_INCLUDES}")
+   endif()
+ endif()
+ 
++set(LIBCXXABI_LIBUNWIND_INCLUDES "${LIBCXXABI_LIBUNWIND_INCLUDES}" CACHE PATH
++    "Specify path to libunwind includes." FORCE)
++set(LIBCXXABI_LIBUNWIND_PATH "${LIBCXXABI_LIBUNWIND_PATH}" CACHE PATH
++    "Specify path to libunwind source." FORCE)
++
++
+ # Add source code. This also contains all of the logic for deciding linker flags
+ # soname, etc...
+ add_subdirectory(include)

--- a/recipes-devtools/clang15/clang/0002-compiler-rt-support-a-new-embedded-linux-target.patch
+++ b/recipes-devtools/clang15/clang/0002-compiler-rt-support-a-new-embedded-linux-target.patch
@@ -1,0 +1,308 @@
+From 2734739b0c2478ebad3f57462c5c68ce71338551 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Sun, 19 Apr 2015 15:16:23 -0700
+Subject: [PATCH] compiler-rt: support a new embedded linux target
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ .../make/platform/clang_linux_embedded.mk     | 286 ++++++++++++++++++
+ .../clang_linux_embedded_test_input.c         |   0
+ 2 files changed, 286 insertions(+)
+ create mode 100644 compiler-rt/make/platform/clang_linux_embedded.mk
+ create mode 100644 compiler-rt/make/platform/clang_linux_embedded_test_input.c
+
+diff --git a/compiler-rt/make/platform/clang_linux_embedded.mk b/compiler-rt/make/platform/clang_linux_embedded.mk
+new file mode 100644
+index 000000000000..d0a890075a1c
+--- /dev/null
++++ b/compiler-rt/make/platform/clang_linux_embedded.mk
+@@ -0,0 +1,286 @@
++# These are the functions which clang needs when it is targeting a previous
++# version of the OS. The issue is that the backend may use functions which were
++# not present in the libgcc that shipped on the platform. In such cases, we link
++# with a version of the library which contains private_extern definitions of all
++# the extra functions which might be referenced.
++
++Description := Static runtime libraries for embedded clang/Linux
++
++# A function that ensures we don't try to build for architectures that we
++# don't have working toolchains for.
++CheckArches = \
++  $(shell \
++    result=""; \
++    for arch in $(1); do \
++      if $(CC) -arch $$arch -c \
++	  -integrated-as \
++	  $(ProjSrcRoot)/make/platform/clang_linux_embedded_test_input.c \
++	  -o /dev/null > /dev/null 2> /dev/null; then \
++        result="$$result$$arch "; \
++      else \
++	printf 1>&2 \
++	  "warning: clang_linux_embedded.mk: dropping arch '$$arch' from lib '$(2)'\n"; \
++      fi; \
++    done; \
++    echo $$result)
++
++XCRun = \
++  $(shell \
++    result=`xcrun -find $(1) 2> /dev/null`; \
++    if [ "$$?" != "0" ]; then result=$(1); fi; \
++    echo $$result)
++
++###
++
++CC       := $(call XCRun,clang)
++AR       := $(call XCRun,ar)
++RANLIB   := $(call XCRun,ranlib)
++STRIP    := $(call XCRun,strip)
++LIPO     := $(call XCRun,lipo)
++DSYMUTIL := $(call XCRun,dsymutil)
++Configs :=
++UniversalArchs :=
++
++# Soft-float version of the runtime. No floating-point instructions will be used
++# and the ABI (out of necessity) passes floating values in normal registers:
++# non-VFP variant of the AAPCS.
++UniversalArchs.soft_static := $(call CheckArches,arm armv7m armv7em armv7,soft_static)
++Configs += $(if $(UniversalArchs.soft_static),soft_static)
++
++# Hard-float version of the runtime. On ARM VFP instructions and registers are
++# allowed, and floating point values get passed in them. VFP variant of the
++# AAPCS.
++UniversalArchs.hard_static := $(call CheckArches,armv7em armv7 i386 x86_64,hard_static)
++Configs += $(if $(UniversalArchs.hard_static),hard_static)
++
++UniversalArchs.soft_pic := $(call CheckArches,armv6m armv7m armv7em armv7,soft_pic)
++Configs += $(if $(UniversalArchs.soft_pic),soft_pic)
++
++UniversalArchs.hard_pic := $(call CheckArches,armv7em armv7 i386 x86_64,hard_pic)
++Configs += $(if $(UniversalArchs.hard_pic),hard_pic)
++
++CFLAGS := -Wall -Werror -Oz -fomit-frame-pointer -ffreestanding
++
++PIC_CFLAGS := -fPIC
++STATIC_CFLAGS := -static
++
++CFLAGS_SOFT := -mfloat-abi=soft
++CFLAGS_HARD := -mfloat-abi=hard
++
++CFLAGS_I386  := -march=pentium
++
++CFLAGS.soft_static := $(CFLAGS) $(STATIC_CFLAGS) $(CFLAGS_SOFT)
++CFLAGS.hard_static := $(CFLAGS) $(STATIC_CFLAGS) $(CFLAGS_HARD)
++CFLAGS.soft_pic    := $(CFLAGS) $(PIC_CFLAGS) $(CFLAGS_SOFT)
++CFLAGS.hard_pic    := $(CFLAGS) $(PIC_CFLAGS) $(CFLAGS_HARD)
++
++CFLAGS.soft_static.armv7 := $(CFLAGS.soft_static) $(CFLAGS_ARMV7)
++CFLAGS.hard_static.armv7 := $(CFLAGS.hard_static) $(CFLAGS_ARMV7)
++CFLAGS.soft_pic.armv7    := $(CFLAGS.soft_pic) $(CFLAGS_ARMV7)
++CFLAGS.hard_pic.armv7    := $(CFLAGS.hard_pic) $(CFLAGS_ARMV7)
++
++# x86 platforms ignore -mfloat-abi options and complain about doing so. Despite
++# this they're hard-float.
++CFLAGS.hard_static.i386   := $(CFLAGS) $(STATIC_CFLAGS) $(CFLAGS_I386)
++CFLAGS.hard_pic.i386      := $(CFLAGS) $(PIC_CFLAGS) $(CFLAGS_I386)
++CFLAGS.hard_static.x86_64 := $(CFLAGS) $(STATIC_CFLAGS)
++CFLAGS.hard_pic.x86_64    := $(CFLAGS) $(PIC_CFLAGS)
++
++# Functions not wanted:
++#   + eprintf is obsolete anyway
++#   + *vfp: designed for Thumb1 CPUs with VFPv2
++
++COMMON_FUNCTIONS := \
++	absvdi2 \
++	absvsi2 \
++	addvdi3 \
++	addvsi3 \
++	ashldi3 \
++	ashrdi3 \
++	bswapdi2 \
++	bswapsi2 \
++	clzdi2 \
++	clzsi2 \
++	cmpdi2 \
++	ctzdi2 \
++	ctzsi2 \
++	divdc3 \
++	divdi3 \
++	divsc3 \
++	divmodsi4 \
++	udivmodsi4 \
++	do_global_dtors \
++	ffsdi2 \
++	fixdfdi \
++	fixsfdi \
++	fixunsdfdi \
++	fixunsdfsi \
++	fixunssfdi \
++	fixunssfsi \
++	floatdidf \
++	floatdisf \
++	floatundidf \
++	floatundisf \
++	gcc_bcmp \
++	lshrdi3 \
++	moddi3 \
++	muldc3 \
++	muldi3 \
++	mulsc3 \
++	mulvdi3 \
++	mulvsi3 \
++	negdi2 \
++	negvdi2 \
++	negvsi2 \
++	paritydi2 \
++	paritysi2 \
++	popcountdi2 \
++	popcountsi2 \
++	powidf2 \
++	powisf2 \
++	subvdi3 \
++	subvsi3 \
++	ucmpdi2 \
++	udiv_w_sdiv \
++	udivdi3 \
++	udivmoddi4 \
++	umoddi3 \
++	adddf3 \
++	addsf3 \
++	cmpdf2 \
++	cmpsf2 \
++	div0 \
++	divdf3 \
++	divsf3 \
++	divsi3 \
++	extendsfdf2 \
++	ffssi2 \
++	fixdfsi \
++	fixsfsi \
++	floatsidf \
++	floatsisf \
++	floatunsidf \
++	floatunsisf \
++	comparedf2 \
++	comparesf2 \
++	modsi3 \
++	muldf3 \
++	mulsf3 \
++	negdf2 \
++	negsf2 \
++	subdf3 \
++	subsf3 \
++	truncdfsf2 \
++	udivsi3 \
++	umodsi3 \
++	unorddf2 \
++	unordsf2
++
++ARM_FUNCTIONS := \
++	aeabi_cdcmpeq \
++	aeabi_cdrcmple \
++	aeabi_cfcmpeq \
++	aeabi_cfrcmple \
++	aeabi_dcmpeq \
++	aeabi_dcmpge \
++	aeabi_dcmpgt \
++	aeabi_dcmple \
++	aeabi_dcmplt \
++	aeabi_drsub \
++	aeabi_fcmpeq \
++	aeabi_fcmpge \
++	aeabi_fcmpgt \
++	aeabi_fcmple \
++	aeabi_fcmplt \
++	aeabi_frsub \
++	aeabi_idivmod \
++	aeabi_uidivmod \
++
++# ARM Assembly implementation which requires Thumb2 (i.e. won't work on v6M).
++THUMB2_FUNCTIONS := \
++	switch16 \
++	switch32 \
++	switch8 \
++	switchu8 \
++	sync_fetch_and_add_4 \
++	sync_fetch_and_sub_4 \
++	sync_fetch_and_and_4 \
++	sync_fetch_and_or_4 \
++	sync_fetch_and_xor_4 \
++	sync_fetch_and_nand_4 \
++	sync_fetch_and_max_4 \
++	sync_fetch_and_umax_4 \
++	sync_fetch_and_min_4 \
++	sync_fetch_and_umin_4 \
++	sync_fetch_and_add_8 \
++	sync_fetch_and_sub_8 \
++	sync_fetch_and_and_8 \
++	sync_fetch_and_or_8 \
++	sync_fetch_and_xor_8 \
++	sync_fetch_and_nand_8 \
++	sync_fetch_and_max_8 \
++	sync_fetch_and_umax_8 \
++	sync_fetch_and_min_8 \
++	sync_fetch_and_umin_8
++
++I386_FUNCTIONS :=  \
++	i686.get_pc_thunk.eax \
++	i686.get_pc_thunk.ebp \
++	i686.get_pc_thunk.ebx \
++	i686.get_pc_thunk.ecx \
++	i686.get_pc_thunk.edi \
++	i686.get_pc_thunk.edx \
++	i686.get_pc_thunk.esi
++
++# FIXME: Currently, compiler-rt is missing implementations for a number of the
++# functions. Filter them out for now.
++MISSING_FUNCTIONS := \
++	cmpdf2 cmpsf2 div0 \
++	ffssi2 \
++	udiv_w_sdiv unorddf2 unordsf2 bswapdi2 \
++	bswapsi2 \
++	gcc_bcmp \
++	do_global_dtors \
++	i686.get_pc_thunk.eax i686.get_pc_thunk.ebp i686.get_pc_thunk.ebx \
++	i686.get_pc_thunk.ecx i686.get_pc_thunk.edi i686.get_pc_thunk.edx \
++	i686.get_pc_thunk.esi \
++	aeabi_cdcmpeq aeabi_cdrcmple aeabi_cfcmpeq aeabi_cfrcmple aeabi_dcmpeq \
++	aeabi_dcmpge aeabi_dcmpgt aeabi_dcmple aeabi_dcmplt aeabi_drsub \
++	aeabi_fcmpeq \ aeabi_fcmpge aeabi_fcmpgt aeabi_fcmple aeabi_fcmplt \
++	aeabi_frsub aeabi_idivmod aeabi_uidivmod
++
++FUNCTIONS_ARMV6M  := $(COMMON_FUNCTIONS) $(ARM_FUNCTIONS)
++FUNCTIONS_ARM_ALL := $(COMMON_FUNCTIONS) $(ARM_FUNCTIONS) $(THUMB2_FUNCTIONS)
++FUNCTIONS_I386    := $(COMMON_FUNCTIONS) $(I386_FUNCTIONS)
++FUNCTIONS_X86_64  := $(COMMON_FUNCTIONS)
++
++FUNCTIONS_ARMV6M := \
++	$(filter-out $(MISSING_FUNCTIONS),$(FUNCTIONS_ARMV6M))
++FUNCTIONS_ARM_ALL := \
++	$(filter-out $(MISSING_FUNCTIONS),$(FUNCTIONS_ARM_ALL))
++FUNCTIONS_I386 := \
++	$(filter-out $(MISSING_FUNCTIONS),$(FUNCTIONS_I386))
++FUNCTIONS_X86_64 := \
++	$(filter-out $(MISSING_FUNCTIONS),$(FUNCTIONS_X86_64))
++
++FUNCTIONS.soft_static.armv6m := $(FUNCTIONS_ARMV6M)
++FUNCTIONS.soft_pic.armv6m    := $(FUNCTIONS_ARMV6M)
++
++FUNCTIONS.soft_static.armv7m := $(FUNCTIONS_ARM_ALL)
++FUNCTIONS.soft_pic.armv7m    := $(FUNCTIONS_ARM_ALL)
++
++FUNCTIONS.soft_static.armv7em := $(FUNCTIONS_ARM_ALL)
++FUNCTIONS.hard_static.armv7em := $(FUNCTIONS_ARM_ALL)
++FUNCTIONS.soft_pic.armv7em    := $(FUNCTIONS_ARM_ALL)
++FUNCTIONS.hard_pic.armv7em    := $(FUNCTIONS_ARM_ALL)
++
++FUNCTIONS.soft_static.armv7 := $(FUNCTIONS_ARM_ALL)
++FUNCTIONS.hard_static.armv7 := $(FUNCTIONS_ARM_ALL)
++FUNCTIONS.soft_pic.armv7    := $(FUNCTIONS_ARM_ALL)
++FUNCTIONS.hard_pic.armv7    := $(FUNCTIONS_ARM_ALL)
++
++FUNCTIONS.hard_static.i386 := $(FUNCTIONS_I386)
++FUNCTIONS.hard_pic.i386    := $(FUNCTIONS_I386)
++
++FUNCTIONS.hard_static.x86_64 := $(FUNCTIONS_X86_64)
++FUNCTIONS.hard_pic.x86_64    := $(FUNCTIONS_X86_64)
+diff --git a/compiler-rt/make/platform/clang_linux_embedded_test_input.c b/compiler-rt/make/platform/clang_linux_embedded_test_input.c
+new file mode 100644
+index 000000000000..e69de29bb2d1

--- a/recipes-devtools/clang15/clang/0003-compiler-rt-Simplify-cross-compilation.-Don-t-use-na.patch
+++ b/recipes-devtools/clang15/clang/0003-compiler-rt-Simplify-cross-compilation.-Don-t-use-na.patch
@@ -1,0 +1,43 @@
+From 0980511a0eba734da6112c4416a8a086a13c8c82 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Thu, 19 May 2016 23:11:45 -0700
+Subject: [PATCH] compiler-rt: Simplify cross-compilation. Don't use
+ native-compiled llvm-config.
+
+    Note: AddLLVM.cmake does not expose the LLVM source directory.
+    So if you want to run the test suite, you need to either:
+
+    1) set LLVM_MAIN_SRC_DIR explicitly (to find lit.py)
+    2) change AddLLVM.cmake to point to an installed 'lit'.
+    3) add_subdirectory(compiler-rt/test) from clang instead of compiler-rt.
+
+https://us.codeaurora.org/patches/quic/llvm/50683/compiler-rt-cross-compilation.patch
+
+Signed-off-by: Greg Fitzgerald <gregf@codeaurora.org>
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ compiler-rt/CMakeLists.txt | 11 ++++++++++-
+ 1 file changed, 10 insertions(+), 1 deletion(-)
+
+diff --git a/compiler-rt/CMakeLists.txt b/compiler-rt/CMakeLists.txt
+index 62737735695f..a2c7c3a786ab 100644
+--- a/compiler-rt/CMakeLists.txt
++++ b/compiler-rt/CMakeLists.txt
+@@ -68,7 +68,16 @@ set(COMPILER_RT_BAREMETAL_BUILD OFF CACHE BOOL
+   "Build for a bare-metal target.")
+ 
+ if (COMPILER_RT_STANDALONE_BUILD)
+-  load_llvm_config()
++  find_package(LLVM REQUIRED)
++  list(APPEND CMAKE_MODULE_PATH "${LLVM_CMAKE_DIR}")
++
++  # Variables that AddLLVM.cmake depends on (included by AddCompilerRT)
++  set(LLVM_TOOLS_BINARY_DIR "${LLVM_INSTALL_PREFIX}/bin")
++  set(LLVM_LIBRARY_DIR "${LLVM_INSTALL_PREFIX}/lib")
++
++  set(LLVM_LIBRARY_OUTPUT_INTDIR
++    ${CMAKE_BINARY_DIR}/${CMAKE_CFG_INTDIR}/lib${LLVM_LIBDIR_SUFFIX})
++
+   if (TARGET intrinsics_gen)
+     # Loading the llvm config causes this target to be imported so place it
+     # under the appropriate folder in an IDE.

--- a/recipes-devtools/clang15/clang/0004-llvm-TargetLibraryInfo-Undefine-libc-functions-if-th.patch
+++ b/recipes-devtools/clang15/clang/0004-llvm-TargetLibraryInfo-Undefine-libc-functions-if-th.patch
@@ -1,0 +1,88 @@
+From b0a0d9f515b8423b7f8e0cd8f4882a4ef6fd43af Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Sat, 21 May 2016 00:33:20 +0000
+Subject: [PATCH] llvm: TargetLibraryInfo: Undefine libc functions if they are
+ macros
+
+musl defines some functions as macros and not inline functions
+if this is the case then make sure to undefine them
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ .../llvm/Analysis/TargetLibraryInfo.def       | 21 +++++++++++++++++++
+ 1 file changed, 21 insertions(+)
+
+diff --git a/llvm/include/llvm/Analysis/TargetLibraryInfo.def b/llvm/include/llvm/Analysis/TargetLibraryInfo.def
+index 9c1abef33b28..29d2a79ddecc 100644
+--- a/llvm/include/llvm/Analysis/TargetLibraryInfo.def
++++ b/llvm/include/llvm/Analysis/TargetLibraryInfo.def
+@@ -815,6 +815,9 @@ TLI_DEFINE_STRING_INTERNAL("fmodl")
+ TLI_DEFINE_ENUM_INTERNAL(fopen)
+ TLI_DEFINE_STRING_INTERNAL("fopen")
+ /// FILE *fopen64(const char *filename, const char *opentype)
++#ifdef fopen64
++#undef fopen64
++#endif
+ TLI_DEFINE_ENUM_INTERNAL(fopen64)
+ TLI_DEFINE_STRING_INTERNAL("fopen64")
+ /// int fork();
+@@ -862,6 +865,9 @@ TLI_DEFINE_STRING_INTERNAL("fseek")
+ /// int fseeko(FILE *stream, off_t offset, int whence);
+ TLI_DEFINE_ENUM_INTERNAL(fseeko)
+ TLI_DEFINE_STRING_INTERNAL("fseeko")
++#ifdef fseeko64
++#undef fseeko64
++#endif
+ /// int fseeko64(FILE *stream, off64_t offset, int whence)
+ TLI_DEFINE_ENUM_INTERNAL(fseeko64)
+ TLI_DEFINE_STRING_INTERNAL("fseeko64")
+@@ -872,6 +878,9 @@ TLI_DEFINE_STRING_INTERNAL("fsetpos")
+ TLI_DEFINE_ENUM_INTERNAL(fstat)
+ TLI_DEFINE_STRING_INTERNAL("fstat")
+ /// int fstat64(int filedes, struct stat64 *buf)
++#ifdef fstat64
++#undef fstat64
++#endif
+ TLI_DEFINE_ENUM_INTERNAL(fstat64)
+ TLI_DEFINE_STRING_INTERNAL("fstat64")
+ /// int fstatvfs(int fildes, struct statvfs *buf);
+@@ -887,6 +896,9 @@ TLI_DEFINE_STRING_INTERNAL("ftell")
+ TLI_DEFINE_ENUM_INTERNAL(ftello)
+ TLI_DEFINE_STRING_INTERNAL("ftello")
+ /// off64_t ftello64(FILE *stream)
++#ifdef ftello64
++#undef ftello64
++#endif
+ TLI_DEFINE_ENUM_INTERNAL(ftello64)
+ TLI_DEFINE_STRING_INTERNAL("ftello64")
+ /// int ftrylockfile(FILE *file);
+@@ -1013,6 +1025,9 @@ TLI_DEFINE_STRING_INTERNAL("logl")
+ TLI_DEFINE_ENUM_INTERNAL(lstat)
+ TLI_DEFINE_STRING_INTERNAL("lstat")
+ /// int lstat64(const char *path, struct stat64 *buf);
++#ifdef lstat64
++#undef lstat64
++#endif
+ TLI_DEFINE_ENUM_INTERNAL(lstat64)
+ TLI_DEFINE_STRING_INTERNAL("lstat64")
+ /// void *malloc(size_t size);
+@@ -1262,6 +1277,9 @@ TLI_DEFINE_STRING_INTERNAL("sscanf")
+ TLI_DEFINE_ENUM_INTERNAL(stat)
+ TLI_DEFINE_STRING_INTERNAL("stat")
+ /// int stat64(const char *path, struct stat64 *buf);
++#ifdef stat64
++#undef stat64
++#endif
+ TLI_DEFINE_ENUM_INTERNAL(stat64)
+ TLI_DEFINE_STRING_INTERNAL("stat64")
+ /// int statvfs(const char *path, struct statvfs *buf);
+@@ -1397,6 +1415,9 @@ TLI_DEFINE_STRING_INTERNAL("times")
+ TLI_DEFINE_ENUM_INTERNAL(tmpfile)
+ TLI_DEFINE_STRING_INTERNAL("tmpfile")
+ /// FILE *tmpfile64(void)
++#ifdef tmpfile64
++#undef tmpfile64
++#endif
+ TLI_DEFINE_ENUM_INTERNAL(tmpfile64)
+ TLI_DEFINE_STRING_INTERNAL("tmpfile64")
+ /// int toascii(int c);

--- a/recipes-devtools/clang15/clang/0005-llvm-allow-env-override-of-exe-and-libdir-path.patch
+++ b/recipes-devtools/clang15/clang/0005-llvm-allow-env-override-of-exe-and-libdir-path.patch
@@ -1,0 +1,71 @@
+From d88d1f16df8f3f28246c8fdeb2a3bdb84bfe3121 Mon Sep 17 00:00:00 2001
+From: Martin Kelly <mkelly@xevo.com>
+Date: Fri, 19 May 2017 00:22:57 -0700
+Subject: [PATCH] llvm: allow env override of exe and libdir path
+
+When using a native llvm-config from inside a sysroot, we need llvm-config to
+return the libraries, include directories, etc. from inside the sysroot rather
+than from the native sysroot. Thus provide an env override for calling
+llvm-config from a target sysroot.
+
+Add YOCTO_ALTERNATE_LIBDIR and YOCTO_ALTERNATE_EXE_PATH env variables
+
+Upstream-Status: Inappropriate [OE-specific]
+
+Signed-off-by: Martin Kelly <mkelly@xevo.com>
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ llvm/tools/llvm-config/llvm-config.cpp | 25 +++++++++++++++++++------
+ 1 file changed, 19 insertions(+), 6 deletions(-)
+
+diff --git a/llvm/tools/llvm-config/llvm-config.cpp b/llvm/tools/llvm-config/llvm-config.cpp
+index 2c6c55f89d38..77da3d7827dd 100644
+--- a/llvm/tools/llvm-config/llvm-config.cpp
++++ b/llvm/tools/llvm-config/llvm-config.cpp
+@@ -249,6 +249,13 @@ Typical components:\n\
+ 
+ /// Compute the path to the main executable.
+ std::string GetExecutablePath(const char *Argv0) {
++  // Hack for Yocto: we need to override the root path when we are using
++  // llvm-config from within a target sysroot.
++  const char *Sysroot = std::getenv("YOCTO_ALTERNATE_EXE_PATH");
++  if (Sysroot != nullptr) {
++    return Sysroot;
++  }
++
+   // This just needs to be some symbol in the binary; C++ doesn't
+   // allow taking the address of ::main however.
+   void *P = (void *)(intptr_t)GetExecutablePath;
+@@ -328,7 +335,7 @@ int main(int argc, char **argv) {
+   // Compute various directory locations based on the derived location
+   // information.
+   std::string ActivePrefix, ActiveBinDir, ActiveIncludeDir, ActiveLibDir,
+-              ActiveCMakeDir;
++              ActiveCMakeDir, BaseLibDir;
+   std::string ActiveIncludeOption;
+   if (IsInDevelopmentTree) {
+     ActiveIncludeDir = std::string(LLVM_SRC_ROOT) + "/include";
+@@ -369,12 +376,18 @@ int main(int argc, char **argv) {
+       sys::fs::make_absolute(ActivePrefix, Path);
+       ActiveBinDir = std::string(Path.str());
+     }
+-    ActiveLibDir = ActivePrefix + "/lib" + LLVM_LIBDIR_SUFFIX;
+-    {
+-      SmallString<256> Path(LLVM_INSTALL_PACKAGE_DIR);
+-      sys::fs::make_absolute(ActivePrefix, Path);
+-      ActiveCMakeDir = std::string(Path.str());
++    // Hack for Yocto: we need to override the lib path when we are using
++    // llvm-config from within a target sysroot since LLVM_LIBDIR_SUFFIX
++    // maybe different for host llvm vs target e.g. ppc64 Libdir=lib64 but
++    // x86_64 Libdir = lib
++    const char *YoctoLibDir = std::getenv("YOCTO_ALTERNATE_LIBDIR");
++    if (YoctoLibDir != nullptr) {
++      BaseLibDir = std::string(YoctoLibDir);
++    } else {
++      BaseLibDir = std::string("/lib") + LLVM_LIBDIR_SUFFIX;
+     }
++    ActiveLibDir = ActivePrefix + BaseLibDir;
++    ActiveCMakeDir = ActiveLibDir + "/cmake/llvm";
+     ActiveIncludeOption = "-I" + ActiveIncludeDir;
+   }
+ 

--- a/recipes-devtools/clang15/clang/0006-clang-driver-Check-sysroot-for-ldso-path.patch
+++ b/recipes-devtools/clang15/clang/0006-clang-driver-Check-sysroot-for-ldso-path.patch
@@ -1,0 +1,61 @@
+From 3f9d367a0f519c04c0a59c6aec49898270860f46 Mon Sep 17 00:00:00 2001
+From: Dan McGregor <dan.mcgregor@usask.ca>
+Date: Wed, 26 Apr 2017 20:29:41 -0600
+Subject: [PATCH] clang: driver: Check sysroot for ldso path
+
+OE does not necessarily follow the default path for the dynamic linker,
+therefore adjust it for OE. Check for the default path, and if it isn't
+there, check /lib.
+
+Signed-off-by: Dan McGregor <dan.mcgregor@usask.ca>
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ clang/lib/Driver/ToolChains/Linux.cpp | 16 ++++++++++++++++
+ 1 file changed, 16 insertions(+)
+
+diff --git a/clang/lib/Driver/ToolChains/Linux.cpp b/clang/lib/Driver/ToolChains/Linux.cpp
+index ceb1a982c3a4..69f5a4662732 100644
+--- a/clang/lib/Driver/ToolChains/Linux.cpp
++++ b/clang/lib/Driver/ToolChains/Linux.cpp
+@@ -508,11 +508,19 @@ std::string Linux::getDynamicLinker(const ArgList &Args) const {
+     LibDir = "lib64";
+     Loader =
+         (tools::ppc::hasPPCAbiArg(Args, "elfv2")) ? "ld64.so.2" : "ld64.so.1";
++    if (!getVFS().exists(getDriver().SysRoot + "/" + LibDir + "/" + Loader) &&
++         getVFS().exists(getDriver().SysRoot + "/lib/" + Loader)) {
++        LibDir = "lib";
++    }
+     break;
+   case llvm::Triple::ppc64le:
+     LibDir = "lib64";
+     Loader =
+         (tools::ppc::hasPPCAbiArg(Args, "elfv1")) ? "ld64.so.1" : "ld64.so.2";
++    if (!getVFS().exists(getDriver().SysRoot + "/" + LibDir + "/" + Loader) &&
++         getVFS().exists(getDriver().SysRoot + "/lib/" + Loader)) {
++        LibDir = "lib";
++    }
+     break;
+   case llvm::Triple::riscv32: {
+     StringRef ABIName = tools::riscv::getRISCVABI(Args, Triple);
+@@ -534,6 +542,10 @@ std::string Linux::getDynamicLinker(const ArgList &Args) const {
+   case llvm::Triple::sparcv9:
+     LibDir = "lib64";
+     Loader = "ld-linux.so.2";
++    if (!getVFS().exists(getDriver().SysRoot + "/" + LibDir + "/" + Loader) &&
++         getVFS().exists(getDriver().SysRoot + "/lib/" + Loader)) {
++        LibDir = "lib";
++    }
+     break;
+   case llvm::Triple::systemz:
+     LibDir = "lib";
+@@ -548,6 +560,10 @@ std::string Linux::getDynamicLinker(const ArgList &Args) const {
+ 
+     LibDir = X32 ? "libx32" : "lib64";
+     Loader = X32 ? "ld-linux-x32.so.2" : "ld-linux-x86-64.so.2";
++    if (!getVFS().exists(getDriver().SysRoot + "/" + LibDir + "/" + Loader) &&
++         getVFS().exists(getDriver().SysRoot + "/lib/" + Loader)) {
++        LibDir = "lib";
++    }
+     break;
+   }
+   case llvm::Triple::ve:

--- a/recipes-devtools/clang15/clang/0007-clang-Driver-tools.cpp-Add-lssp_nonshared-on-musl.patch
+++ b/recipes-devtools/clang15/clang/0007-clang-Driver-tools.cpp-Add-lssp_nonshared-on-musl.patch
@@ -1,0 +1,31 @@
+From 8d8ad213bf8683093f95112ba61934dff0d42c52 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Thu, 19 May 2016 21:11:06 -0700
+Subject: [PATCH] clang: Driver/tools.cpp: Add -lssp_nonshared on musl
+
+musl driver will need to add ssp_nonshared for stack_check_local
+on the linker cmdline when using stack protector commands on
+compiler cmdline
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ clang/lib/Driver/ToolChains/Gnu.cpp | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/clang/lib/Driver/ToolChains/Gnu.cpp b/clang/lib/Driver/ToolChains/Gnu.cpp
+index f203cae1d329..0b5255a10404 100644
+--- a/clang/lib/Driver/ToolChains/Gnu.cpp
++++ b/clang/lib/Driver/ToolChains/Gnu.cpp
+@@ -654,6 +654,12 @@ void tools::gnutools::Linker::ConstructJob(Compilation &C, const JobAction &JA,
+       if (IsIAMCU)
+         CmdArgs.push_back("-lgloss");
+ 
++      if (ToolChain.getTriple().isMusl() &&
++          (Args.hasArg(options::OPT_fstack_protector) ||
++          Args.hasArg(options::OPT_fstack_protector_strong) ||
++          Args.hasArg(options::OPT_fstack_protector_all))) {
++        CmdArgs.push_back("-lssp_nonshared");
++      }
+       if (IsStatic || IsStaticPIE)
+         CmdArgs.push_back("--end-group");
+       else

--- a/recipes-devtools/clang15/clang/0008-clang-Prepend-trailing-to-sysroot.patch
+++ b/recipes-devtools/clang15/clang/0008-clang-Prepend-trailing-to-sysroot.patch
@@ -1,0 +1,38 @@
+From 0004f72d90c276ee934f39706bb101d6d738333f Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Thu, 16 Mar 2017 09:02:13 -0700
+Subject: [PATCH] clang: Prepend trailing '/' to sysroot
+
+This is needed to handle a case where clang
+isntall and target sysroot are perilously same
+
+e.g.
+
+sysroot = /mnt/clang/recipe-sysroot
+clang install = /mnt/clang/recipe-sysroot-native
+
+in this case it will mistakenly assume that
+clang is installed under the same sysroot dir
+and it will try to add relative ../lib paths
+to linker steps which would then be wrong
+since they will become relative to clang
+installation and not sysroot
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ clang/lib/Driver/ToolChains/Linux.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/clang/lib/Driver/ToolChains/Linux.cpp b/clang/lib/Driver/ToolChains/Linux.cpp
+index 69f5a4662732..7555466e7e2b 100644
+--- a/clang/lib/Driver/ToolChains/Linux.cpp
++++ b/clang/lib/Driver/ToolChains/Linux.cpp
+@@ -183,7 +183,7 @@ Linux::Linux(const Driver &D, const llvm::Triple &Triple, const ArgList &Args)
+   Multilibs = GCCInstallation.getMultilibs();
+   SelectedMultilib = GCCInstallation.getMultilib();
+   llvm::Triple::ArchType Arch = Triple.getArch();
+-  std::string SysRoot = computeSysRoot();
++  std::string SysRoot = computeSysRoot() + "/";
+   ToolChain::path_list &PPaths = getProgramPaths();
+ 
+   Generic_GCC::PushPPaths(PPaths);

--- a/recipes-devtools/clang15/clang/0009-clang-Look-inside-the-target-sysroot-for-compiler-ru.patch
+++ b/recipes-devtools/clang15/clang/0009-clang-Look-inside-the-target-sysroot-for-compiler-ru.patch
@@ -1,0 +1,40 @@
+From 6c3940c923c5554b2b26e09e347e452ba293b391 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Thu, 16 Mar 2017 19:06:26 -0700
+Subject: [PATCH] clang: Look inside the target sysroot for compiler runtime
+
+In OE compiler-rt and libc++ are built and staged into target
+sysroot and not into resourcedir which is relative to clang
+driver installation where the libraries are not instlled
+
+Specific to cross compiling the way yocto/OE works
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ clang/lib/Driver/ToolChain.cpp | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/clang/lib/Driver/ToolChain.cpp b/clang/lib/Driver/ToolChain.cpp
+index 7a4319ea680f..3068d25dab75 100644
+--- a/clang/lib/Driver/ToolChain.cpp
++++ b/clang/lib/Driver/ToolChain.cpp
+@@ -13,6 +13,7 @@
+ #include "ToolChains/InterfaceStubs.h"
+ #include "clang/Basic/ObjCRuntime.h"
+ #include "clang/Basic/Sanitizers.h"
++#include "clang/Basic/Version.h"
+ #include "clang/Config/config.h"
+ #include "clang/Driver/Action.h"
+ #include "clang/Driver/Driver.h"
+@@ -458,7 +459,10 @@ StringRef ToolChain::getOSLibName() const {
+ }
+ 
+ std::string ToolChain::getCompilerRTPath() const {
+-  SmallString<128> Path(getDriver().ResourceDir);
++  SmallString<128> Path(getDriver().SysRoot);
++  StringRef ClangLibdirSuffix(CLANG_LIBDIR_SUFFIX);
++  llvm::sys::path::append(Path, "/usr/", Twine("lib") + ClangLibdirSuffix, "clang",
++                            CLANG_VERSION_STRING);
+   if (Triple.isOSUnknown()) {
+     llvm::sys::path::append(Path, "lib");
+   } else {

--- a/recipes-devtools/clang15/clang/0010-clang-Define-releative-gcc-installation-dir.patch
+++ b/recipes-devtools/clang15/clang/0010-clang-Define-releative-gcc-installation-dir.patch
@@ -1,0 +1,46 @@
+From 349fd23e6ecf8b6290460dd7da2e79cbe2fddf7a Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Sat, 20 Mar 2021 16:09:16 -0700
+Subject: [PATCH] clang: Define / releative gcc installation dir
+
+This is required for OE gcc installation to work.
+Without this its not able to find the paths for libgcc
+and other standard headers and libraries from gcc
+installation in OE
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ clang/lib/Driver/ToolChains/Gnu.cpp | 14 +++++++-------
+ 1 file changed, 7 insertions(+), 7 deletions(-)
+
+diff --git a/clang/lib/Driver/ToolChains/Gnu.cpp b/clang/lib/Driver/ToolChains/Gnu.cpp
+index 0b5255a10404..bddc77cde2d6 100644
+--- a/clang/lib/Driver/ToolChains/Gnu.cpp
++++ b/clang/lib/Driver/ToolChains/Gnu.cpp
+@@ -2642,19 +2642,19 @@ void Generic_GCC::GCCInstallationDetector::ScanLibDirForGCCTriple(
+     // Whether this library suffix is relevant for the triple.
+     bool Active;
+   } Suffixes[] = {
+-      // This is the normal place.
+-      {"gcc/" + CandidateTriple.str(), "../..", GCCDirExists},
+-
+-      // Debian puts cross-compilers in gcc-cross.
+-      {"gcc-cross/" + CandidateTriple.str(), "../..", GCCCrossDirExists},
+-
+       // The Freescale PPC SDK has the gcc libraries in
+       // <sysroot>/usr/lib/<triple>/x.y.z so have a look there as well. Only do
+       // this on Freescale triples, though, since some systems put a *lot* of
+       // files in that location, not just GCC installation data.
+       {CandidateTriple.str(), "..",
+        TargetTriple.getVendor() == llvm::Triple::Freescale ||
+-           TargetTriple.getVendor() == llvm::Triple::OpenEmbedded}};
++           TargetTriple.getVendor() == llvm::Triple::OpenEmbedded},
++
++      // This is the normal place.
++      {"gcc/" + CandidateTriple.str(), "../..", GCCDirExists},
++
++      // Debian puts cross-compilers in gcc-cross.
++      {"gcc-cross/" + CandidateTriple.str(), "../..", GCCCrossDirExists}};
+ 
+   for (auto &Suffix : Suffixes) {
+     if (!Suffix.Active)

--- a/recipes-devtools/clang15/clang/0011-clang-Add-lpthread-and-ldl-along-with-lunwind-for-st.patch
+++ b/recipes-devtools/clang15/clang/0011-clang-Add-lpthread-and-ldl-along-with-lunwind-for-st.patch
@@ -1,0 +1,34 @@
+From 0680ca156584888a7eddef687e47888369ad70c3 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Wed, 31 Jul 2019 22:51:39 -0700
+Subject: [PATCH] clang: Add -lpthread and -ldl along with -lunwind for static
+ linking
+
+When doing static liking with --unwindlib=libunwind -static we encounter
+undefined symbols
+libunwind/src/RWMutex.hpp:68: undefined reference to `pthread_rwlock_wrlock'
+
+and
+
+libunwind/src/AddressSpace.hpp:597: undefined reference to `dladdr'
+
+therefore we need to link in libpthread and libdl to fill these symbols
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ clang/lib/Driver/ToolChains/CommonArgs.cpp | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/clang/lib/Driver/ToolChains/CommonArgs.cpp b/clang/lib/Driver/ToolChains/CommonArgs.cpp
+index 443725f7d8a8..c8eabfac21dc 100644
+--- a/clang/lib/Driver/ToolChains/CommonArgs.cpp
++++ b/clang/lib/Driver/ToolChains/CommonArgs.cpp
+@@ -1537,6 +1537,8 @@ static void AddUnwindLibrary(const ToolChain &TC, const Driver &D,
+         CmdArgs.push_back("-lunwind");
+     } else if (LGT == LibGccType::StaticLibGcc) {
+       CmdArgs.push_back("-l:libunwind.a");
++      CmdArgs.push_back("-lpthread");
++      CmdArgs.push_back("-ldl");
+     } else if (LGT == LibGccType::SharedLibGcc) {
+       if (TC.getTriple().isOSCygMing())
+         CmdArgs.push_back("-l:libunwind.dll.a");

--- a/recipes-devtools/clang15/clang/0012-Pass-PYTHON_EXECUTABLE-when-cross-compiling-for-nati.patch
+++ b/recipes-devtools/clang15/clang/0012-Pass-PYTHON_EXECUTABLE-when-cross-compiling-for-nati.patch
@@ -1,0 +1,23 @@
+From e47a0db499655d06965e517f2aca297fb9c7ef8d Mon Sep 17 00:00:00 2001
+From: Anuj Mittal <anuj.mittal@intel.com>
+Date: Thu, 26 Dec 2019 12:56:16 -0800
+Subject: [PATCH] Pass PYTHON_EXECUTABLE when cross compiling for native build
+
+Signed-off-by: Anuj Mittal <anuj.mittal@intel.com>
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ llvm/cmake/modules/CrossCompile.cmake | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/llvm/cmake/modules/CrossCompile.cmake b/llvm/cmake/modules/CrossCompile.cmake
+index 52b893dd0214..4399cec3e19a 100644
+--- a/llvm/cmake/modules/CrossCompile.cmake
++++ b/llvm/cmake/modules/CrossCompile.cmake
+@@ -84,6 +84,7 @@ function(llvm_create_cross_target project_name target_name toolchain buildtype)
+         -DLLVM_ENABLE_RUNTIMES="${llvm_enable_runtimes_arg}"
+         ${external_project_source_dirs}
+         -DLLVM_TEMPORARILY_ALLOW_OLD_TOOLCHAIN="${LLVM_TEMPORARILY_ALLOW_OLD_TOOLCHAIN}"
++	-DPYTHON_EXECUTABLE="${PYTHON_EXECUTABLE}"
+         ${build_type_flags} ${linker_flag} ${external_clang_dir}
+         ${ARGN}
+     WORKING_DIRECTORY ${${project_name}_${target_name}_BUILD}

--- a/recipes-devtools/clang15/clang/0013-Check-for-atomic-double-intrinsics.patch
+++ b/recipes-devtools/clang15/clang/0013-Check-for-atomic-double-intrinsics.patch
@@ -1,0 +1,33 @@
+From 4686a186fa1b70adc646eb10fe293f47a397071b Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Mon, 18 Nov 2019 17:00:29 -0800
+Subject: [PATCH] Check for atomic<double> intrinsics
+
+On some architectures e.g. x86/32bit gcc decides to inline calls to
+double atomic variables but clang does not and defers it to libatomic
+therefore detect if clang can use built-ins for atomic<double> if not
+then link libatomic, this helps building clangd for x86 on linux systems
+with gcc runtime
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ llvm/cmake/modules/CheckAtomic.cmake | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/llvm/cmake/modules/CheckAtomic.cmake b/llvm/cmake/modules/CheckAtomic.cmake
+index 3c5ba72993a3..34a1b950bbed 100644
+--- a/llvm/cmake/modules/CheckAtomic.cmake
++++ b/llvm/cmake/modules/CheckAtomic.cmake
+@@ -30,10 +30,11 @@ function(check_working_cxx_atomics64 varname)
+ #include <atomic>
+ #include <cstdint>
+ std::atomic<uint64_t> x (0);
++std::atomic<double> y (0);
+ int main() {
+   uint64_t i = x.load(std::memory_order_relaxed);
+   (void)i;
+-  return 0;
++  return int(y);
+ }
+ " ${varname})
+   set(CMAKE_REQUIRED_FLAGS ${OLD_CMAKE_REQUIRED_FLAGS})

--- a/recipes-devtools/clang15/clang/0014-libcxx-Add-compiler-runtime-library-to-link-step-for.patch
+++ b/recipes-devtools/clang15/clang/0014-libcxx-Add-compiler-runtime-library-to-link-step-for.patch
@@ -1,0 +1,37 @@
+From c99af87e7ff2088c2fabdae236fa142fbe415ec8 Mon Sep 17 00:00:00 2001
+From: Jeremy Puhlman <jpuhlman@mvista.com>
+Date: Thu, 16 Jan 2020 21:16:10 +0000
+Subject: [PATCH] libcxx: Add compiler runtime library to link step for libcxx
+
+This corrects "undefined reference to __divti3"
+
+Upstream-Status: Inappropriate [configuration]
+
+Signed-off-by: Jeremy Puhlman <jpuhlman@mvista.com>
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ libcxx/src/CMakeLists.txt | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/libcxx/src/CMakeLists.txt b/libcxx/src/CMakeLists.txt
+index 9abf548abbb9..a16c529781c6 100644
+--- a/libcxx/src/CMakeLists.txt
++++ b/libcxx/src/CMakeLists.txt
+@@ -199,7 +199,7 @@ if (LIBCXX_ENABLE_SHARED)
+   add_library(cxx_shared SHARED ${exclude_from_all} ${LIBCXX_SOURCES} ${LIBCXX_HEADERS})
+   target_include_directories(cxx_shared PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+   target_link_libraries(cxx_shared PUBLIC cxx-headers
+-                                   PRIVATE ${LIBCXX_LIBRARIES})
++                                   PRIVATE ${LIBCXX_LIBRARIES} "$$($$CC --print-libgcc-file-name)")
+   set_target_properties(cxx_shared
+     PROPERTIES
+       COMPILE_FLAGS "${LIBCXX_COMPILE_FLAGS}"
+@@ -283,7 +283,7 @@ if (LIBCXX_ENABLE_STATIC)
+   add_library(cxx_static STATIC ${exclude_from_all} ${LIBCXX_SOURCES} ${LIBCXX_HEADERS})
+   target_include_directories(cxx_static PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+   target_link_libraries(cxx_static PUBLIC cxx-headers
+-                                   PRIVATE ${LIBCXX_LIBRARIES}
++                                   PRIVATE ${LIBCXX_LIBRARIES} "$$($$CC --print-libgcc-file-name)"
+                                    PRIVATE libcxx-abi-static)
+   set_target_properties(cxx_static
+     PROPERTIES

--- a/recipes-devtools/clang15/clang/0015-clang-llvm-cmake-Fix-configure-for-packages-using-fi.patch
+++ b/recipes-devtools/clang15/clang/0015-clang-llvm-cmake-Fix-configure-for-packages-using-fi.patch
@@ -1,0 +1,116 @@
+From a85b06f3aa67a35b65fe2742d6ca53c949235198 Mon Sep 17 00:00:00 2001
+From: Ovidiu Panait <ovidiu.panait@windriver.com>
+Date: Fri, 31 Jan 2020 10:56:11 +0200
+Subject: [PATCH] clang,llvm: cmake: Fix configure for packages using
+ find_package()
+
+Currently, when a package (i.e. bcc [https://github.com/iovisor/bcc.git])
+that depends on LLVM/Clang tries to run cmake find_package() during
+do_configure, it will fail with a similar error:
+
+|   The imported target "llvm-tblgen" references the file
+|      ".../recipe-sysroot/usr/bin/llvm-tblgen"
+|
+|   but this file does not exist.  Possible reasons include:
+|   * The file was deleted, renamed, or moved to another location.
+|   * An install or uninstall procedure did not complete successfully.
+|   * The installation package was faulty and contained
+|      ".../recipe-sysroot/usr/lib/cmake/LLVMExports.cmake"
+|   but not all the files it references.
+
+This is due to the fact that currently the cmake scripts look for target
+binaries in sysroot. Work around this by not exporting the target binaries in
+Exports-* cmake files.
+
+Upstream-Status: Inappropriate [oe-specific]
+
+Signed-off-by: Ovidiu Panait <ovidiu.panait@windriver.com>
+---
+ clang/cmake/modules/AddClang.cmake | 2 --
+ llvm/cmake/modules/AddLLVM.cmake   | 6 ------
+ llvm/cmake/modules/TableGen.cmake  | 7 -------
+ 3 files changed, 15 deletions(-)
+
+diff --git a/clang/cmake/modules/AddClang.cmake b/clang/cmake/modules/AddClang.cmake
+index 21ac332e4f5f..86c93cfec59d 100644
+--- a/clang/cmake/modules/AddClang.cmake
++++ b/clang/cmake/modules/AddClang.cmake
+@@ -165,7 +165,6 @@ macro(add_clang_tool name)
+     if (CLANG_BUILD_TOOLS)
+       get_target_export_arg(${name} Clang export_to_clangtargets)
+       install(TARGETS ${name}
+-        ${export_to_clangtargets}
+         RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+         COMPONENT ${name})
+ 
+@@ -174,7 +173,6 @@ macro(add_clang_tool name)
+                                  DEPENDS ${name}
+                                  COMPONENT ${name})
+       endif()
+-      set_property(GLOBAL APPEND PROPERTY CLANG_EXPORTS ${name})
+     endif()
+   endif()
+ endmacro()
+diff --git a/llvm/cmake/modules/AddLLVM.cmake b/llvm/cmake/modules/AddLLVM.cmake
+index 057431208322..e7c77e824d58 100644
+--- a/llvm/cmake/modules/AddLLVM.cmake
++++ b/llvm/cmake/modules/AddLLVM.cmake
+@@ -1299,7 +1299,6 @@ macro(llvm_add_tool project name)
+       if( LLVM_BUILD_TOOLS )
+         get_target_export_arg(${name} LLVM export_to_llvmexports)
+         install(TARGETS ${name}
+-                ${export_to_llvmexports}
+                 RUNTIME DESTINATION ${${project}_TOOLS_INSTALL_DIR}
+                 COMPONENT ${name})
+ 
+@@ -1310,9 +1309,6 @@ macro(llvm_add_tool project name)
+         endif()
+       endif()
+     endif()
+-    if( LLVM_BUILD_TOOLS )
+-      set_property(GLOBAL APPEND PROPERTY LLVM_EXPORTS ${name})
+-    endif()
+     set_target_properties(${name} PROPERTIES FOLDER "Tools")
+   endif()
+ endmacro(llvm_add_tool project name)
+@@ -1357,7 +1353,6 @@ macro(add_llvm_utility name)
+     if (LLVM_INSTALL_UTILS AND LLVM_BUILD_UTILS)
+       get_target_export_arg(${name} LLVM export_to_llvmexports)
+       install(TARGETS ${name}
+-              ${export_to_llvmexports}
+               RUNTIME DESTINATION ${LLVM_UTILS_INSTALL_DIR}
+               COMPONENT ${name})
+ 
+@@ -1366,7 +1361,6 @@ macro(add_llvm_utility name)
+                                  DEPENDS ${name}
+                                  COMPONENT ${name})
+       endif()
+-      set_property(GLOBAL APPEND PROPERTY LLVM_EXPORTS ${name})
+     elseif(LLVM_BUILD_UTILS)
+       set_property(GLOBAL APPEND PROPERTY LLVM_EXPORTS_BUILDTREE_ONLY ${name})
+     endif()
+diff --git a/llvm/cmake/modules/TableGen.cmake b/llvm/cmake/modules/TableGen.cmake
+index 4711456776c8..857392499525 100644
+--- a/llvm/cmake/modules/TableGen.cmake
++++ b/llvm/cmake/modules/TableGen.cmake
+@@ -187,14 +187,8 @@ macro(add_tablegen target project)
+   endif()
+ 
+   if ((${project} STREQUAL LLVM OR ${project} STREQUAL MLIR) AND NOT LLVM_INSTALL_TOOLCHAIN_ONLY AND LLVM_BUILD_UTILS)
+-    set(export_to_llvmexports)
+-    if(${target} IN_LIST LLVM_DISTRIBUTION_COMPONENTS OR
+-        NOT LLVM_DISTRIBUTION_COMPONENTS)
+-      set(export_to_llvmexports EXPORT LLVMExports)
+-    endif()
+ 
+     install(TARGETS ${target}
+-            ${export_to_llvmexports}
+             COMPONENT ${target}
+             RUNTIME DESTINATION "${${project}_TOOLS_INSTALL_DIR}")
+     if(NOT LLVM_ENABLE_IDE)
+@@ -203,5 +197,4 @@ macro(add_tablegen target project)
+                                COMPONENT ${target})
+     endif()
+   endif()
+-  set_property(GLOBAL APPEND PROPERTY LLVM_EXPORTS ${target})
+ endmacro()

--- a/recipes-devtools/clang15/clang/0016-clang-Fix-resource-dir-location-for-cross-toolchains.patch
+++ b/recipes-devtools/clang15/clang/0016-clang-Fix-resource-dir-location-for-cross-toolchains.patch
@@ -1,0 +1,39 @@
+From 96c42b814881a7548d3d6a74423bf47b85482ca9 Mon Sep 17 00:00:00 2001
+From: Jim Broadus <jbroadus@xevo.com>
+Date: Thu, 26 Mar 2020 16:05:53 -0700
+Subject: [PATCH] clang: Fix resource dir location for cross toolchains
+
+When clang looks for the resources directory, it does so based on the binary
+location and assumes that the containing directory is a sibling to lib. The
+Yocto cross.bbclass defines the default bindir as
+${exec_prefix}/bin/${CROSS_TARGET_SYS_DIR}. ex: /usr/bin/aarch64-poky-linux/.
+This causes clang to form a path that looks like /usr/bin/lib/clang/...
+
+As a fix for this, check the parent directory name. If that is "bin", then
+use that directory's parent.
+
+Signed-off-by: Jim Broadus <jbroadus@xevo.com>
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ clang/lib/Driver/Driver.cpp | 8 +++++++-
+ 1 file changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/clang/lib/Driver/Driver.cpp b/clang/lib/Driver/Driver.cpp
+index 3f29afd35971..45f2e0bede97 100644
+--- a/clang/lib/Driver/Driver.cpp
++++ b/clang/lib/Driver/Driver.cpp
+@@ -179,7 +179,13 @@ std::string Driver::GetResourcesPath(StringRef BinaryPath,
+     // With a static-library build of libclang, LibClangPath will contain the
+     // path of the embedding binary, which for LLVM binaries will be in bin/.
+     // ../lib gets us to lib/ in both cases.
+-    P = llvm::sys::path::parent_path(Dir);
++    Dir = std::string(llvm::sys::path::parent_path(Dir));
++
++    // OE cross toolchains are installed, by default, in a subdir of bin.
++    if (llvm::sys::path::filename(Dir) == "bin") {
++      Dir = std::string(llvm::sys::path::parent_path(Dir));
++    }
++    P = Dir;
+     llvm::sys::path::append(P, Twine("lib") + CLANG_LIBDIR_SUFFIX, "clang",
+                             CLANG_VERSION_STRING);
+   }

--- a/recipes-devtools/clang15/clang/0017-clang-driver-Add-dyld-prefix-when-checking-sysroot-f.patch
+++ b/recipes-devtools/clang15/clang/0017-clang-driver-Add-dyld-prefix-when-checking-sysroot-f.patch
@@ -1,0 +1,67 @@
+From 1669b300c9460e1cf1ebcff9ee9bfb7e499c9d95 Mon Sep 17 00:00:00 2001
+From: Oleksandr Ocheretnyi <oocheret@cisco.com>
+Date: Wed, 15 Apr 2020 00:08:39 +0300
+Subject: [PATCH] clang: driver: Add dyld-prefix when checking sysroot for ldso
+ path
+
+ * the dyld-prefix shall be taken into account when the default
+   path for the dynamic linker has to be checked.
+
+ * this patch shall be used as annex to the next patch:
+   'clang: driver: Check sysroot for ldso path' which includes
+   the usrmerge scenario.
+
+Signed-off-by: Oleksandr Ocheretnyi <oocheret@cisco.com>
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ clang/lib/Driver/ToolChains/Linux.cpp | 16 ++++++++--------
+ 1 file changed, 8 insertions(+), 8 deletions(-)
+
+diff --git a/clang/lib/Driver/ToolChains/Linux.cpp b/clang/lib/Driver/ToolChains/Linux.cpp
+index 7555466e7e2b..27951858fb5d 100644
+--- a/clang/lib/Driver/ToolChains/Linux.cpp
++++ b/clang/lib/Driver/ToolChains/Linux.cpp
+@@ -508,8 +508,8 @@ std::string Linux::getDynamicLinker(const ArgList &Args) const {
+     LibDir = "lib64";
+     Loader =
+         (tools::ppc::hasPPCAbiArg(Args, "elfv2")) ? "ld64.so.2" : "ld64.so.1";
+-    if (!getVFS().exists(getDriver().SysRoot + "/" + LibDir + "/" + Loader) &&
+-         getVFS().exists(getDriver().SysRoot + "/lib/" + Loader)) {
++    if (!getVFS().exists(getDriver().SysRoot + getDriver().DyldPrefix + "/" + LibDir + "/" + Loader) &&
++         getVFS().exists(getDriver().SysRoot + getDriver().DyldPrefix + "/lib/" + Loader)) {
+         LibDir = "lib";
+     }
+     break;
+@@ -517,8 +517,8 @@ std::string Linux::getDynamicLinker(const ArgList &Args) const {
+     LibDir = "lib64";
+     Loader =
+         (tools::ppc::hasPPCAbiArg(Args, "elfv1")) ? "ld64.so.1" : "ld64.so.2";
+-    if (!getVFS().exists(getDriver().SysRoot + "/" + LibDir + "/" + Loader) &&
+-         getVFS().exists(getDriver().SysRoot + "/lib/" + Loader)) {
++    if (!getVFS().exists(getDriver().SysRoot + getDriver().DyldPrefix + "/" + LibDir + "/" + Loader) &&
++         getVFS().exists(getDriver().SysRoot + getDriver().DyldPrefix + "/lib/" + Loader)) {
+         LibDir = "lib";
+     }
+     break;
+@@ -542,8 +542,8 @@ std::string Linux::getDynamicLinker(const ArgList &Args) const {
+   case llvm::Triple::sparcv9:
+     LibDir = "lib64";
+     Loader = "ld-linux.so.2";
+-    if (!getVFS().exists(getDriver().SysRoot + "/" + LibDir + "/" + Loader) &&
+-         getVFS().exists(getDriver().SysRoot + "/lib/" + Loader)) {
++    if (!getVFS().exists(getDriver().SysRoot + getDriver().DyldPrefix + "/" + LibDir + "/" + Loader) &&
++         getVFS().exists(getDriver().SysRoot + getDriver().DyldPrefix + "/lib/" + Loader)) {
+         LibDir = "lib";
+     }
+     break;
+@@ -560,8 +560,8 @@ std::string Linux::getDynamicLinker(const ArgList &Args) const {
+ 
+     LibDir = X32 ? "libx32" : "lib64";
+     Loader = X32 ? "ld-linux-x32.so.2" : "ld-linux-x86-64.so.2";
+-    if (!getVFS().exists(getDriver().SysRoot + "/" + LibDir + "/" + Loader) &&
+-         getVFS().exists(getDriver().SysRoot + "/lib/" + Loader)) {
++    if (!getVFS().exists(getDriver().SysRoot + getDriver().DyldPrefix + "/" + LibDir + "/" + Loader) &&
++         getVFS().exists(getDriver().SysRoot + getDriver().DyldPrefix + "/lib/" + Loader)) {
+         LibDir = "lib";
+     }
+     break;

--- a/recipes-devtools/clang15/clang/0018-clang-Use-python3-in-python-scripts.patch
+++ b/recipes-devtools/clang15/clang/0018-clang-Use-python3-in-python-scripts.patch
@@ -1,0 +1,68 @@
+From 88fb7548f93674b4ec1e5e7f3e096791bd32ed42 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Wed, 14 Oct 2020 22:19:57 -0700
+Subject: [PATCH] clang: Use python3 in python scripts
+
+Some scripts ask for python, but they work fine with python3
+and in OE python symlink is not exposed to build, only python3 is
+
+Upstream-Status: Pending
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ .../find-all-symbols/tool/run-find-all-symbols.py               | 2 +-
+ clang-tools-extra/clang-tidy/add_new_check.py                   | 2 +-
+ clang-tools-extra/clang-tidy/rename_check.py                    | 2 +-
+ clang-tools-extra/clang-tidy/tool/clang-tidy-diff.py            | 2 +-
+ clang/tools/scan-view/bin/scan-view                             | 2 +-
+ 5 files changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/clang-tools-extra/clang-include-fixer/find-all-symbols/tool/run-find-all-symbols.py b/clang-tools-extra/clang-include-fixer/find-all-symbols/tool/run-find-all-symbols.py
+index 8655af137bb2..e95ba59a421c 100755
+--- a/clang-tools-extra/clang-include-fixer/find-all-symbols/tool/run-find-all-symbols.py
++++ b/clang-tools-extra/clang-include-fixer/find-all-symbols/tool/run-find-all-symbols.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python3
+ #
+ #=- run-find-all-symbols.py - Parallel find-all-symbols runner -*- python  -*-=#
+ #
+diff --git a/clang-tools-extra/clang-tidy/add_new_check.py b/clang-tools-extra/clang-tidy/add_new_check.py
+index 19b6896e508f..a85767acdce9 100644
+--- a/clang-tools-extra/clang-tidy/add_new_check.py
++++ b/clang-tools-extra/clang-tidy/add_new_check.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python3
+ #
+ #===- add_new_check.py - clang-tidy check generator ---------*- python -*--===#
+ #
+diff --git a/clang-tools-extra/clang-tidy/rename_check.py b/clang-tools-extra/clang-tidy/rename_check.py
+index 9c2021751e0e..4bb9af8cbe0a 100755
+--- a/clang-tools-extra/clang-tidy/rename_check.py
++++ b/clang-tools-extra/clang-tidy/rename_check.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python3
+ #
+ #===- rename_check.py - clang-tidy check renamer ------------*- python -*--===#
+ #
+diff --git a/clang-tools-extra/clang-tidy/tool/clang-tidy-diff.py b/clang-tools-extra/clang-tidy/tool/clang-tidy-diff.py
+index a26d2144b7f9..396a201b667e 100755
+--- a/clang-tools-extra/clang-tidy/tool/clang-tidy-diff.py
++++ b/clang-tools-extra/clang-tidy/tool/clang-tidy-diff.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python3
+ #
+ #===- clang-tidy-diff.py - ClangTidy Diff Checker -----------*- python -*--===#
+ #
+diff --git a/clang/tools/scan-view/bin/scan-view b/clang/tools/scan-view/bin/scan-view
+index 6165432e7af8..07effbca5969 100755
+--- a/clang/tools/scan-view/bin/scan-view
++++ b/clang/tools/scan-view/bin/scan-view
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python3
+ 
+ from __future__ import print_function
+ 

--- a/recipes-devtools/clang15/clang/0019-For-x86_64-set-Yocto-based-GCC-install-search-path.patch
+++ b/recipes-devtools/clang15/clang/0019-For-x86_64-set-Yocto-based-GCC-install-search-path.patch
@@ -1,0 +1,70 @@
+From c9b225aeeb3d2b1d98d823c9a6c8afc613fc932b Mon Sep 17 00:00:00 2001
+From: Hongxu Jia <hongxu.jia@windriver.com>
+Date: Mon, 25 Jan 2021 16:14:35 +0800
+Subject: [PATCH] For x86_64, set Yocto based GCC install search path
+
+Under Yocto host, while using clang-native to build, it searches
+install host gcc failed which causing the include file not found
+[snip]
+|clang++ -target x86_64-linux  -MMD -MF src/base/files/file_path_constants.o.d -I../../../tools/gn/src -I. \
+-isystem/tmp-glibc/work/x86_64-linux/gn-native/87.0.4280.141-r0/recipe-sysroot-native/usr/include -O2 -pipe \
+-std=c++17 -c ../../../tools/gn/src/base/files/file_path_constants.cc -o src/base/files/file_path_constants.o
+|../../../tools/gn/src/base/files/file_path_constants.cc:7:10: fatal error: 'iterator' file not found
+|#include <iterator>
+|         ^~~~~~~~
+[snip]
+
+Set three Yocto based GCC triple: poky, oe-core and wind river
+
+Before aplly the patch
+[snip]
+$ ../recipe-sysroot-native/usr/bin/clang++ -v
+clang version 11.0.1 (https://github.com/llvm/llvm-project 43ff75f2c3feef64f9d73328230d34dac8832a91)
+Target: x86_64-unknown-linux-gnu
+Thread model: posix
+InstalledDir:tmp-glibc/work/x86_64-linux/gn-native/87.0.4280.141-r0/chromium-87.0.4280.141/../recipe-sysroot-native/usr/bin
+[snip]
+
+After aplly the patch:
+[snip]
+$ ../recipe-sysroot-native/usr/bin/clang++ -v
+clang version 11.0.1 (https://github.com/llvm/llvm-project 22c3241ff9a6224261df48d0258957fd8acc3d64)
+Target: x86_64-unknown-linux-gnu
+Thread model: posix
+InstalledDir:tmp-glibc/work/x86_64-linux/gn-native/87.0.4280.141-r0/chromium-87.0.4280.141/../recipe-sysroot-native/usr/bin
+Found candidate GCC installation: /usr/lib//x86_64-wrs-linux/10.1.0
+Found candidate GCC installation: /usr/lib/gcc/x86_64-wrs-linux/10.1.0
+Selected GCC installation: /usr/lib//x86_64-wrs-linux/10.1.0
+Candidate multilib: .;@m64
+Selected multilib: .;@m64
+[snip]
+
+BTW, it is hardly to insert a triple by the replacement of TARGET_SYS
+(=${TARGET_ARCH}${TARGET_VENDOR}-${TARGET_OS}), since TARGET_VENDOR
+is different between clang and clang-native
+
+The //CLANG_EXTRA_OE_VENDORS_TRIPLES string is replaced with list of
+additional triples based on CLANG_EXTRA_OE_VENDORS variable in
+recipes-devtools/clang/llvm-project-source.inc:add_more_target_vendors()
+
+Upstream-Status: Inappropriate [oe specific]
+
+Signed-off-by: Martin Jansa <martin.jansa@gmail.com>
+Signed-off-by: Hongxu Jia <hongxu.jia@windriver.com>
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ clang/lib/Driver/ToolChains/Gnu.cpp | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/clang/lib/Driver/ToolChains/Gnu.cpp b/clang/lib/Driver/ToolChains/Gnu.cpp
+index bddc77cde2d6..5b4271b58337 100644
+--- a/clang/lib/Driver/ToolChains/Gnu.cpp
++++ b/clang/lib/Driver/ToolChains/Gnu.cpp
+@@ -2224,6 +2224,7 @@ void Generic_GCC::GCCInstallationDetector::AddDefaultGCCPrefixes(
+       "x86_64-redhat-linux",    "x86_64-suse-linux",
+       "x86_64-manbo-linux-gnu", "x86_64-linux-gnu",
+       "x86_64-slackware-linux", "x86_64-unknown-linux",
++      "x86_64-oe-linux",//CLANG_EXTRA_OE_VENDORS_TRIPLES
+       "x86_64-amazon-linux"};
+   static const char *const X32Triples[] = {"x86_64-linux-gnux32",
+                                            "x86_64-pc-linux-gnux32"};

--- a/recipes-devtools/clang15/clang/0020-llvm-Do-not-use-find_library-for-ncurses.patch
+++ b/recipes-devtools/clang15/clang/0020-llvm-Do-not-use-find_library-for-ncurses.patch
@@ -1,0 +1,44 @@
+From 77c05d78ece8599932dc7c53aa43d153471ea13c Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Sun, 7 Feb 2021 23:58:41 -0800
+Subject: [PATCH] llvm: Do not use find_library for ncurses
+
+This ensures that it lets OE to decide which lib to link
+otherwise it adds absolute paths to linker cmdline and confuses it
+horribly with native and target libs when build clang for target
+
+TOPDIR/build/tmp/work/cortexa57-yoe-linux-musl/clang/12.0.0-r0/recipe-sysroot-native/usr/lib/libtinfo.so: error adding symbols: file in wrong format
+clang-12: error: linker command failed with exit code 1 (use -v to see invocation)
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ compiler-rt/cmake/config-ix.cmake     | 2 +-
+ llvm/cmake/modules/FindTerminfo.cmake | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/compiler-rt/cmake/config-ix.cmake b/compiler-rt/cmake/config-ix.cmake
+index cd45176cf2ba..73948a0274cd 100644
+--- a/compiler-rt/cmake/config-ix.cmake
++++ b/compiler-rt/cmake/config-ix.cmake
+@@ -160,7 +160,7 @@ else()
+   set(MAYBE_REQUIRED)
+ endif()
+ if(LLVM_ENABLE_TERMINFO)
+-  find_library(COMPILER_RT_TERMINFO_LIB NAMES terminfo tinfo curses ncurses ncursesw ${MAYBE_REQUIRED})
++  find_library(COMPILER_RT_TERMINFO_LIB NAMES terminfo tinfo curses ncurses ncursesw ${MAYBE_REQUIRED} NO_DEFAULT_PATH NO_CMAKE_FIND_ROOT_PATH)
+ endif()
+ if(COMPILER_RT_TERMINFO_LIB)
+   set(LLVM_ENABLE_TERMINFO 1)
+diff --git a/llvm/cmake/modules/FindTerminfo.cmake b/llvm/cmake/modules/FindTerminfo.cmake
+index 65edb80fa69a..a58180be8926 100644
+--- a/llvm/cmake/modules/FindTerminfo.cmake
++++ b/llvm/cmake/modules/FindTerminfo.cmake
+@@ -11,7 +11,7 @@
+ # Additionally, the following import target will be defined:
+ # Terminfo::terminfo
+ 
+-find_library(Terminfo_LIBRARIES NAMES terminfo tinfo curses ncurses ncursesw)
++find_library(Terminfo_LIBRARIES NAMES terminfo tinfo curses ncurses ncursesw NO_DEFAULT_PATH NO_CMAKE_FIND_ROOT_PATH)
+ 
+ if(Terminfo_LIBRARIES)
+   include(CMakePushCheckState)

--- a/recipes-devtools/clang15/clang/0021-llvm-Insert-anchor-for-adding-OE-distro-vendor-names.patch
+++ b/recipes-devtools/clang15/clang/0021-llvm-Insert-anchor-for-adding-OE-distro-vendor-names.patch
@@ -1,0 +1,32 @@
+From addc8d02106241de5c0913fa302c4cca8c6f95ec Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Thu, 11 Feb 2021 16:42:49 -0800
+Subject: [PATCH] llvm: Insert anchor for adding OE distro vendor names
+
+This helps in making right detection for OE built gcc toolchains
+
+The //CLANG_EXTRA_OE_VENDORS_CASES string is replaced with list of
+additional Ceses based on CLANG_EXTRA_OE_VENDORS variable in
+recipes-devtools/clang/llvm-project-source.inc:add_more_target_vendors()
+
+Upstream-Status: Inappropriate [OE-specific]
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+Signed-off-by: Martin Jansa <martin.jansa@gmail.com>
+---
+ llvm/lib/Support/Triple.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/llvm/lib/Support/Triple.cpp b/llvm/lib/Support/Triple.cpp
+index 6696d158b2c1..c5aea898ab24 100644
+--- a/llvm/lib/Support/Triple.cpp
++++ b/llvm/lib/Support/Triple.cpp
+@@ -542,7 +542,7 @@ static Triple::VendorType parseVendor(StringRef VendorName) {
+     .Case("amd", Triple::AMD)
+     .Case("mesa", Triple::Mesa)
+     .Case("suse", Triple::SUSE)
+-    .Case("oe", Triple::OpenEmbedded)
++    .Case("oe", Triple::OpenEmbedded)//CLANG_EXTRA_OE_VENDORS_CASES
+     .Default(Triple::UnknownVendor);
+ }
+ 

--- a/recipes-devtools/clang15/clang/0022-compiler-rt-Do-not-use-backtrace-APIs-on-non-glibc-l.patch
+++ b/recipes-devtools/clang15/clang/0022-compiler-rt-Do-not-use-backtrace-APIs-on-non-glibc-l.patch
@@ -1,0 +1,68 @@
+From e83ac76ea900deb1b12ad97e1241f67c305a9c04 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Wed, 19 May 2021 17:32:13 -0700
+Subject: [PATCH] compiler-rt: Do not use backtrace APIs on non-glibc linux
+
+musl e.g. does not provide backtrace APIs
+
+Upstream-Status: Pending
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ .../lib/gwp_asan/optional/backtrace_linux_libc.cpp  | 13 ++++++++++++-
+ 1 file changed, 12 insertions(+), 1 deletion(-)
+
+diff --git a/compiler-rt/lib/gwp_asan/optional/backtrace_linux_libc.cpp b/compiler-rt/lib/gwp_asan/optional/backtrace_linux_libc.cpp
+index ea8e72be287d..0344074dd254 100644
+--- a/compiler-rt/lib/gwp_asan/optional/backtrace_linux_libc.cpp
++++ b/compiler-rt/lib/gwp_asan/optional/backtrace_linux_libc.cpp
+@@ -7,7 +7,9 @@
+ //===----------------------------------------------------------------------===//
+ 
+ #include <assert.h>
++#ifdef __GLIBC__
+ #include <execinfo.h>
++#endif
+ #include <stddef.h>
+ #include <stdint.h>
+ #include <stdlib.h>
+@@ -21,8 +23,11 @@
+ namespace {
+ size_t Backtrace(uintptr_t *TraceBuffer, size_t Size) {
+   static_assert(sizeof(uintptr_t) == sizeof(void *), "uintptr_t is not void*");
+-
++#ifdef __GLIBC__
+   return backtrace(reinterpret_cast<void **>(TraceBuffer), Size);
++#else
++  return -1;
++#endif
+ }
+ 
+ // We don't need any custom handling for the Segv backtrace - the libc unwinder
+@@ -30,7 +35,11 @@ size_t Backtrace(uintptr_t *TraceBuffer, size_t Size) {
+ // to avoid the additional frame.
+ GWP_ASAN_ALWAYS_INLINE size_t SegvBacktrace(uintptr_t *TraceBuffer, size_t Size,
+                                             void * /*Context*/) {
++#ifdef __GLIBC__
+   return Backtrace(TraceBuffer, Size);
++#else
++  return -1;
++#endif
+ }
+ 
+ static void PrintBacktrace(uintptr_t *Trace, size_t TraceLength,
+@@ -40,6 +49,7 @@ static void PrintBacktrace(uintptr_t *Trace, size_t TraceLength,
+     return;
+   }
+ 
++#ifdef __GLIBC__
+   char **BacktraceSymbols =
+       backtrace_symbols(reinterpret_cast<void **>(Trace), TraceLength);
+ 
+@@ -53,6 +63,7 @@ static void PrintBacktrace(uintptr_t *Trace, size_t TraceLength,
+   Printf("\n");
+   if (BacktraceSymbols)
+     free(BacktraceSymbols);
++#endif
+ }
+ } // anonymous namespace
+ 

--- a/recipes-devtools/clang15/clang/0023-clang-Fix-x86-triple-for-non-debian-multiarch-linux-.patch
+++ b/recipes-devtools/clang15/clang/0023-clang-Fix-x86-triple-for-non-debian-multiarch-linux-.patch
@@ -1,0 +1,27 @@
+From 54a8c40d02d02e169f0e646e419e7f72305646af Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Wed, 19 May 2021 17:56:03 -0700
+Subject: [PATCH] clang: Fix x86 triple for non-debian multiarch linux distros
+
+OpenEmbedded does not hardcode mutli-arch like debian therefore ensure
+that it still uses the proper tuple
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ clang/lib/Driver/ToolChains/Linux.cpp | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/clang/lib/Driver/ToolChains/Linux.cpp b/clang/lib/Driver/ToolChains/Linux.cpp
+index 27951858fb5d..aac45650f97b 100644
+--- a/clang/lib/Driver/ToolChains/Linux.cpp
++++ b/clang/lib/Driver/ToolChains/Linux.cpp
+@@ -657,6 +657,9 @@ void Linux::addLibStdCxxIncludePaths(const llvm::opt::ArgList &DriverArgs,
+       GCCInstallation.getTriple().getArch() == llvm::Triple::x86
+           ? "i386-linux-gnu"
+           : TripleStr;
++  // OpenEmbedded does not hardcode the triple to i386-linux-gnu like debian
++  if (GCCInstallation.getTriple().getVendor() == llvm::Triple::OpenEmbedded)
++	  DebianMultiarch = TripleStr;
+ 
+   // Try generic GCC detection first.
+   if (Generic_GCC::addGCCLibStdCxxIncludePaths(DriverArgs, CC1Args,

--- a/recipes-devtools/clang15/clang/0024-compiler-rt-Link-scudo-with-SANITIZER_CXX_ABI_LIBRAR.patch
+++ b/recipes-devtools/clang15/clang/0024-compiler-rt-Link-scudo-with-SANITIZER_CXX_ABI_LIBRAR.patch
@@ -1,0 +1,28 @@
+From 458b502f8fabf9559d5323225a9ce746fabc05e7 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Wed, 19 May 2021 21:49:18 -0700
+Subject: [PATCH] compiler-rt: Link scudo with SANITIZER_CXX_ABI_LIBRARIES
+
+If SANITIZER_CXX_ABI_LIBRARIES is set then link scudo with it, this
+fixes build time errors like
+
+projects/compiler-rt/lib/sanitizer_common/CMakeFiles/RTSanitizerCommonLibc.armhf.dir/sanitizer_posix_libcdep.cpp.o: in function `__sanitizer::UnsetAlternateSignalStack()':
+| sanitizer_posix_libcdep.cpp:(.text+0x3d2): undefined reference to `__cxa_guard_acquire'
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ compiler-rt/lib/scudo/CMakeLists.txt | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/compiler-rt/lib/scudo/CMakeLists.txt b/compiler-rt/lib/scudo/CMakeLists.txt
+index 31a6976960f7..8f3e291960b0 100644
+--- a/compiler-rt/lib/scudo/CMakeLists.txt
++++ b/compiler-rt/lib/scudo/CMakeLists.txt
+@@ -15,6 +15,7 @@ append_list_if(COMPILER_RT_HAS_LIBDL dl SCUDO_MINIMAL_DYNAMIC_LIBS)
+ append_list_if(COMPILER_RT_HAS_LIBRT rt SCUDO_MINIMAL_DYNAMIC_LIBS)
+ append_list_if(COMPILER_RT_HAS_LIBPTHREAD pthread SCUDO_MINIMAL_DYNAMIC_LIBS)
+ append_list_if(COMPILER_RT_HAS_LIBLOG log SCUDO_MINIMAL_DYNAMIC_LIBS)
++append_list_if(SANITIZER_CXX_ABI_LIBRARIES ${SANITIZER_CXX_ABI_LIBRARIES} SCUDO_MINIMAL_DYNAMIC_LIBS)
+ append_list_if(COMPILER_RT_HAS_OMIT_FRAME_POINTER_FLAG -fno-omit-frame-pointer
+                SCUDO_CFLAGS)
+ 

--- a/recipes-devtools/clang15/clang/0025-libunwind-Added-unw_backtrace-method.patch
+++ b/recipes-devtools/clang15/clang/0025-libunwind-Added-unw_backtrace-method.patch
@@ -1,0 +1,55 @@
+From 85855552afe94097eaaa0adf904d016af66b3424 Mon Sep 17 00:00:00 2001
+From: Maksim Kita <maksim-kita@yandex-team.ru>
+Date: Sun, 23 May 2021 10:27:29 +0000
+Subject: [PATCH] libunwind: Added unw_backtrace method
+
+Source: https://github.com/ClickHouse-Extras/libunwind/commit/52f0f7861926cbfaef7e6c97d8a6d7ba2a1f6747#diff-a82fc885e2e4facf4b92d26171c13aa4aa5db296f77e1158ba2f8664e3bd1f5c
+Upstream-Status: Pending
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ libunwind/include/libunwind.h |  1 +
+ libunwind/src/libunwind.cpp   | 18 ++++++++++++++++++
+ 2 files changed, 19 insertions(+)
+
+diff --git a/libunwind/include/libunwind.h b/libunwind/include/libunwind.h
+index f878b46f0348..d922f84011ee 100644
+--- a/libunwind/include/libunwind.h
++++ b/libunwind/include/libunwind.h
+@@ -130,6 +130,7 @@ extern int unw_is_fpreg(unw_cursor_t *, unw_regnum_t) LIBUNWIND_AVAIL;
+ extern int unw_is_signal_frame(unw_cursor_t *) LIBUNWIND_AVAIL;
+ extern int unw_get_proc_name(unw_cursor_t *, char *, size_t, unw_word_t *) LIBUNWIND_AVAIL;
+ //extern int       unw_get_save_loc(unw_cursor_t*, int, unw_save_loc_t*);
++extern int unw_backtrace(void **, int) LIBUNWIND_AVAIL;
+ 
+ extern unw_addr_space_t unw_local_addr_space;
+ 
+diff --git a/libunwind/src/libunwind.cpp b/libunwind/src/libunwind.cpp
+index b8b41ff25e54..ca7d9a01e631 100644
+--- a/libunwind/src/libunwind.cpp
++++ b/libunwind/src/libunwind.cpp
+@@ -338,7 +338,25 @@ void __unw_remove_dynamic_eh_frame_section(unw_word_t eh_frame_start) {
+ #endif // defined(_LIBUNWIND_SUPPORT_DWARF_UNWIND)
+ #endif // !defined(__USING_SJLJ_EXCEPTIONS__)
+ 
++int unw_backtrace(void **buffer, int size) {
++  unw_context_t context;
++  unw_cursor_t cursor;
++  if (unw_getcontext(&context) || unw_init_local(&cursor, &context)) {
++    return 0;
++  }
++
++  unw_word_t ip;
++  int current = 0;
++  while (unw_step(&cursor) > 0) {
++    if (current >= size || unw_get_reg(&cursor, UNW_REG_IP, &ip)) {
++      break;
++    }
+ 
++    buffer[current++] = reinterpret_cast<void *>(static_cast<uintptr_t>(ip));
++  }
++
++  return current;
++}
+ 
+ // Add logging hooks in Debug builds only
+ #ifndef NDEBUG

--- a/recipes-devtools/clang15/clang/0026-clang-Do-not-use-install-relative-libc-headers.patch
+++ b/recipes-devtools/clang15/clang/0026-clang-Do-not-use-install-relative-libc-headers.patch
@@ -1,0 +1,32 @@
+From 176d5b0f6a46f015854eb48f34922bc34a999d2f Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Wed, 11 Aug 2021 18:37:11 -0700
+Subject: [PATCH] clang: Do not use install relative libc++ headers
+
+In OE we use same clang for native and cross builds, therefore we need
+to ensure that native sysroot install of libc++ is not searched for
+headers when doing cross compile instead it searches the target sysroot
+this is especially troublesome when libcxx-native is staged along with
+libcxx e.g. chromium
+
+Upstream-Status: Pending
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ clang/lib/Driver/ToolChains/Gnu.cpp | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/clang/lib/Driver/ToolChains/Gnu.cpp b/clang/lib/Driver/ToolChains/Gnu.cpp
+index 5b4271b58337..107ab8d78598 100644
+--- a/clang/lib/Driver/ToolChains/Gnu.cpp
++++ b/clang/lib/Driver/ToolChains/Gnu.cpp
+@@ -3049,7 +3049,9 @@ Generic_GCC::addLibCxxIncludePaths(const llvm::opt::ArgList &DriverArgs,
+ 
+   // Android never uses the libc++ headers installed alongside the toolchain,
+   // which are generally incompatible with the NDK libraries anyway.
+-  if (!getTriple().isAndroid())
++  // And also do not add it when --sysroot is specified, since it would expect
++  // libc++ headers from sysroot
++  if (!getTriple().isAndroid() && SysRoot.empty())
+     if (AddIncludePath(getDriver().Dir + "/../include"))
+       return;
+   // If this is a development, non-installed, clang, libcxx will

--- a/recipes-devtools/clang15/clang/0027-clang-Fix-how-driver-finds-GCC-installation-path-on-.patch
+++ b/recipes-devtools/clang15/clang/0027-clang-Fix-how-driver-finds-GCC-installation-path-on-.patch
@@ -1,0 +1,97 @@
+From e58c09f18c4489ed414c2921a37e6e977141b93a Mon Sep 17 00:00:00 2001
+From: David Abdurachmanov <david.abdurachmanov@sifive.com>
+Date: Wed, 20 Oct 2021 17:30:36 -0700
+Subject: [PATCH] clang: Fix how driver finds GCC installation path on
+ OpenEmbedded
+
+Fix how Clang Driver finds GCC installation path on OpenEmbedded
+
+- For RISCV (riscv{32,64}) we define new two multi-lib options without any
+  subdirectories (e.g., lib32/ilp32d or lib64/lp64d). OpenEmbedded GCC
+  builds don't use them.
+- Modify how Clang Driver finds GCC installation path. This is important
+  because GCC files on OpenEmbedded are in two different directories:
+   (1) /usr/bin/../lib/gcc/riscv64-oe-linux/9.2.0
+   (2) /usr/lib/riscv64-oe-linux/9.2.0
+
+Clang Driver will check (1) first. The directory exist, but will produce
+no valid multi-libs and there will be no multi-lib selected. (2) contains
+actual GCC run-time objects/libraries, but because the path has exact
+same GCC version (9.2.0) it will be skipped.
+
+We modify the approach by allowing to check other directories with the same
+GCC version. We also avoid picking GCC installation path if it results in
+an empty multi-lib list.
+
+Upstream-Status: Pending
+Signed-off-by: David Abdurachmanov <david.abdurachmanov@sifive.com>
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ clang/lib/Driver/ToolChains/Gnu.cpp | 39 +++++++++++++++++++++--------
+ 1 file changed, 28 insertions(+), 11 deletions(-)
+
+diff --git a/clang/lib/Driver/ToolChains/Gnu.cpp b/clang/lib/Driver/ToolChains/Gnu.cpp
+index 107ab8d78598..b5ee01c566e3 100644
+--- a/clang/lib/Driver/ToolChains/Gnu.cpp
++++ b/clang/lib/Driver/ToolChains/Gnu.cpp
+@@ -1737,18 +1737,29 @@ static void findRISCVMultilibs(const Driver &D,
+     return findRISCVBareMetalMultilibs(D, TargetTriple, Path, Args, Result);
+ 
+   FilterNonExistent NonExistent(Path, "/crtbegin.o", D.getVFS());
+-  Multilib Ilp32 = makeMultilib("lib32/ilp32").flag("+m32").flag("+mabi=ilp32");
+-  Multilib Ilp32f =
++  MultilibSet RISCVMultilibs;
++
++  if (TargetTriple.getVendor() == llvm::Triple::OpenEmbedded) {
++    Multilib OpenEmbeddedIlp32d = makeMultilib("").flag("+m32").flag("+mabi=ilp32d");
++    Multilib OpenEmbeddedLp64d = makeMultilib("").flag("+m64").flag("+mabi=lp64d");
++    RISCVMultilibs =
++        MultilibSet()
++            .Either({OpenEmbeddedIlp32d, OpenEmbeddedLp64d})
++            .FilterOut(NonExistent);
++  } else {
++    Multilib Ilp32 = makeMultilib("lib32/ilp32").flag("+m32").flag("+mabi=ilp32");
++    Multilib Ilp32f =
+       makeMultilib("lib32/ilp32f").flag("+m32").flag("+mabi=ilp32f");
+-  Multilib Ilp32d =
++    Multilib Ilp32d =
+       makeMultilib("lib32/ilp32d").flag("+m32").flag("+mabi=ilp32d");
+-  Multilib Lp64 = makeMultilib("lib64/lp64").flag("+m64").flag("+mabi=lp64");
+-  Multilib Lp64f = makeMultilib("lib64/lp64f").flag("+m64").flag("+mabi=lp64f");
+-  Multilib Lp64d = makeMultilib("lib64/lp64d").flag("+m64").flag("+mabi=lp64d");
+-  MultilibSet RISCVMultilibs =
+-      MultilibSet()
+-          .Either({Ilp32, Ilp32f, Ilp32d, Lp64, Lp64f, Lp64d})
+-          .FilterOut(NonExistent);
++    Multilib Lp64 = makeMultilib("lib64/lp64").flag("+m64").flag("+mabi=lp64");
++    Multilib Lp64f = makeMultilib("lib64/lp64f").flag("+m64").flag("+mabi=lp64f");
++    Multilib Lp64d = makeMultilib("lib64/lp64d").flag("+m64").flag("+mabi=lp64d");
++    RISCVMultilibs =
++        MultilibSet()
++            .Either({Ilp32, Ilp32f, Ilp32d, Lp64, Lp64f, Lp64d})
++            .FilterOut(NonExistent);
++  }
+ 
+   Multilib::flags_list Flags;
+   bool IsRV64 = TargetTriple.getArch() == llvm::Triple::riscv64;
+@@ -2674,13 +2685,19 @@ void Generic_GCC::GCCInstallationDetector::ScanLibDirForGCCTriple(
+           continue; // Saw this path before; no need to look at it again.
+       if (CandidateVersion.isOlderThan(4, 1, 1))
+         continue;
+-      if (CandidateVersion <= Version)
++      if (CandidateVersion < Version)
+         continue;
+ 
+       if (!ScanGCCForMultilibs(TargetTriple, Args, LI->path(),
+                                NeedsBiarchSuffix))
+         continue;
+ 
++      // We might have found existing directory with GCCVersion, but it
++      // might not have GCC libraries we are looking for (i.e. return an
++      // empty Mulilibs)
++      if (Multilibs.size() == 0)
++        continue;
++
+       Version = CandidateVersion;
+       GCCTriple.setTriple(CandidateTriple);
+       // FIXME: We hack together the directory name here instead of

--- a/recipes-devtools/clang15/clang/0028-Fix-lib-paths-for-OpenEmbedded-Host.patch
+++ b/recipes-devtools/clang15/clang/0028-Fix-lib-paths-for-OpenEmbedded-Host.patch
@@ -1,0 +1,79 @@
+From a1ef24c4217263bc4914e5e1ad21da79211ea4cc Mon Sep 17 00:00:00 2001
+From: Changqing Li <changqing.li@windriver.com>
+Date: Tue, 7 Dec 2021 04:08:22 +0000
+Subject: [PATCH] Fix lib paths for OpenEmbedded Host
+
+Under OpenEmbedded Host, while building with clang-native, it cannot find
+the GCCInstallPath, which causing following error:
+[snip]
+compiler-rt-native/13.0.1-r0/recipe-sysroot-native/usr/bin/clang
+-target x86_64-linux
+-isystem/path/to/x86_64-linux/compiler-rt-native/13.0.1-r0/recipe-sysroot-native/usr/include
+-O2 -pipe
+/path/to/compiler-rt-native/13.0.1-r0/recipe-sysroot-native/usr/share/cmake-3.21/Modules/CMakeCCompilerABI.c`
+hosttools/ld: cannot find crtbeginS.o: No such file or directory
+[snip]
+
+Before this patch:
+compiler-rt-native/13.0.1-r0/recipe-sysroot-native/usr/bin/clang
+clang version 13.0.1 (https://github.com/llvm/llvm-project 08e3a5ccd952edee36b3c002e3a29c6b1b5153de)
+Target: x86_64-unknown-linux-gnu
+Thread model: posix
+InstalledDir: /build/tmp-glibc/work/x86_64-linux/compiler-rt-native/13.0.1-r0/recipe-sysroot-native/usr/bin
+Found candidate GCC installation: /usr/lib/gcc/x86_64-wrs-linux/10.2.0
+
+After this patch:
+compiler-rt-native/13.0.1-r0/recipe-sysroot-native/usr/bin/clang
+clang version 13.0.1 (https://github.com/llvm/llvm-project 08e3a5ccd952edee36b3c002e3a29c6b1b5153de)
+Thread model: posix
+InstalledDir: /build/tmp-glibc/work/x86_64-linux/compiler-rt-native/13.0.1-r0/recipe-sysroot-native/usr/bin
+Found candidate GCC installation: /usr/lib/gcc/x86_64-wrs-linux/10.2.0
+Found candidate GCC installation: /usr/lib/x86_64-wrs-linux/10.2.0
+Selected GCC installation: /usr/lib/x86_64-wrs-linux/10.2.0
+Candidate multilib: .;@m64
+Selected multilib: .;@m64
+
+Summary:
+For OpenEmbedded Host, sysroots are of the form<sysroot>/usr/lib/<triple>/x.y.z.
+Take x86-64 as example, the default triple is x86_64-unknown-linux-gnu.
+For clang-native, the target vendor is '-unknown', need to test current distro
+to follow above form.
+
+Upstream-Status: Inappropriate [oe specific]
+
+Signed-off-by: Changqing Li <changqing.li@windriver.com>
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ clang/lib/Driver/ToolChains/Gnu.cpp | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/clang/lib/Driver/ToolChains/Gnu.cpp b/clang/lib/Driver/ToolChains/Gnu.cpp
+index b5ee01c566e3..f9dce01b579f 100644
+--- a/clang/lib/Driver/ToolChains/Gnu.cpp
++++ b/clang/lib/Driver/ToolChains/Gnu.cpp
+@@ -23,6 +23,7 @@
+ #include "clang/Driver/Options.h"
+ #include "clang/Driver/Tool.h"
+ #include "clang/Driver/ToolChain.h"
++#include "clang/Driver/Distro.h"
+ #include "llvm/Option/ArgList.h"
+ #include "llvm/Support/CodeGen.h"
+ #include "llvm/Support/Path.h"
+@@ -2643,6 +2644,7 @@ void Generic_GCC::GCCInstallationDetector::ScanLibDirForGCCTriple(
+     const llvm::Triple &TargetTriple, const ArgList &Args,
+     const std::string &LibDir, StringRef CandidateTriple,
+     bool NeedsBiarchSuffix, bool GCCDirExists, bool GCCCrossDirExists) {
++  Distro Distro(D.getVFS(), TargetTriple);
+   // Locations relative to the system lib directory where GCC's triple-specific
+   // directories might reside.
+   struct GCCLibSuffix {
+@@ -2660,7 +2662,8 @@ void Generic_GCC::GCCInstallationDetector::ScanLibDirForGCCTriple(
+       // files in that location, not just GCC installation data.
+       {CandidateTriple.str(), "..",
+        TargetTriple.getVendor() == llvm::Triple::Freescale ||
+-           TargetTriple.getVendor() == llvm::Triple::OpenEmbedded},
++           TargetTriple.getVendor() == llvm::Triple::OpenEmbedded ||
++           Distro.IsOpenEmbedded()},
+ 
+       // This is the normal place.
+       {"gcc/" + CandidateTriple.str(), "../..", GCCDirExists},

--- a/recipes-devtools/clang15/clang/0029-Correct-library-search-path-for-OpenEmbedded-Host.patch
+++ b/recipes-devtools/clang15/clang/0029-Correct-library-search-path-for-OpenEmbedded-Host.patch
@@ -1,0 +1,84 @@
+From 8691b31bfbebf0b5ad31f7f164470b2d3d17b15d Mon Sep 17 00:00:00 2001
+From: Changqing Li <changqing.li@windriver.com>
+Date: Tue, 7 Dec 2021 04:55:48 +0000
+Subject: [PATCH] Correct library search path for OpenEmbedded Host
+
+For OpenEmbedded Host, the gcc install path is
+/usr/lib/x86_64-[distroname]-linux/[gcc-version].
+So the library search path is not found with default triple
+'x86_64-linux-gnu' for x86_64. Causing following error:
+[snip]
+compiler-rt-native/13.0.1-r0/recipe-sysroot-native/usr/bin/clang
+-target x86_64-linux
+-isystem/path/to/x86_64-linux/compiler-rt-native/13.0.1-r0/recipe-sysroot-native/usr/include
+-O2 -pipe
+/path/to/compiler-rt-native/13.0.1-r0/recipe-sysroot-native/usr/share/cmake-3.21/Modules/CMakeCCompilerABI.c`
+|     /build/tmp-glibc/hosttools/ld: cannot find -lgcc
+|     /build/tmp-glibc/hosttools/ld: cannot find -lgcc
+|     clang-13: error: linker command failed with exit code 1 (use -v to see invocation)
+[snip]
+
+before this patch:
+b59da142f2b0:$ /path/to/x86_64-linux/compiler-rt-native/13.0.1-r0/recipe-sysroot-native/usr/bin/clang --print-search-dirs
+programs: =/build/tmp-glibc/work/x86_64-linux/compiler-rt-native/13.0.1-r0/recipe-sysroot-native/usr/bin
+libraries: =/build/tmp-glibc/work/x86_64-linux/compiler-rt-native/13.0.1-r0/recipe-sysroot-native/usr/lib/clang/13.0.1:/build/tmp-glibc/work/x86_64-linux/compiler-rt-native/13.0.1-r0/recipe-sysroot-native/usr/bin/../lib://lib://usr/lib
+
+after this patch:
+b59da142f2b0:$ /path/to/x86_64-linux/compiler-rt-native/13.0.1-r0/recipe-sysroot-native/usr/bin/clang --print-search-dirs
+programs: =/build/tmp-glibc/work/x86_64-linux/compiler-rt-native/13.0.1-r0/recipe-sysroot-native/usr/bin
+libraries: =/build/tmp-glibc/work/x84_64-linux/compiler-rt-native/13.0.1-r0/recipe-sysroot-native/usr/lib/clang/13.0.1:/usr/lib/x86_64-wrs-linux/10.2.0://lib/x86_64-wrs-linux://usr/lib/x86_64-wrs-linux:/build/tmp-glibc/work/x86_64-linux/compiler-rt-native/13.0.1-r0/recipe-sysroot-native/usr/bin/../lib://lib://usr/lib
+
+Upstream-Status: Inappropriate [oe specific]
+
+Signed-off-by: Changqing Li <changqing.li@windriver.com>
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ clang/include/clang/Driver/Distro.h   | 2 ++
+ clang/lib/Driver/Distro.cpp           | 1 +
+ clang/lib/Driver/ToolChains/Linux.cpp | 1 +
+ 3 files changed, 4 insertions(+)
+
+diff --git a/clang/include/clang/Driver/Distro.h b/clang/include/clang/Driver/Distro.h
+index 01d66b30b038..4d5aa366a005 100644
+--- a/clang/include/clang/Driver/Distro.h
++++ b/clang/include/clang/Driver/Distro.h
+@@ -45,6 +45,7 @@ public:
+     RHEL7,
+     Fedora,
+     Gentoo,
++    //CLANG_EXTRA_OE_DISTRO_NAME
+     OpenSUSE,
+     UbuntuHardy,
+     UbuntuIntrepid,
+@@ -134,6 +135,7 @@ public:
+ 
+   bool IsGentoo() const { return DistroVal == Gentoo; }
+ 
++  //CLANG_EXTRA_OE_DISTRO_CHECK
+   /// @}
+ };
+ 
+diff --git a/clang/lib/Driver/Distro.cpp b/clang/lib/Driver/Distro.cpp
+index 1898667279cc..ab7bc8d45ac1 100644
+--- a/clang/lib/Driver/Distro.cpp
++++ b/clang/lib/Driver/Distro.cpp
+@@ -44,6 +44,7 @@ static Distro::DistroType DetectOsRelease(llvm::vfs::FileSystem &VFS) {
+                     .Case("sles", Distro::OpenSUSE)
+                     .Case("opensuse", Distro::OpenSUSE)
+                     .Case("exherbo", Distro::Exherbo)
++                    //CLANG_EXTRA_OE_DISTRO_CASE
+                     .Default(Distro::UnknownDistro);
+   return Version;
+ }
+diff --git a/clang/lib/Driver/ToolChains/Linux.cpp b/clang/lib/Driver/ToolChains/Linux.cpp
+index aac45650f97b..3c4034ea4921 100644
+--- a/clang/lib/Driver/ToolChains/Linux.cpp
++++ b/clang/lib/Driver/ToolChains/Linux.cpp
+@@ -77,6 +77,7 @@ std::string Linux::getMultiarchTriple(const Driver &D,
+       return "x86_64-linux-android";
+     if (TargetEnvironment == llvm::Triple::GNUX32)
+       return "x86_64-linux-gnux32";
++    //CLANG_EXTRA_OE_DISTRO_TRIPLE
+     return "x86_64-linux-gnu";
+   case llvm::Triple::aarch64:
+     if (IsAndroid)

--- a/recipes-devtools/clang15/clang/0030-lldb-Link-with-libatomic-on-x86.patch
+++ b/recipes-devtools/clang15/clang/0030-lldb-Link-with-libatomic-on-x86.patch
@@ -1,0 +1,33 @@
+From d63ad7dc689b4c6e7d30614bc70ab43f4c50c62c Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Tue, 8 Feb 2022 01:31:26 -0800
+Subject: [PATCH] lldb: Link with libatomic on x86
+
+cmake atomic check is not sufficient for i686 target where clang14 still
+generates __atomic_store calls but the check does not entail this
+function and happily thinks that compiler can resolve all atomic via intrinsics
+on i686, but thats not the case, ideally the check for determining
+atomic operation should be make more robust but until then lets ask to
+link with libatomic on i686/linux
+
+Upstream-Status: Inappropriate [OE-Specific]
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ lldb/source/Utility/CMakeLists.txt | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/lldb/source/Utility/CMakeLists.txt b/lldb/source/Utility/CMakeLists.txt
+index 1a92c033fac4..a0d8f3288c06 100644
+--- a/lldb/source/Utility/CMakeLists.txt
++++ b/lldb/source/Utility/CMakeLists.txt
+@@ -19,6 +19,10 @@ if (CMAKE_SYSTEM_NAME MATCHES "Windows")
+   list(APPEND LLDB_SYSTEM_LIBS ws2_32 rpcrt4)
+ endif ()
+ 
++if (CMAKE_SYSTEM_PROCESSOR MATCHES "i686" AND CMAKE_SYSTEM_NAME MATCHES "Linux")
++    list(APPEND LLDB_SYSTEM_LIBS atomic)
++endif()
++
+ if (NOT HAVE_CXX_ATOMICS64_WITHOUT_LIB )
+     list(APPEND LLDB_SYSTEM_LIBS atomic)
+ endif()

--- a/recipes-devtools/clang15/clang/0031-clang-exclude-openembedded-distributions-from-settin.patch
+++ b/recipes-devtools/clang15/clang/0031-clang-exclude-openembedded-distributions-from-settin.patch
@@ -1,0 +1,35 @@
+From 556bf92b3b502cc1eeb9a435c241ca2ce3f6968b Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Fri, 11 Feb 2022 12:29:14 -0800
+Subject: [PATCH] clang: exclude openembedded distributions from setting rpath
+ on openmp executables
+
+OpenEmbedded based SDKs stage toolchains outsides the target rootfs and
+libomp.so is part of the target rootfs and not part of compiler
+toolchain install or relative to it. It finds the libraries via
+--sysroot during compile. This ensures that -rpath is not added for such
+systems, since it is adding cross-compile paths to rpath which is not
+correct when the binaries are run on real targets.
+
+Upstream-Status: Submitted [https://reviews.llvm.org/D119590]
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ clang/lib/Driver/ToolChains/CommonArgs.cpp | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/clang/lib/Driver/ToolChains/CommonArgs.cpp b/clang/lib/Driver/ToolChains/CommonArgs.cpp
+index c8eabfac21dc..6e1e626a90ea 100644
+--- a/clang/lib/Driver/ToolChains/CommonArgs.cpp
++++ b/clang/lib/Driver/ToolChains/CommonArgs.cpp
+@@ -649,6 +649,11 @@ void tools::addLTOOptions(const ToolChain &ToolChain, const ArgList &Args,
+ void tools::addOpenMPRuntimeSpecificRPath(const ToolChain &TC,
+                                           const ArgList &Args,
+                                           ArgStringList &CmdArgs) {
++  // OpenEmbedded/Yocto installs libomp.so into <sysroot>/usr/lib
++  // therefore using -rpath is not needed, on the contrary it adds
++  // paths from cross compiler install location which is not correct
++  if (TC.getTriple().getVendor() == llvm::Triple::OpenEmbedded)
++    return;
+ 
+   if (Args.hasFlag(options::OPT_fopenmp_implicit_rpath,
+                    options::OPT_fno_openmp_implicit_rpath, true)) {

--- a/recipes-devtools/clang15/clang/0032-compiler-rt-Enable-__int128-for-ppc32.patch
+++ b/recipes-devtools/clang15/clang/0032-compiler-rt-Enable-__int128-for-ppc32.patch
@@ -1,0 +1,73 @@
+From c9784a9dff18bce24e68f8d5654c57c2345babff Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Wed, 9 Mar 2022 16:28:16 -0800
+Subject: [PATCH] compiler-rt: Enable __int128 for ppc32
+
+Upstream-Status: Pending
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ compiler-rt/lib/builtins/CMakeLists.txt | 15 +++++++--------
+ compiler-rt/lib/builtins/int_types.h    |  2 +-
+ 2 files changed, 8 insertions(+), 9 deletions(-)
+
+diff --git a/compiler-rt/lib/builtins/CMakeLists.txt b/compiler-rt/lib/builtins/CMakeLists.txt
+index ec668e294d6d..72556d2fc58e 100644
+--- a/compiler-rt/lib/builtins/CMakeLists.txt
++++ b/compiler-rt/lib/builtins/CMakeLists.txt
+@@ -628,11 +628,9 @@ set(mips64_SOURCES ${GENERIC_TF_SOURCES}
+ set(mips64el_SOURCES ${GENERIC_TF_SOURCES}
+                      ${mips_SOURCES})
+ 
+-set(powerpc_SOURCES ${GENERIC_SOURCES})
+-
+ set(powerpcspe_SOURCES ${GENERIC_SOURCES})
+ 
+-set(powerpc64_SOURCES
++set(powerpc_SOURCES
+   ppc/divtc3.c
+   ppc/fixtfdi.c
+   ppc/fixunstfdi.c
+@@ -647,14 +645,15 @@ set(powerpc64_SOURCES
+ )
+ # These routines require __int128, which isn't supported on AIX.
+ if (NOT ${CMAKE_SYSTEM_NAME} MATCHES "AIX")
+-  set(powerpc64_SOURCES
++  set(powerpc_SOURCES
+     ppc/floattitf.c
+     ppc/fixtfti.c
+     ppc/fixunstfti.c
+-    ${powerpc64_SOURCES}
++    ${powerpc_SOURCES}
+   )
+ endif()
+-set(powerpc64le_SOURCES ${powerpc64_SOURCES})
++set(powerpc64le_SOURCES ${powerpc_SOURCES})
++set(powerpc64_SOURCES ${powerpc_SOURCES})
+ 
+ set(riscv_SOURCES
+   riscv/save.S
+@@ -761,9 +760,9 @@ else ()
+         list(APPEND BUILTIN_CFLAGS_${arch} -fomit-frame-pointer -DCOMPILER_RT_ARMHF_TARGET)
+       endif()
+ 
+-      # For RISCV32, we must force enable int128 for compiling long
++      # For RISCV32/PPC32, we must force enable int128 for compiling long
+       # double routines.
+-      if("${arch}" STREQUAL "riscv32")
++      if("${arch}" STREQUAL "riscv32" OR "${arch}" STREQUAL "powerpc" )
+         list(APPEND BUILTIN_CFLAGS_${arch} -fforce-enable-int128)
+       endif()
+ 
+diff --git a/compiler-rt/lib/builtins/int_types.h b/compiler-rt/lib/builtins/int_types.h
+index 7a72de480676..9ee5a327b28a 100644
+--- a/compiler-rt/lib/builtins/int_types.h
++++ b/compiler-rt/lib/builtins/int_types.h
+@@ -64,7 +64,7 @@ typedef union {
+ } udwords;
+ 
+ #if defined(__LP64__) || defined(__wasm__) || defined(__mips64) ||             \
+-    defined(__riscv) || defined(_WIN64)
++    defined(__riscv) || defined(_WIN64) || defined(__powerpc__)
+ #define CRT_HAS_128BIT
+ #endif
+ 

--- a/recipes-devtools/clang15/clang/0033-llvm-Do-not-use-cmake-infra-to-detect-libzstd.patch
+++ b/recipes-devtools/clang15/clang/0033-llvm-Do-not-use-cmake-infra-to-detect-libzstd.patch
@@ -1,0 +1,60 @@
+From fde148342b7475a1d83cf270db1c912a22d950f7 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Fri, 12 Aug 2022 11:50:57 -0700
+Subject: [PATCH] llvm: Do not use cmake infra to detect libzstd
+
+OE's version is build using plain make not cmake as a result we do not
+have the cmake support files and this probing method can get this info
+from build host and force linking with libzstd from /usr/lib which is
+not what we want when cross building.
+
+Fixes errors building llvm-config like
+/usr/lib/libzstd.so.1.5.2: error adding symbols: file in wrong
+format
+| clang-15: error: linker command failed with exit code 1 (use -v to see invocation)
+| ninja: build stopped: subcommand failed.
+
+Upstream-Status: Inappropriate [OE-Specific]
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ llvm/lib/Support/CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/llvm/lib/Support/CMakeLists.txt
++++ b/llvm/lib/Support/CMakeLists.txt
+@@ -22,7 +22,7 @@ if (HAS_WERROR_GLOBAL_CTORS)
+ endif()
+ 
+ if(LLVM_ENABLE_ZLIB)
+-  list(APPEND imported_libs ZLIB::ZLIB)
++  list(APPEND imported_libs z)
+ endif()
+ 
+ if(LLVM_ENABLE_ZSTD)
+@@ -34,7 +34,7 @@ if(LLVM_ENABLE_ZSTD)
+ endif()
+ 
+ if(LLVM_ENABLE_ZSTD)
+-  list(APPEND imported_libs ${zstd_target})
++  list(APPEND imported_libs zstd)
+ endif()
+ 
+ if( MSVC OR MINGW )
+@@ -301,7 +301,7 @@ if(LLVM_ENABLE_ZLIB)
+     get_property(zlib_library TARGET ZLIB::ZLIB PROPERTY LOCATION)
+   endif()
+   get_library_name(${zlib_library} zlib_library)
+-  set(llvm_system_libs ${llvm_system_libs} "${zlib_library}")
++  set(llvm_system_libs ${llvm_system_libs} z)
+ endif()
+ 
+ if(LLVM_ENABLE_ZSTD)
+@@ -314,7 +314,7 @@ if(LLVM_ENABLE_ZSTD)
+     get_property(zstd_library TARGET ${zstd_target} PROPERTY LOCATION)
+   endif()
+   get_library_name(${zstd_library} zstd_library)
+-  set(llvm_system_libs ${llvm_system_libs} "${zstd_library}")
++  set(llvm_system_libs ${llvm_system_libs} zstd)
+ endif()
+ 
+ if(LLVM_ENABLE_TERMINFO)

--- a/recipes-devtools/clang15/clang/0034-compiler-rt-Fix-stat-struct-s-size-for-O32-ABI.patch
+++ b/recipes-devtools/clang15/clang/0034-compiler-rt-Fix-stat-struct-s-size-for-O32-ABI.patch
@@ -1,0 +1,47 @@
+From abebd2f8fd9b78e4fa3403fd93d926f8cc16a001 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Tue, 3 Jan 2023 18:44:34 -0800
+Subject: [PATCH] compiler-rt: Fix stat struct's size for O32 ABI
+
+stat struct size differs on glibc based on ABI choices e.g. 64bit off_t
+and/or 64bit time_t will make this size different. Therefore separate
+out the O32 case out, makes it more readable.
+
+Upstream-Status: Submitted [https://reviews.llvm.org/D140948]
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ .../sanitizer_platform_limits_posix.h               | 13 +++++++++++++
+ 1 file changed, 13 insertions(+)
+
+diff --git a/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.h b/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.h
+index bd5692ed511b..08d1ac8ab51b 100644
+--- a/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.h
++++ b/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.h
+@@ -98,11 +98,24 @@ const unsigned struct_kernel_stat64_sz = 104;
+ const unsigned struct_kernel_stat_sz = 144;
+ const unsigned struct_kernel_stat64_sz = 104;
+ #elif defined(__mips__)
++#if defined(__mips_o32) // O32 ABI
++#if _TIME_BITS == 64
++const unsigned struct_kernel_stat_sz = 112;
++const unsigned struct_kernel_stat64_sz = 112;
++#elif _FILE_OFFSET_BITS == 64
++const unsigned struct_kernel_stat_sz = 160;
++const unsigned struct_kernel_stat64_sz = 160;
++#else
++const unsigned struct_kernel_stat_sz = 144;
++const unsigned struct_kernel_stat64_sz = 160;
++#endif
++#else // __mips_o32
+ const unsigned struct_kernel_stat_sz =
+     SANITIZER_ANDROID
+         ? FIRST_32_SECOND_64(104, 128)
+         : FIRST_32_SECOND_64((_MIPS_SIM == _ABIN32) ? 160 : 144, 216);
+ const unsigned struct_kernel_stat64_sz = 104;
++#endif
+ #elif defined(__s390__) && !defined(__s390x__)
+ const unsigned struct_kernel_stat_sz = 64;
+ const unsigned struct_kernel_stat64_sz = 104;
+-- 
+2.39.0
+

--- a/recipes-devtools/clang15/clang/0035-cmake-Enable-64bit-off_t-on-32bit-glibc-systems.patch
+++ b/recipes-devtools/clang15/clang/0035-cmake-Enable-64bit-off_t-on-32bit-glibc-systems.patch
@@ -1,0 +1,131 @@
+From cd2fa12d715929642513fc441287c402f4560096 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Sun, 25 Dec 2022 15:13:41 -0800
+Subject: [PATCH] build: Enable 64bit off_t on 32bit glibc systems
+
+Pass -D_FILE_OFFSET_BITS=64 to compiler flags on 32bit glibc based
+systems. This will make sure that 64bit versions of LFS functions are
+used e.g. lseek will behave same as lseek64. Also revert [1] partially
+because this added a cmake test to detect lseek64 but then forgot to
+pass the needed macro during actual compile, this test was incomplete too
+since libc implementations like musl has 64-bit off_t by default on 32-bit
+systems and does not bundle -D_LARGEFILE64_SOURCE [2] under -D_GNU_SOURCE
+like glibc, which means the compile now fails on musl because the cmake
+check passes but we do not have _LARGEFILE64_SOURCE defined. Moreover,
+Using the *64 function was transitional anyways so use
+-D_FILE_OFFSET_BITS=64 instead
+
+[1] https://github.com/llvm/llvm-project/commit/8db7e5e4eed4c4e697dc3164f2c9351d8c3e942b
+[2] https://git.musl-libc.org/cgit/musl/commit/?id=25e6fee27f4a293728dd15b659170e7b9c7db9bc
+
+Upstream-Status: Submitted [https://reviews.llvm.org/D139752]
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ llvm/cmake/config-ix.cmake                                | 8 +++++---
+ llvm/include/llvm/Config/config.h.cmake                   | 3 ---
+ llvm/lib/Support/raw_ostream.cpp                          | 2 --
+ llvm/utils/gn/secondary/llvm/include/llvm/Config/BUILD.gn | 2 --
+ utils/bazel/llvm-project-overlay/llvm/config.bzl          | 1 -
+ .../llvm/include/llvm/Config/config.h                     | 3 ---
+ utils/bazel/llvm_configs/config.h.cmake                   | 3 ---
+ 7 files changed, 5 insertions(+), 17 deletions(-)
+
+--- a/llvm/cmake/config-ix.cmake
++++ b/llvm/cmake/config-ix.cmake
+@@ -284,9 +284,6 @@ check_symbol_exists(futimes sys/time.h H
+ if( HAVE_SIGNAL_H AND NOT LLVM_USE_SANITIZER MATCHES ".*Address.*" AND NOT APPLE )
+   check_symbol_exists(sigaltstack signal.h HAVE_SIGALTSTACK)
+ endif()
+-set(CMAKE_REQUIRED_DEFINITIONS "-D_LARGEFILE64_SOURCE")
+-check_symbol_exists(lseek64 "sys/types.h;unistd.h" HAVE_LSEEK64)
+-set(CMAKE_REQUIRED_DEFINITIONS "")
+ check_symbol_exists(mallctl malloc_np.h HAVE_MALLCTL)
+ check_symbol_exists(mallinfo malloc.h HAVE_MALLINFO)
+ check_symbol_exists(mallinfo2 malloc.h HAVE_MALLINFO2)
+@@ -350,6 +347,11 @@ check_symbol_exists(__GLIBC__ stdio.h LL
+ if( LLVM_USING_GLIBC )
+   add_definitions( -D_GNU_SOURCE )
+   list(APPEND CMAKE_REQUIRED_DEFINITIONS "-D_GNU_SOURCE")
++# enable 64bit off_t on 32bit systems using glibc
++  if (CMAKE_SIZEOF_VOID_P EQUAL 4)
++    add_compile_definitions(_FILE_OFFSET_BITS=64)
++    list(APPEND CMAKE_REQUIRED_DEFINITIONS "-D_FILE_OFFSET_BITS=64")
++  endif()
+ endif()
+ # This check requires _GNU_SOURCE
+ if (NOT PURE_WINDOWS)
+--- a/llvm/include/llvm/Config/config.h.cmake
++++ b/llvm/include/llvm/Config/config.h.cmake
+@@ -128,9 +128,6 @@
+ /* Define to 1 if you have the <link.h> header file. */
+ #cmakedefine HAVE_LINK_H ${HAVE_LINK_H}
+ 
+-/* Define to 1 if you have the `lseek64' function. */
+-#cmakedefine HAVE_LSEEK64 ${HAVE_LSEEK64}
+-
+ /* Define to 1 if you have the <mach/mach.h> header file. */
+ #cmakedefine HAVE_MACH_MACH_H ${HAVE_MACH_MACH_H}
+ 
+--- a/llvm/lib/Support/raw_ostream.cpp
++++ b/llvm/lib/Support/raw_ostream.cpp
+@@ -804,8 +804,6 @@ uint64_t raw_fd_ostream::seek(uint64_t o
+   flush();
+ #ifdef _WIN32
+   pos = ::_lseeki64(FD, off, SEEK_SET);
+-#elif defined(HAVE_LSEEK64)
+-  pos = ::lseek64(FD, off, SEEK_SET);
+ #else
+   pos = ::lseek(FD, off, SEEK_SET);
+ #endif
+--- a/llvm/utils/gn/secondary/llvm/include/llvm/Config/BUILD.gn
++++ b/llvm/utils/gn/secondary/llvm/include/llvm/Config/BUILD.gn
+@@ -139,7 +139,6 @@ write_cmake_config("config") {
+     values += [
+       "HAVE_FUTIMENS=1",
+       "HAVE_LINK_H=1",
+-      "HAVE_LSEEK64=1",
+       "HAVE_MALLINFO=1",
+       "HAVE_STRUCT_STAT_ST_MTIM_TV_NSEC=1",
+     ]
+@@ -147,7 +146,6 @@ write_cmake_config("config") {
+     values += [
+       "HAVE_FUTIMENS=",
+       "HAVE_LINK_H=",
+-      "HAVE_LSEEK64=",
+       "HAVE_MALLINFO=",
+       "HAVE_STRUCT_STAT_ST_MTIM_TV_NSEC=",
+     ]
+--- a/utils/bazel/llvm-project-overlay/llvm/config.bzl
++++ b/utils/bazel/llvm-project-overlay/llvm/config.bzl
+@@ -40,7 +40,6 @@ posix_defines = [
+ linux_defines = posix_defines + [
+     "_GNU_SOURCE",
+     "HAVE_LINK_H=1",
+-    "HAVE_LSEEK64=1",
+     "HAVE_MALLINFO=1",
+     "HAVE_SBRK=1",
+     "HAVE_STRUCT_STAT_ST_MTIM_TV_NSEC=1",
+--- a/utils/bazel/llvm-project-overlay/llvm/include/llvm/Config/config.h
++++ b/utils/bazel/llvm-project-overlay/llvm/include/llvm/Config/config.h
+@@ -144,9 +144,6 @@
+ /* Define to 1 if you have the <link.h> header file. */
+ /* HAVE_LINK_H defined in Bazel */
+ 
+-/* Define to 1 if you have the `lseek64' function. */
+-/* HAVE_LSEEK64 defined in Bazel */
+-
+ /* Define to 1 if you have the <mach/mach.h> header file. */
+ /* HAVE_MACH_MACH_H defined in Bazel */
+ 
+--- a/utils/bazel/llvm_configs/config.h.cmake
++++ b/utils/bazel/llvm_configs/config.h.cmake
+@@ -128,9 +128,6 @@
+ /* Define to 1 if you have the <link.h> header file. */
+ #cmakedefine HAVE_LINK_H ${HAVE_LINK_H}
+ 
+-/* Define to 1 if you have the `lseek64' function. */
+-#cmakedefine HAVE_LSEEK64 ${HAVE_LSEEK64}
+-
+ /* Define to 1 if you have the <mach/mach.h> header file. */
+ #cmakedefine HAVE_MACH_MACH_H ${HAVE_MACH_MACH_H}
+ 

--- a/recipes-devtools/clang15/clang/0036-compiler-rt-Undef-_TIME_BITS-along-with-_FILE_OFFSET.patch
+++ b/recipes-devtools/clang15/clang/0036-compiler-rt-Undef-_TIME_BITS-along-with-_FILE_OFFSET.patch
@@ -1,0 +1,37 @@
+From 2030455a866828bb6d5f03e901e1147dacd95ed5 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Sat, 31 Dec 2022 15:03:24 -0800
+Subject: [PATCH] compiler-rt: Undef _TIME_BITS along with _FILE_OFFSET_BITS on
+ linux
+
+On 32bit systems using 64bit time_t build fails because
+_FILE_OFFSET_BITS is undefined here but _TIME_BITS is still set to 64
+
+Fixes
+/usr/include/features-time64.h:26:5: error: "_TIME_BITS=64 is allowed
+ only with _FILE_OFFSET_BITS=64"
+| #   error "_TIME_BITS=64 is allowed only with _FILE_OFFSET_BITS=64"
+|     ^
+| 1 error generated.
+
+Upstream-Status: Submitted [https://reviews.llvm.org/D140812]
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ .../lib/sanitizer_common/sanitizer_platform_limits_posix.cpp     | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.cpp b/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.cpp
+index 4e0d428d3284..9e646500350b 100644
+--- a/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.cpp
++++ b/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.cpp
+@@ -18,6 +18,7 @@
+ // depends on _FILE_OFFSET_BITS setting.
+ // To get this "true" dirent definition, we undefine _FILE_OFFSET_BITS below.
+ #undef _FILE_OFFSET_BITS
++#undef _TIME_BITS
+ #endif
+ 
+ // Must go after undef _FILE_OFFSET_BITS.
+-- 
+2.39.0
+

--- a/recipes-devtools/clang15/clang/libunwind.pc.in
+++ b/recipes-devtools/clang15/clang/libunwind.pc.in
@@ -1,0 +1,9 @@
+prefix=/usr
+exec_prefix=/usr
+libdir=@LIBDIR@
+includedir=/usr/include
+
+Name: libunwind
+Description: libunwind base library
+Version: @VERSION@
+Libs: -lunwind

--- a/recipes-devtools/clang15/clang/llvm-config
+++ b/recipes-devtools/clang15/clang/llvm-config
@@ -1,0 +1,52 @@
+#!/bin/bash
+#
+# Wrapper script for llvm-config. Supplies the right environment variables
+# for the target and delegates to the native llvm-config for anything else. This
+# is needed because arguments like --ldflags, --cxxflags, etc. are set by the
+# native compile rather than the target compile.
+#
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+NEXT_LLVM_CONFIG="$(which -a llvm-config | sed -n 2p)"
+export YOCTO_ALTERNATE_EXE_PATH="${YOCTO_ALTERNATE_EXE_PATH:="$(readlink -f "$SCRIPT_DIR/../llvm-config")"}"
+if [ -n "$( echo $base_libdir | sed -n '/lib64/p')" ]; then
+    export YOCTO_ALTERNATE_LIBDIR="${YOCTO_ALTERNATE_LIBDIR:="/lib64"}"
+else
+    export YOCTO_ALTERNATE_LIBDIR="${YOCTO_ALTERNATE_LIBDIR:="/lib"}"
+fi
+if [[ $# == 0 ]]; then
+  exec "$NEXT_LLVM_CONFIG"
+fi
+
+if [[ $1 == "--libs" ]]; then
+  exec "$NEXT_LLVM_CONFIG" $@
+fi
+
+if [[ $1 == "--bindir" ]]; then
+  unset YOCTO_ALTERNATE_EXE_PATH
+  exec "$NEXT_LLVM_CONFIG" $@
+fi
+
+if [[ $1 == "--libfiles" ]]; then
+  exec "$NEXT_LLVM_CONFIG" $@
+fi
+
+
+for arg in "$@"; do
+  case "$arg" in
+    --cppflags)
+      echo $CPPFLAGS
+      ;;
+    --cflags)
+      echo $CFLAGS
+      ;;
+    --cxxflags)
+      echo $CXXFLAGS
+      ;;
+    --ldflags)
+      echo $LDFLAGS
+      ;;
+    *)
+      echo "$("$NEXT_LLVM_CONFIG" "$arg")"
+      ;;
+  esac
+done

--- a/recipes-devtools/clang15/clang15-cross-canadian_git.bb
+++ b/recipes-devtools/clang15/clang15-cross-canadian_git.bb
@@ -12,7 +12,7 @@ require clang.inc
 require common-source.inc
 inherit cross-canadian
 
-DEPENDS += "nativesdk-clang15 binutils-cross-canadian-${TRANSLATED_TARGET_ARCH} virtual/${HOST_PREFIX}binutils-crosssdk virtual/nativesdk-libc"
+DEPENDS += "nativesdk-clang15 binutils-cross-canadian-${TRANSLATED_TARGET_ARCH} virtual/${HOST_PREFIX}binutils virtual/nativesdk-libc"
 # We have to point gcc at a sysroot but we don't need to rebuild if this changes
 # e.g. we switch between different machines with different tunes.
 EXTRA_OECONF_PATHS[vardepsexclude] = "TUNE_PKGARCH"

--- a/recipes-devtools/clang15/clang15-cross-canadian_git.bb
+++ b/recipes-devtools/clang15/clang15-cross-canadian_git.bb
@@ -1,0 +1,36 @@
+# Copyright (C) 2014 Khem Raj <raj.khem@gmail.com>
+# Released under the MIT license (see COPYING.MIT for the terms)
+
+DESCRIPTION = "Clang/LLVM based C/C++ compiler (cross-canadian for ${TARGET_ARCH} target)"
+HOMEPAGE = "http://clang.llvm.org/"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0-with-LLVM-exception;md5=0bcd48c3bdfef0c9d9fd17726e4b7dab"
+SECTION = "devel"
+
+PN = "clang15-cross-canadian-${TRANSLATED_TARGET_ARCH}"
+
+require clang.inc
+require common-source.inc
+inherit cross-canadian
+
+DEPENDS += "nativesdk-clang15 binutils-cross-canadian-${TRANSLATED_TARGET_ARCH} virtual/${HOST_PREFIX}binutils-crosssdk virtual/nativesdk-libc"
+# We have to point gcc at a sysroot but we don't need to rebuild if this changes
+# e.g. we switch between different machines with different tunes.
+EXTRA_OECONF_PATHS[vardepsexclude] = "TUNE_PKGARCH"
+TARGET_ARCH[vardepsexclude] = "TUNE_ARCH"
+
+do_install() {
+        install -d ${D}${bindir}
+	for tool in clang clang++ clang-tidy lld ld.lld llvm-profdata \
+            llvm-nm llvm-ar llvm-as llvm-ranlib llvm-strip llvm-objcopy llvm-objdump llvm-readelf \
+            llvm-addr2line llvm-dwp llvm-size llvm-strings llvm-cov
+	do
+		ln -sf ../$tool ${D}${bindir}/${TARGET_PREFIX}$tool
+	done
+}
+SSTATE_SCAN_FILES += "*-clang *-clang++ *-llvm-profdata *-llvm-ar \
+                      *-llvm-ranlib *-llvm-nm *-lld *-ld.lld *-llvm-as *-llvm-strip \
+                      *-llvm-objcopy *-llvm-objdump *-llvm-readelf *-llvm-addr2line \
+                      *-llvm-dwp *-llvm-size *-llvm-strings *-llvm-cov"
+do_install:append() {
+        cross_canadian_bindirlinks
+}

--- a/recipes-devtools/clang15/clang15-cross_git.bb
+++ b/recipes-devtools/clang15/clang15-cross_git.bb
@@ -1,0 +1,35 @@
+# Copyright (C) 2014 Khem Raj <raj.khem@gmail.com>
+# Released under the MIT license (see COPYING.MIT for the terms)
+
+DESCRIPTION = "Cross compiler wrappers for LLVM based C/C++ compiler"
+HOMEPAGE = "http://clang.llvm.org/"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0-with-LLVM-exception;md5=0bcd48c3bdfef0c9d9fd17726e4b7dab"
+SECTION = "devel"
+
+PN = "clang15-cross-${TARGET_ARCH}"
+
+require clang.inc
+require common-source.inc
+inherit cross
+DEPENDS += "clang15-native virtual/${TARGET_PREFIX}binutils"
+
+do_install() {
+        install -d ${D}${bindir}
+	for tool in clang clang++ clang-tidy lld ld.lld llvm-profdata \
+            llvm-nm llvm-ar llvm-as llvm-ranlib llvm-strip llvm-objcopy llvm-objdump llvm-readelf \
+            llvm-addr2line llvm-dwp llvm-size llvm-strings llvm-cov
+	do
+		ln -sf ../$tool ${D}${bindir}/${TARGET_PREFIX}$tool
+	done
+}
+SSTATE_SCAN_FILES += "*-clang *-clang++ *-llvm-profdata *-lld *-ld.lld \
+                      *-llvm-nm *-llvm-ar *-llvm-as *-llvm-ranlib *-llvm-strip \
+                      *-llvm-objcopy *-llvm-objdump *-llvm-readelf *-llvm-addr2line \
+                      *-llvm-dwp *-llvm-size *-llvm-strings *-llvm-cov"
+
+SYSROOT_PREPROCESS_FUNCS += "clangcross_sysroot_preprocess"
+
+clangcross_sysroot_preprocess () {
+        sysroot_stage_dir ${D}${bindir} ${SYSROOT_DESTDIR}${bindir}
+}
+PACKAGES = ""

--- a/recipes-devtools/clang15/clang15-crosssdk_git.bb
+++ b/recipes-devtools/clang15/clang15-crosssdk_git.bb
@@ -11,7 +11,7 @@ PN = "clang15-crosssdk-${TARGET_ARCH}"
 require clang.inc
 require common-source.inc
 inherit crosssdk
-DEPENDS += "clang15-native nativesdk-clang15-glue virtual/${TARGET_PREFIX}binutils-crosssdk virtual/nativesdk-libc"
+DEPENDS += "clang15-native nativesdk-clang15-glue virtual/${TARGET_PREFIX}binutils virtual/nativesdk-libc"
 
 do_install() {
         install -d ${D}${bindir}

--- a/recipes-devtools/clang15/clang15-crosssdk_git.bb
+++ b/recipes-devtools/clang15/clang15-crosssdk_git.bb
@@ -1,0 +1,34 @@
+# Copyright (C) 2014 Khem Raj <raj.khem@gmail.com>
+# Released under the MIT license (see COPYING.MIT for the terms)
+
+DESCRIPTION = "SDK Cross compiler wrappers for LLVM based C/C++ compiler"
+HOMEPAGE = "http://clang.llvm.org/"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0-with-LLVM-exception;md5=0bcd48c3bdfef0c9d9fd17726e4b7dab"
+SECTION = "devel"
+
+PN = "clang15-crosssdk-${TARGET_ARCH}"
+
+require clang.inc
+require common-source.inc
+inherit crosssdk
+DEPENDS += "clang15-native nativesdk-clang15-glue virtual/${TARGET_PREFIX}binutils-crosssdk virtual/nativesdk-libc"
+
+do_install() {
+        install -d ${D}${bindir}
+	for tool in clang clang++ clang-tidy lld ld.lld llvm-profdata \
+            llvm-nm llvm-ar llvm-as llvm-ranlib llvm-strip llvm-objcopy llvm-objdump llvm-readelf \
+            llvm-addr2line llvm-dwp llvm-size llvm-strings llvm-cov
+	do
+		ln -sf ../$tool ${D}${bindir}/${TARGET_PREFIX}$tool
+	done
+}
+SSTATE_SCAN_FILES += "*-clang *-clang++ *-llvm-profdata *-lld *-ld.lld \
+                      *-llvm-nm *-llvm-ar *-llvm-as *-llvm-ranlib *-llvm-strip \
+                      *-llvm-objcopy *-llvm-objdump *-llvm-readelf *-llvm-addr2line \
+                      *-llvm-dwp *-llvm-size *-llvm-strings *-llvm-cov"
+sysroot_stage_all () {
+        sysroot_stage_dir ${D}${bindir} ${SYSROOT_DESTDIR}${bindir}
+}
+
+PACKAGES = ""
+

--- a/recipes-devtools/clang15/clang15_git.bb
+++ b/recipes-devtools/clang15/clang15_git.bb
@@ -202,7 +202,7 @@ EXTRA_OECMAKE:append:class-target = "\
 "
 
 DEPENDS = "binutils zlib zstd libffi libxml2 libxml2-native ninja-native swig-native"
-DEPENDS:append:class-nativesdk = " clang15-crosssdk-${SDK_ARCH} virtual/${TARGET_PREFIX}binutils-crosssdk nativesdk-python3"
+DEPENDS:append:class-nativesdk = " clang15-crosssdk-${SDK_ARCH} virtual/${TARGET_PREFIX}binutils nativesdk-python3"
 DEPENDS:append:class-target = " clang15-cross-${TARGET_ARCH} gcc-cross-${TARGET_ARCH} python3 compiler-rt15 libcxx15-initial"
 
 RRECOMMENDS:${PN} = "binutils"

--- a/recipes-devtools/clang15/clang15_git.bb
+++ b/recipes-devtools/clang15/clang15_git.bb
@@ -1,0 +1,434 @@
+# Copyright (C) 2014 Khem Raj <raj.khem@gmail.com>
+# Released under the MIT license (see COPYING.MIT for the terms)
+
+DESCRIPTION = "LLVM based C/C++ compiler"
+HOMEPAGE = "http://clang.llvm.org/"
+SECTION = "devel"
+
+require clang.inc
+require common-source.inc
+
+INHIBIT_DEFAULT_DEPS = "1"
+
+BUILD_CC:class-nativesdk = "clang"
+BUILD_CXX:class-nativesdk = "clang++"
+BUILD_AR:class-nativesdk = "llvm-ar"
+BUILD_RANLIB:class-nativesdk = "llvm-ranlib"
+BUILD_NM:class-nativesdk = "llvm-nm"
+LDFLAGS:remove:class-nativesdk = "-fuse-ld=lld"
+
+LDFLAGS:append:class-target:riscv32 = " -Wl,--no-as-needed -latomic -Wl,--as-needed"
+LDFLAGS:append:class-target:mips = " -Wl,--no-as-needed -latomic -Wl,--as-needed"
+
+inherit cmake cmake-native pkgconfig python3native python3targetconfig
+
+OECMAKE_FIND_ROOT_PATH_MODE_PROGRAM = "BOTH"
+
+def get_clang_experimental_arch(bb, d, arch_var):
+    import re
+    a = d.getVar(arch_var, True)
+    return ""
+
+def get_clang_arch(bb, d, arch_var):
+    import re
+    a = d.getVar(arch_var, True)
+    if   re.match('(i.86|athlon|x86.64)$', a):         return 'X86'
+    elif re.match('arm$', a):                          return 'ARM'
+    elif re.match('armeb$', a):                        return 'ARM'
+    elif re.match('aarch64$', a):                      return 'AArch64'
+    elif re.match('aarch64_be$', a):                   return 'AArch64'
+    elif re.match('mips(isa|)(32|64|)(r6|)(el|)$', a): return 'Mips'
+    elif re.match('riscv32$', a):                      return 'riscv32'
+    elif re.match('riscv64$', a):                      return 'riscv64'
+    elif re.match('p(pc|owerpc)(|64)', a):             return 'PowerPC'
+    else:
+        bb.note("'%s' is not a primary llvm architecture" % a)
+    return ""
+
+def get_clang_host_arch(bb, d):
+    return get_clang_arch(bb, d, 'HOST_ARCH')
+
+def get_clang_target_arch(bb, d):
+    return get_clang_arch(bb, d, 'TARGET_ARCH')
+
+def get_clang_experimental_target_arch(bb, d):
+    return get_clang_experimental_arch(bb, d, 'TARGET_ARCH')
+
+PACKAGECONFIG ??= "compiler-rt libcplusplus shared-libs lldb-wchar \
+                   ${@bb.utils.filter('DISTRO_FEATURES', 'thin-lto lto', d)} \
+                   ${@bb.utils.contains('RUNTIME', 'llvm', 'compiler-rt libcplusplus unwindlib libomp', '', d)} \
+                   rtti eh libedit terminfo \
+                   "
+PACKAGECONFIG:class-native = "rtti eh libedit shared-libs ${@bb.utils.contains('RUNTIME', 'llvm', 'compiler-rt libcplusplus unwindlib libomp', '', d)}"
+PACKAGECONFIG:class-nativesdk = "rtti eh libedit shared-libs ${@bb.utils.filter('DISTRO_FEATURES', 'thin-lto lto', d)} ${@bb.utils.contains('RUNTIME', 'llvm', 'compiler-rt libcplusplus unwindlib libomp', '', d)}"
+
+PACKAGECONFIG[compiler-rt] = "-DCLANG_DEFAULT_RTLIB=compiler-rt,,"
+PACKAGECONFIG[libcplusplus] = "-DCLANG_DEFAULT_CXX_STDLIB=libc++,,"
+PACKAGECONFIG[unwindlib] = "-DCLANG_DEFAULT_UNWINDLIB=libunwind,-DCLANG_DEFAULT_UNWINDLIB=libgcc,,"
+PACKAGECONFIG[libomp] = "-DCLANG_DEFAULT_OPENMP_RUNTIME=libomp,,"
+PACKAGECONFIG[thin-lto] = "-DLLVM_ENABLE_LTO=Thin -DLLVM_BINUTILS_INCDIR=${STAGING_INCDIR},,binutils,"
+PACKAGECONFIG[lto] = "-DLLVM_ENABLE_LTO=Full -DLLVM_BINUTILS_INCDIR=${STAGING_INCDIR},,binutils,"
+PACKAGECONFIG[shared-libs] = "-DLLVM_BUILD_LLVM_DYLIB=ON -DLLVM_LINK_LLVM_DYLIB=ON,,,"
+PACKAGECONFIG[terminfo] = "-DLLVM_ENABLE_TERMINFO=ON -DCOMPILER_RT_TERMINFO_LIB=ON,-DLLVM_ENABLE_TERMINFO=OFF -DCOMPILER_RT_TERMINFO_LIB=OFF,ncurses,"
+PACKAGECONFIG[pfm] = "-DLLVM_ENABLE_LIBPFM=ON,-DLLVM_ENABLE_LIBPFM=OFF,libpfm,"
+PACKAGECONFIG[lldb-wchar] = "-DLLDB_EDITLINE_USE_WCHAR=1,-DLLDB_EDITLINE_USE_WCHAR=0,"
+PACKAGECONFIG[lldb-lua] = "-DLLDB_ENABLE_LUA=ON,-DLLDB_ENABLE_LUA=OFF,lua"
+PACKAGECONFIG[bootstrap] = "-DCLANG_ENABLE_BOOTSTRAP=On -DCLANG_BOOTSTRAP_PASSTHROUGH='${PASSTHROUGH}' -DBOOTSTRAP_LLVM_ENABLE_LTO=Thin -DBOOTSTRAP_LLVM_ENABLE_LLD=ON,,,"
+PACKAGECONFIG[eh] = "-DLLVM_ENABLE_EH=ON,-DLLVM_ENABLE_EH=OFF,,"
+PACKAGECONFIG[rtti] = "-DLLVM_ENABLE_RTTI=ON,-DLLVM_ENABLE_RTTI=OFF,,"
+PACKAGECONFIG[split-dwarf] = "-DLLVM_USE_SPLIT_DWARF=ON,-DLLVM_USE_SPLIT_DWARF=OFF,,"
+PACKAGECONFIG[libedit] = "-DLLVM_ENABLE_LIBEDIT=ON -DLLDB_ENABLE_LIBEDIT=ON,-DLLVM_ENABLE_LIBEDIT=OFF -DLLDB_ENABLE_LIBEDIT=OFF,libedit libedit-native"
+
+OECMAKE_SOURCEPATH = "${S}/llvm"
+
+OECMAKE_TARGET_COMPILE = "${@bb.utils.contains('PACKAGECONFIG', 'bootstrap', 'stage2', 'all', d)}"
+OECMAKE_TARGET_INSTALL = "${@bb.utils.contains('PACKAGECONFIG', 'bootstrap', 'stage2-install', 'install', d)}"
+BINPATHPREFIX = "${@bb.utils.contains('PACKAGECONFIG', 'bootstrap', '/tools/clang/stage2-bins/NATIVE', '', d)}"
+
+PASSTHROUGH = "\
+CLANG_DEFAULT_RTLIB;CLANG_DEFAULT_CXX_STDLIB;LLVM_BUILD_LLVM_DYLIB;LLVM_LINK_LLVM_DYLIB;\
+LLVM_ENABLE_ASSERTIONS;LLVM_ENABLE_EXPENSIVE_CHECKS;LLVM_ENABLE_PIC;\
+LLVM_BINDINGS_LIST;LLVM_ENABLE_FFI;FFI_INCLUDE_DIR;LLVM_OPTIMIZED_TABLEGEN;\
+LLVM_ENABLE_RTTI;LLVM_ENABLE_EH;LLVM_BUILD_EXTERNAL_COMPILER_RT;CMAKE_SYSTEM_NAME;\
+CMAKE_BUILD_TYPE;BUILD_SHARED_LIBS;LLVM_ENABLE_PROJECTS;LLVM_BINUTILS_INCDIR;\
+LLVM_TARGETS_TO_BUILD;LLVM_EXPERIMENTAL_TARGETS_TO_BUILD;PYTHON_EXECUTABLE;\
+PYTHON_LIBRARY;PYTHON_INCLUDE_DIR;LLVM_TEMPORARILY_ALLOW_OLD_TOOLCHAIN;LLDB_EDITLINE_USE_WCHAR;\
+LLVM_ENABLE_LIBEDIT;LLDB_ENABLE_LIBEDIT;LLDB_PYTHON_RELATIVE_PATH;LLDB_PYTHON_EXE_RELATIVE_PATH;\
+LLDB_PYTHON_EXT_SUFFIX;CMAKE_C_FLAGS_RELEASE;CMAKE_CXX_FLAGS_RELEASE;CMAKE_ASM_FLAGS_RELEASE;\
+CLANG_DEFAULT_CXX_STDLIB;CLANG_DEFAULT_RTLIB;CLANG_DEFAULT_UNWINDLIB;\
+CLANG_DEFAULT_OPENMP_RUNTIME;LLVM_ENABLE_PER_TARGET_RUNTIME_DIR;\
+LLVM_BUILD_TOOLS;LLVM_USE_HOST_TOOLS;LLVM_CONFIG_PATH;\
+"
+#
+# Default to build all OE-Core supported target arches (user overridable).
+# Gennerally setting LLVM_TARGETS_TO_BUILD = "" in local.conf is ok in most simple situations
+# where only one target architecture is needed along with just one build arch (usually X86)
+#
+LLVM_TARGETS_TO_BUILD ?= "AMDGPU;AArch64;ARM;BPF;Mips;PowerPC;RISCV;X86"
+
+LLVM_EXPERIMENTAL_TARGETS_TO_BUILD ?= ""
+LLVM_EXPERIMENTAL_TARGETS_TO_BUILD:append = ";${@get_clang_experimental_target_arch(bb, d)}"
+
+HF = ""
+HF:class-target = "${@ bb.utils.contains('TUNE_CCARGS_MFLOAT', 'hard', 'hf', '', d)}"
+HF[vardepvalue] = "${HF}"
+
+LLVM_PROJECTS ?= "clang;clang-tools-extra;lld${LLDB}"
+LLDB ?= ";lldb"
+# LLDB support for RISCV/Mips32 does not work yet
+LLDB:riscv32 = ""
+LLDB:riscv64 = ""
+LLDB:mips = ""
+LLDB:mipsel = ""
+LLDB:powerpc = ""
+
+# linux hosts (.so) on Windows .pyd
+SOLIBSDEV:mingw32 = ".pyd"
+
+#CMAKE_VERBOSE = "VERBOSE=1"
+
+EXTRA_OECMAKE += "-DLLVM_ENABLE_ASSERTIONS=OFF \
+                  -DLLVM_ENABLE_PER_TARGET_RUNTIME_DIR=OFF \
+                  -DLLVM_ENABLE_EXPENSIVE_CHECKS=OFF \
+                  -DLLVM_ENABLE_PIC=ON \
+                  -DCLANG_DEFAULT_PIE_ON_LINUX=ON \
+                  -DLLVM_BINDINGS_LIST='' \
+                  -DLLVM_ENABLE_FFI=ON \
+                  -DLLVM_ENABLE_ZSTD=ON \
+                  -DFFI_INCLUDE_DIR=$(pkg-config --variable=includedir libffi) \
+                  -DLLVM_OPTIMIZED_TABLEGEN=ON \
+                  -DLLVM_BUILD_EXTERNAL_COMPILER_RT=ON \
+                  -DCMAKE_SYSTEM_NAME=Linux \
+                  -DCMAKE_BUILD_TYPE=Release \
+                  -DCMAKE_CXX_FLAGS_RELEASE='${CXXFLAGS} -DNDEBUG -g0' \
+                  -DCMAKE_C_FLAGS_RELEASE='${CFLAGS} -DNDEBUG -g0' \
+                  -DBUILD_SHARED_LIBS=OFF \
+                  -DLLVM_ENABLE_PROJECTS='${LLVM_PROJECTS}' \
+                  -DLLVM_BINUTILS_INCDIR=${STAGING_INCDIR} \
+                  -DLLVM_TEMPORARILY_ALLOW_OLD_TOOLCHAIN=ON \
+                  -DLLVM_TARGETS_TO_BUILD='${LLVM_TARGETS_TO_BUILD}' \
+                  -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD='${LLVM_EXPERIMENTAL_TARGETS_TO_BUILD}' \
+"
+
+EXTRA_OECMAKE:append:class-native = "\
+                  -DPYTHON_EXECUTABLE='${PYTHON}' \
+"
+EXTRA_OECMAKE:append:class-nativesdk = "\
+                  -DCMAKE_CROSSCOMPILING:BOOL=ON \
+                  -DCROSS_TOOLCHAIN_FLAGS_NATIVE='-DLLDB_PYTHON_RELATIVE_PATH=${PYTHON_SITEPACKAGES_DIR} \
+                                                  -DLLDB_PYTHON_EXE_RELATIVE_PATH=${PYTHON} \
+                                                  -DLLDB_PYTHON_EXT_SUFFIX=${SOLIBSDEV} \
+                                                  -DCMAKE_TOOLCHAIN_FILE=${WORKDIR}/toolchain-native.cmake' \
+                  -DCMAKE_RANLIB=${STAGING_BINDIR_TOOLCHAIN}/${TARGET_PREFIX}llvm-ranlib \
+                  -DCMAKE_AR=${STAGING_BINDIR_TOOLCHAIN}/${TARGET_PREFIX}llvm-ar \
+                  -DCMAKE_NM=${STAGING_BINDIR_TOOLCHAIN}/${TARGET_PREFIX}llvm-nm \
+                  -DCMAKE_STRIP=${STAGING_BINDIR_TOOLCHAIN}/${TARGET_PREFIX}llvm-strip \
+                  -DLLVM_USE_HOST_TOOLS=OFF \
+                  -DLLVM_CONFIG_PATH=${STAGING_BINDIR_NATIVE}/llvm-config \
+                  -DLLVM_TABLEGEN=${STAGING_BINDIR_NATIVE}/llvm-tblgen \
+                  -DLLDB_TABLEGEN=${STAGING_BINDIR_NATIVE}/lldb-tblgen \
+                  -DCLANG_TABLEGEN=${STAGING_BINDIR_NATIVE}/clang-tblgen \
+                  -DCLANG_TIDY_CONFUSABLE_CHARS_GEN=${STAGING_BINDIR_NATIVE}/clang-tidy-confusable-chars-gen \
+                  -DCLANG_PSEUDO_GEN=${STAGING_BINDIR_NATIVE}/clang-pseudo-gen \
+                  -DPYTHON_LIBRARY=${STAGING_LIBDIR}/lib${PYTHON_DIR}${PYTHON_ABI}.so \
+                  -DLLDB_PYTHON_RELATIVE_PATH=${PYTHON_SITEPACKAGES_DIR} \
+                  -DLLDB_PYTHON_EXE_RELATIVE_PATH=${PYTHON} \
+                  -DLLDB_PYTHON_EXT_SUFFIX=${SOLIBSDEV} \
+                  -DPYTHON_INCLUDE_DIR=${STAGING_INCDIR}/${PYTHON_DIR}${PYTHON_ABI} \
+                  -DPYTHON_EXECUTABLE='${PYTHON}' \
+"
+EXTRA_OECMAKE:append:class-target = "\
+                  -DCMAKE_CROSSCOMPILING:BOOL=ON \
+                  -DLLVM_USE_HOST_TOOLS=OFF \
+                  -DLLVM_CONFIG_PATH=${STAGING_BINDIR_NATIVE}/llvm-config \
+                  -DLLVM_TABLEGEN=${STAGING_BINDIR_NATIVE}/llvm-tblgen \
+                  -DLLDB_TABLEGEN=${STAGING_BINDIR_NATIVE}/lldb-tblgen \
+                  -DCLANG_TABLEGEN=${STAGING_BINDIR_NATIVE}/clang-tblgen \
+                  -DCLANG_TIDY_CONFUSABLE_CHARS_GEN=${STAGING_BINDIR_NATIVE}/clang-tidy-confusable-chars-gen \
+                  -DCLANG_PSEUDO_GEN=${STAGING_BINDIR_NATIVE}/clang-pseudo-gen \
+                  -DCMAKE_RANLIB=${STAGING_BINDIR_TOOLCHAIN}/${TARGET_PREFIX}llvm-ranlib \
+                  -DCMAKE_AR=${STAGING_BINDIR_TOOLCHAIN}/${TARGET_PREFIX}llvm-ar \
+                  -DCMAKE_NM=${STAGING_BINDIR_TOOLCHAIN}/${TARGET_PREFIX}llvm-nm \
+                  -DCMAKE_STRIP=${STAGING_BINDIR_TOOLCHAIN}/${TARGET_PREFIX}llvm-strip \
+                  -DLLVM_TARGET_ARCH=${@get_clang_target_arch(bb, d)} \
+                  -DLLVM_DEFAULT_TARGET_TRIPLE=${TARGET_SYS}${HF} \
+                  -DLLVM_HOST_TRIPLE=${TARGET_SYS}${HF} \
+                  -DPYTHON_LIBRARY=${STAGING_LIBDIR}/lib${PYTHON_DIR}${PYTHON_ABI}.so \
+                  -DPYTHON_INCLUDE_DIR=${STAGING_INCDIR}/${PYTHON_DIR}${PYTHON_ABI} \
+                  -DLLVM_LIBDIR_SUFFIX=${@d.getVar('baselib').replace('lib', '')} \
+                  -DLLDB_PYTHON_RELATIVE_PATH=${PYTHON_SITEPACKAGES_DIR} \
+                  -DLLDB_PYTHON_EXE_RELATIVE_PATH=${bindir} \
+                  -DLLDB_PYTHON_EXT_SUFFIX=${SOLIBSDEV} \
+"
+
+DEPENDS = "binutils zlib zstd libffi libxml2 libxml2-native ninja-native swig-native"
+DEPENDS:append:class-nativesdk = " clang15-crosssdk-${SDK_ARCH} virtual/${TARGET_PREFIX}binutils-crosssdk nativesdk-python3"
+DEPENDS:append:class-target = " clang15-cross-${TARGET_ARCH} gcc-cross-${TARGET_ARCH} python3 compiler-rt15 libcxx15-initial"
+
+RRECOMMENDS:${PN} = "binutils"
+RRECOMMENDS:${PN}:append:class-target = " libcxx-dev"
+
+# patch out build host paths for reproducibility
+do_compile:prepend:class-target() {
+    sed -i -e "s,${STAGING_DIR_NATIVE},,g" \
+        -e "s,${STAGING_DIR_TARGET},,g" \
+        -e "s,${S},,g"  \
+        -e "s,${B},,g" \
+        ${B}/tools/llvm-config/BuildVariables.inc
+}
+
+do_install:append() {
+    rm -rf ${D}${libdir}/python*/site-packages/six.py
+}
+
+do_install:append:class-target () {
+    # Allow bin path to change based on YOCTO_ALTERNATE_EXE_PATH
+    sed -i 's;${_IMPORT_PREFIX}/bin;${_IMPORT_PREFIX_BIN};g' ${D}${libdir}/cmake/llvm/LLVMExports-release.cmake
+
+    # Insert function to populate Import Variables
+    sed -i "4i\
+if(DEFINED ENV{YOCTO_ALTERNATE_EXE_PATH})\n\
+  execute_process(COMMAND \"llvm-config\" \"--bindir\" OUTPUT_VARIABLE _IMPORT_PREFIX_BIN OUTPUT_STRIP_TRAILING_WHITESPACE)\n\
+else()\n\
+  set(_IMPORT_PREFIX_BIN \"\${_IMPORT_PREFIX}/bin\")\n\
+endif()\n" ${D}${libdir}/cmake/llvm/LLVMExports-release.cmake
+
+    if [ -n "${LLVM_LIBDIR_SUFFIX}" ]; then
+        mkdir -p ${D}${nonarch_libdir}
+        mv ${D}${libdir}/clang ${D}${nonarch_libdir}/clang
+        ln -rs ${D}${nonarch_libdir}/clang ${D}${libdir}/clang
+        rmdir --ignore-fail-on-non-empty ${D}${libdir}
+    fi
+    for t in clang clang++ llvm-nm llvm-ar llvm-as llvm-ranlib llvm-strip llvm-objcopy llvm-objdump llvm-readelf \
+        llvm-addr2line llvm-dwp llvm-size llvm-strings llvm-cov; do
+        ln -sf $t ${D}${bindir}/${TARGET_PREFIX}$t
+    done
+
+    # reproducibility
+    sed -i -e 's,${B},,g' ${D}${libdir}/cmake/llvm/LLVMConfig.cmake
+}
+
+do_install:append:class-native () {
+    install -Dm 0755 ${B}${BINPATHPREFIX}/bin/clang-tblgen ${D}${bindir}/clang-tblgen
+    install -Dm 0755 ${B}${BINPATHPREFIX}/bin/clang-pseudo-gen ${D}${bindir}/clang-pseudo-gen
+    install -Dm 0755 ${B}${BINPATHPREFIX}/bin/lldb-tblgen ${D}${bindir}/lldb-tblgen
+    install -Dm 0755 ${B}${BINPATHPREFIX}/bin/clang-tidy-confusable-chars-gen ${D}${bindir}/clang-tidy-confusable-chars-gen
+    for f in `find ${D}${bindir} -executable -type f -not -type l`; do
+        test -n "`file -b $f|grep -i ELF`" && ${STRIP} $f
+        echo "stripped $f"
+    done
+    ln -sf clang-tblgen ${D}${bindir}/clang-tblgen${PV}
+    ln -sf llvm-tblgen ${D}${bindir}/llvm-tblgen${PV}
+    ln -sf llvm-config ${D}${bindir}/llvm-config${PV}
+}
+
+do_install:append:class-nativesdk () {
+    install -Dm 0755 ${B}${BINPATHPREFIX}/bin/clang-tblgen ${D}${bindir}/clang-tblgen
+    install -Dm 0755 ${B}${BINPATHPREFIX}/bin/clang-pseudo-gen ${D}${bindir}/clang-pseudo-gen
+    install -Dm 0755 ${B}${BINPATHPREFIX}/bin/lldb-tblgen ${D}${bindir}/lldb-tblgen
+    install -Dm 0755 ${B}${BINPATHPREFIX}/bin/clang-tidy-confusable-chars-gen ${D}${bindir}/clang-tidy-confusable-chars-gen
+    for f in `find ${D}${bindir} -executable -type f -not -type l`; do
+        test -n "`file -b $f|grep -i ELF`" && ${STRIP} $f
+    done
+    ln -sf clang-tblgen ${D}${bindir}/clang-tblgen${PV}
+    ln -sf llvm-tblgen ${D}${bindir}/llvm-tblgen${PV}
+    ln -sf llvm-config ${D}${bindir}/llvm-config${PV}
+    rm -rf ${D}${datadir}/llvm/cmake
+    rm -rf ${D}${datadir}/llvm
+}
+
+PACKAGES =+ "${PN}-libllvm ${PN}-lldb-python ${PN}-libclang-cpp ${PN}-tidy ${PN}-format ${PN}-tools \
+             libclang15 lldb15 lldb15-server liblldb15 llvm15-linker-tools"
+
+PROVIDES += "llvm15 llvm15-${PV}"
+PROVIDES:append:class-native = " llvm15-native"
+
+BBCLASSEXTEND = "native nativesdk"
+
+RDEPENDS:lldb15 += "${PN}-lldb-python lldb15-server"
+
+RRECOMMENDS:${PN}-tidy += "${PN}-tools"
+
+FILES:llvm15-linker-tools = "${libdir}/LLVMgold* ${libdir}/libLTO.so.* ${libdir}/LLVMPolly*"
+
+FILES:${PN}-libclang-cpp = "${libdir}/libclang-cpp.so.*"
+
+FILES:${PN}-lldb-python = "${libdir}/python*/site-packages/lldb/*"
+
+FILES:${PN}-tidy = "${bindir}/*clang-tidy*"
+FILES:${PN}-format = "${bindir}/*clang-format*"
+
+FILES:${PN}-tools = "${bindir}/analyze-build \
+  ${bindir}/c-index-test \
+  ${bindir}/clang-apply-replacements \
+  ${bindir}/clang-change-namespace \
+  ${bindir}/clang-check \
+  ${bindir}/clang-cl \
+  ${bindir}/clang-doc \
+  ${bindir}/clang-extdef-mapping \
+  ${bindir}/clang-include-fixer \
+  ${bindir}/clang-linker-wrapper \
+  ${bindir}/clang-move \
+  ${bindir}/clang-nvlink-wrapper \
+  ${bindir}/clang-offload-bundler \
+  ${bindir}/clang-offload-packager \
+  ${bindir}/clang-pseudo \
+  ${bindir}/clang-query \
+  ${bindir}/clang-refactor \
+  ${bindir}/clang-rename \
+  ${bindir}/clang-reorder-fields \
+  ${bindir}/clang-repl \
+  ${bindir}/clang-scan-deps \
+  ${bindir}/diagtool \
+  ${bindir}/find-all-symbols \
+  ${bindir}/hmaptool \
+  ${bindir}/hwasan_symbolize \
+  ${bindir}/intercept-build \
+  ${bindir}/modularize \
+  ${bindir}/pp-trace \
+  ${bindir}/sancov \
+  ${bindir}/scan-build \
+  ${bindir}/scan-build-py \
+  ${bindir}/scan-view \
+  ${bindir}/split-file \
+  ${libdir}/libscanbuild/* \
+  ${libdir}/libear/* \
+  ${libexecdir}/analyze-c++ \
+  ${libexecdir}/analyze-cc \
+  ${libexecdir}/c++-analyzer \
+  ${libexecdir}/ccc-analyzer \
+  ${libexecdir}/intercept-c++ \
+  ${libexecdir}/intercept-cc \
+  ${datadir}/scan-build/* \
+  ${datadir}/scan-view/* \
+  ${datadir}/opt-viewer/* \
+  ${datadir}/clang/* \
+"
+
+FILES:${PN} += "\
+  ${libdir}/BugpointPasses.so \
+  ${libdir}/LLVMHello.so \
+  ${libdir}/LLVMgold.so \
+  ${libdir}/*Plugin.so \
+  ${libdir}/${BPN} \
+  ${nonarch_libdir}/clang/*/include/ \
+  ${datadir}/scan-* \
+  ${nonarch_libdir}/libscanbuild \
+  ${datadir}/opt-viewer/ \
+"
+
+FILES:lldb15 = "\
+  ${bindir}/lldb \
+  ${bindir}/lldb-argdumper \
+  ${bindir}/lldb-instr \
+  ${bindir}/lldb-vscode \
+"
+
+FILES:lldb15-server = "\
+  ${bindir}/lldb-server \
+"
+
+FILES:liblldb15 = "\
+  ${libdir}/liblldbIntelFeatures.so.* \
+  ${libdir}/liblldb.so.* \
+"
+
+FILES:${PN}-libllvm =+ "\
+  ${libdir}/libLLVM-${MAJOR_VER}.${MINOR_VER}.so \
+  ${libdir}/libLLVM-${MAJOR_VER}.so \
+  ${libdir}/libLLVM-${MAJOR_VER}git.so \
+  ${libdir}/libLLVM-${MAJOR_VER}.${MINOR_VER}git.so \
+  ${libdir}/libRemarks.so.* \
+"
+
+FILES:libclang15 = "\
+  ${libdir}/libclang.so.* \
+"
+
+FILES:${PN}-dev += "\
+  ${datadir}/llvm/cmake \
+  ${libdir}/cmake \
+  ${nonarch_libdir}/libear \
+  ${nonarch_libdir}/${BPN}/*.la \
+"
+
+FILES:${PN}-staticdev += "${nonarch_libdir}/${BPN}/*.a"
+
+FILES:${PN}-staticdev:remove = "${libdir}/${BPN}/*.a"
+FILES:${PN}-dev:remove = "${libdir}/${BPN}/*.la"
+FILES:${PN}:remove = "${libdir}/${BPN}/*"
+
+
+INSANE_SKIP:${PN} += "already-stripped"
+#INSANE_SKIP:${PN}-dev += "dev-elf"
+INSANE_SKIP:${PN}-lldb-python += "dev-so dev-deps"
+INSANE_SKIP:${MLPREFIX}liblldb = "dev-so"
+
+#Avoid SSTATE_SCAN_COMMAND running sed over llvm-config.
+SSTATE_SCAN_FILES:remove = "*-config"
+
+TOOLCHAIN = "clang15"
+TOOLCHAIN:class-native = "gcc"
+TOOLCHAIN:class-nativesdk = "clang15"
+COMPILER_RT:class-nativesdk:toolchain-clang:runtime-llvm = "-rtlib=libgcc --unwindlib=libgcc"
+LIBCPLUSPLUS:class-nativesdk:toolchain-clang:runtime-llvm = "-stdlib=libstdc++"
+
+SYSROOT_DIRS:append:class-target = " ${nonarch_libdir}"
+
+SYSROOT_PREPROCESS_FUNCS:append:class-target = " clang_sysroot_preprocess"
+
+clang_sysroot_preprocess() {
+	install -d ${SYSROOT_DESTDIR}${bindir_crossscripts}/
+	install -m 0755 ${S}/../llvm-config ${SYSROOT_DESTDIR}${bindir_crossscripts}/
+	ln -sf llvm-config ${SYSROOT_DESTDIR}${bindir_crossscripts}/llvm-config${PV}
+	# LLDTargets.cmake references the lld executable(!) that some modules/plugins link to
+	install -d ${SYSROOT_DESTDIR}${bindir}
+	for f in lld diagtool clang-${MAJOR_VER} clang-format clang-offload-packager \
+            clang-offload-bundler clang-scan-deps clang-repl \
+            clang-rename clang-refactor clang-check clang-extdef-mapping clang-apply-replacements \
+            clang-reorder-fields clang-tidy clang-change-namespace clang-doc clang-include-fixer \
+            find-all-symbols clang-move clang-query pp-trace clang-pseudo clangd modularize
+	do
+		install -m 755 ${D}${bindir}/$f ${SYSROOT_DESTDIR}${bindir}/
+	done
+}

--- a/recipes-devtools/clang15/common-source.inc
+++ b/recipes-devtools/clang15/common-source.inc
@@ -1,0 +1,17 @@
+do_fetch() {
+        :
+}
+do_fetch[noexec] = "1"
+deltask do_unpack
+deltask do_patch
+
+SRC_URI = ""
+
+do_configure[depends] += "llvm-project-source-${PV}:do_patch"
+do_populate_lic[depends] += "llvm-project-source-${PV}:do_unpack"
+do_create_spdx[depends] += "llvm-project-source-${PV}:do_patch"
+
+# spdx shared workdir detection fails as not WORKDIR is altered but S and B
+# return always true to fix that
+def is_work_shared_spdx(d):
+    return True

--- a/recipes-devtools/clang15/common.inc
+++ b/recipes-devtools/clang15/common.inc
@@ -1,0 +1,59 @@
+FILESEXTRAPATHS =. "${FILE_DIRNAME}/clang:"
+
+LIC_FILES_CHKSUM = "file://llvm/LICENSE.TXT;md5=${LLVMMD5SUM} \
+                    file://clang/LICENSE.TXT;md5=${CLANGMD5SUM} \
+"
+LICENSE = "Apache-2.0-with-LLVM-exception"
+
+BASEURI ??= "${LLVM_GIT}/llvm-project;protocol=${LLVM_GIT_PROTOCOL};branch=${BRANCH}"
+SRC_URI = "\
+    ${BASEURI} \
+    file://llvm-config \
+    file://libunwind.pc.in \
+    file://0001-libcxxabi-Find-libunwind-headers-when-LIBCXXABI_LIBU.patch \
+    file://0002-compiler-rt-support-a-new-embedded-linux-target.patch \
+    file://0003-compiler-rt-Simplify-cross-compilation.-Don-t-use-na.patch \
+    file://0004-llvm-TargetLibraryInfo-Undefine-libc-functions-if-th.patch \
+    file://0005-llvm-allow-env-override-of-exe-and-libdir-path.patch \
+    file://0006-clang-driver-Check-sysroot-for-ldso-path.patch \
+    file://0007-clang-Driver-tools.cpp-Add-lssp_nonshared-on-musl.patch \
+    file://0008-clang-Prepend-trailing-to-sysroot.patch \
+    file://0009-clang-Look-inside-the-target-sysroot-for-compiler-ru.patch \
+    file://0010-clang-Define-releative-gcc-installation-dir.patch \
+    file://0011-clang-Add-lpthread-and-ldl-along-with-lunwind-for-st.patch \
+    file://0012-Pass-PYTHON_EXECUTABLE-when-cross-compiling-for-nati.patch \
+    file://0013-Check-for-atomic-double-intrinsics.patch \
+    file://0014-libcxx-Add-compiler-runtime-library-to-link-step-for.patch \
+    file://0015-clang-llvm-cmake-Fix-configure-for-packages-using-fi.patch \
+    file://0016-clang-Fix-resource-dir-location-for-cross-toolchains.patch \
+    file://0017-clang-driver-Add-dyld-prefix-when-checking-sysroot-f.patch \
+    file://0018-clang-Use-python3-in-python-scripts.patch \
+    file://0019-For-x86_64-set-Yocto-based-GCC-install-search-path.patch \
+    file://0020-llvm-Do-not-use-find_library-for-ncurses.patch \
+    file://0021-llvm-Insert-anchor-for-adding-OE-distro-vendor-names.patch \
+    file://0022-compiler-rt-Do-not-use-backtrace-APIs-on-non-glibc-l.patch \
+    file://0023-clang-Fix-x86-triple-for-non-debian-multiarch-linux-.patch \
+    file://0024-compiler-rt-Link-scudo-with-SANITIZER_CXX_ABI_LIBRAR.patch \
+    file://0025-libunwind-Added-unw_backtrace-method.patch \
+    file://0026-clang-Do-not-use-install-relative-libc-headers.patch \
+    file://0027-clang-Fix-how-driver-finds-GCC-installation-path-on-.patch \
+    file://0028-Fix-lib-paths-for-OpenEmbedded-Host.patch \
+    file://0029-Correct-library-search-path-for-OpenEmbedded-Host.patch \
+    file://0030-lldb-Link-with-libatomic-on-x86.patch \
+    file://0031-clang-exclude-openembedded-distributions-from-settin.patch \
+    file://0032-compiler-rt-Enable-__int128-for-ppc32.patch \
+    file://0033-llvm-Do-not-use-cmake-infra-to-detect-libzstd.patch \
+    file://0034-compiler-rt-Fix-stat-struct-s-size-for-O32-ABI.patch \
+    file://0035-cmake-Enable-64bit-off_t-on-32bit-glibc-systems.patch \
+    file://0036-compiler-rt-Undef-_TIME_BITS-along-with-_FILE_OFFSET.patch \
+    "
+# Fallback to no-PIE if not set
+GCCPIE ??= ""
+
+S = "${TMPDIR}/work-shared/llvm-project-source-${PV}-${PR}/git"
+B = "${WORKDIR}/llvm-project-source-${PV}/build.${HOST_SYS}.${TARGET_SYS}"
+
+# We need to ensure that for the shared work directory, the do_patch signatures match
+# The real WORKDIR location isn't a dependency for the shared workdir.
+src_patches[vardepsexclude] = "WORKDIR"
+should_apply[vardepsexclude] += "PN"

--- a/recipes-devtools/clang15/compiler-rt15-sanitizers_git.bb
+++ b/recipes-devtools/clang15/compiler-rt15-sanitizers_git.bb
@@ -1,0 +1,114 @@
+# Copyright (C) 2021 Khem Raj <raj.khem@gmail.com>
+# Released under the MIT license (see COPYING.MIT for the terms)
+
+DESCRIPTION = "LLVM based C/C++ compiler Runtime"
+HOMEPAGE = "http://compiler-rt.llvm.org/"
+SECTION = "base"
+
+require clang.inc
+require common-source.inc
+
+inherit cmake pkgconfig python3native
+
+
+LIC_FILES_CHKSUM = "file://compiler-rt/LICENSE.TXT;md5=d846d1d65baf322d4c485d6ee54e877a"
+
+TUNE_CCARGS:remove = "-no-integrated-as"
+
+DEPENDS += "ninja-native virtual/crypt"
+DEPENDS:append:class-native = " clang15-native libxcrypt-native"
+DEPENDS:append:class-nativesdk = " clang15-native clang15-crosssdk-${SDK_ARCH} nativesdk-libxcrypt"
+
+PACKAGECONFIG ??= ""
+PACKAGECONFIG[crt] = "-DCOMPILER_RT_BUILD_CRT:BOOL=ON,-DCOMPILER_RT_BUILD_CRT:BOOL=OFF"
+PACKAGECONFIG[static-libcxx] = "-DSANITIZER_USE_STATIC_CXX_ABI=ON -DSANITIZER_USE_STATIC_LLVM_UNWINDER=ON -DCOMPILER_RT_ENABLE_STATIC_UNWINDER=ON,,"
+
+HF = ""
+HF:class-target = "${@ bb.utils.contains('TUNE_CCARGS_MFLOAT', 'hard', 'hf', '', d)}"
+HF[vardepvalue] = "${HF}"
+
+CXXFLAGS:append:libc-musl = " -D_LARGEFILE64_SOURCE"
+
+OECMAKE_TARGET_COMPILE = "compiler-rt"
+OECMAKE_TARGET_INSTALL = "install-compiler-rt install-compiler-rt-headers"
+OECMAKE_SOURCEPATH = "${S}/llvm"
+EXTRA_OECMAKE += "-DCMAKE_BUILD_TYPE=RelWithDebInfo \
+                  -DLLVM_ENABLE_PER_TARGET_RUNTIME_DIR=OFF \
+                  -DCOMPILER_RT_STANDALONE_BUILD=OFF \
+                  -DCOMPILER_RT_DEFAULT_TARGET_ONLY=ON \
+                  -DCOMPILER_RT_USE_BUILTINS_LIBRARY=ON \
+                  -DCMAKE_C_COMPILER_TARGET=${HOST_ARCH}${HF}${HOST_VENDOR}-${HOST_OS} \
+                  -DCOMPILER_RT_BUILD_BUILTINS=OFF \
+                  -DSANITIZER_CXX_ABI_LIBNAME=${@bb.utils.contains("RUNTIME", "llvm", "libc++", "libstdc++", d)} \
+                  -DCOMPILER_RT_BUILD_XRAY=ON \
+                  -DCOMPILER_RT_BUILD_SANITIZERS=ON \
+                  -DCOMPILER_RT_BUILD_LIBFUZZER=ON \
+                  -DCOMPILER_RT_BUILD_PROFILE=ON \
+                  -DCOMPILER_RT_BUILD_MEMPROF=ON \
+                  -DLLVM_ENABLE_PROJECTS='compiler-rt' \
+                  -DCMAKE_RANLIB=${STAGING_BINDIR_TOOLCHAIN}/${TARGET_PREFIX}llvm-ranlib \
+                  -DCMAKE_AR=${STAGING_BINDIR_TOOLCHAIN}/${TARGET_PREFIX}llvm-ar \
+                  -DCMAKE_NM=${STAGING_BINDIR_TOOLCHAIN}/${TARGET_PREFIX}llvm-nm \
+                  -DLLVM_LIBDIR_SUFFIX=${LLVM_LIBDIR_SUFFIX} \
+"
+
+EXTRA_OECMAKE:append:class-nativesdk = "\
+               -DLLVM_TABLEGEN=${STAGING_BINDIR_NATIVE}/llvm-tblgen \
+               -DCLANG_TABLEGEN=${STAGING_BINDIR_NATIVE}/clang-tblgen \
+"
+
+EXTRA_OECMAKE:append:class-target = "\
+               -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+"
+
+EXTRA_OECMAKE:append:libc-musl = " -DLIBCXX_HAS_MUSL_LIBC=ON "
+EXTRA_OECMAKE:append:powerpc = " -DCOMPILER_RT_DEFAULT_TARGET_ARCH=powerpc "
+
+do_install:append () {
+    if [ -n "${LLVM_LIBDIR_SUFFIX}" ]; then
+        mkdir -p ${D}${nonarch_libdir}
+        mv ${D}${libdir}/clang ${D}${nonarch_libdir}/clang
+        rmdir --ignore-fail-on-non-empty ${D}${libdir}
+    fi
+    # Already shipped with compile-rt Orc support
+    rm -rf ${D}${nonarch_libdir}/clang/${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}/lib/linux/libclang_rt.orc-*.a
+    rm -rf ${D}${nonarch_libdir}/clang/${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}/include/orc/
+}
+
+FILES_SOLIBSDEV = ""
+FILES:${PN} += "${nonarch_libdir}/clang/${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}/lib/linux/lib*${SOLIBSDEV} \
+                ${nonarch_libdir}/clang/${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}/*.txt \
+                ${nonarch_libdir}/clang/${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}/share/*.txt"
+FILES:${PN}-staticdev += "${nonarch_libdir}/clang/${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}/lib/linux/*.a"
+FILES:${PN}-dev += "${datadir} ${nonarch_libdir}/clang/${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}/lib/linux/*.syms \
+                    ${nonarch_libdir}/clang/${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}/include \
+                    ${nonarch_libdir}/clang/${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}/lib/linux/clang_rt.crt*.o \
+                    ${nonarch_libdir}/clang/${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}/lib/linux/libclang_rt.asan-preinit*.a \
+                   "
+INSANE_SKIP:${PN} = "dev-so libdir"
+INSANE_SKIP:${PN}-dbg = "libdir"
+
+#PROVIDES:append:class-target = "\
+#        virtual/${TARGET_PREFIX}compilerlibs \
+#        libgcc \
+#        libgcc-initial \
+#        libgcc-dev \
+#        libgcc-initial-dev \
+#        "
+#
+
+RDEPENDS:${PN}-dev += "${PN}-staticdev"
+
+BBCLASSEXTEND = "native nativesdk"
+
+ALLOW_EMPTY:${PN} = "1"
+ALLOW_EMPTY:${PN}-dev = "1"
+
+TOOLCHAIN:forcevariable = "clang15"
+SYSROOT_DIRS:append:class-target = " ${nonarch_libdir}"
+
+# riscv and x86_64 Sanitizers work on musl too
+COMPATIBLE_HOST:libc-musl:x86-64 = "(.*)"
+COMPATIBLE_HOST:libc-musl:riscv64 = "(.*)"
+COMPATIBLE_HOST:libc-musl:riscv32 = "(.*)"
+COMPATIBLE_HOST:libc-musl = "null"

--- a/recipes-devtools/clang15/compiler-rt15_git.bb
+++ b/recipes-devtools/clang15/compiler-rt15_git.bb
@@ -1,0 +1,124 @@
+# Copyright (C) 2015 Khem Raj <raj.khem@gmail.com>
+# Released under the MIT license (see COPYING.MIT for the terms)
+
+DESCRIPTION = "LLVM based C/C++ compiler Runtime"
+HOMEPAGE = "http://compiler-rt.llvm.org/"
+SECTION = "base"
+
+require clang.inc
+require common-source.inc
+
+inherit cmake cmake-native clang15 pkgconfig python3native
+
+LIC_FILES_CHKSUM = "file://compiler-rt/LICENSE.TXT;md5=d846d1d65baf322d4c485d6ee54e877a"
+
+LIBCPLUSPLUS = ""
+COMPILER_RT = ""
+
+TUNE_CCARGS:remove = "-no-integrated-as"
+
+INHIBIT_DEFAULT_DEPS = "1"
+
+DEPENDS += "ninja-native libgcc"
+DEPENDS:append:class-target = " clang15-cross-${TARGET_ARCH} virtual/${MLPREFIX}libc gcc-runtime"
+DEPENDS:append:class-nativesdk = " clang15-native clang15-crosssdk-${SDK_ARCH} nativesdk-gcc-runtime"
+DEPENDS:append:class-native = " clang15-native"
+
+# Trick clang.bbclass into not creating circular dependencies
+UNWINDLIB:class-nativesdk = "--unwindlib=libgcc"
+COMPILER_RT:class-nativesdk:toolchain-clang15:runtime-llvm = "-rtlib=libgcc --unwindlib=libgcc"
+LIBCPLUSPLUS:class-nativesdk:toolchain-clang15:runtime-llvm = "-stdlib=libstdc++"
+
+CXXFLAGS += "-stdlib=libstdc++"
+LDFLAGS += "-unwindlib=libgcc -rtlib=libgcc -stdlib=libstdc++"
+BUILD_CXXFLAGS += "-stdlib=libstdc++"
+BUILD_LDFLAGS += "-unwindlib=libgcc -rtlib=libgcc -stdlib=libstdc++"
+BUILD_CPPFLAGS:remove = "-stdlib=libc++"
+BUILD_LDFLAGS:remove = "-stdlib=libc++ -lc++abi"
+
+BUILD_CC:toolchain-clang15  = "${CCACHE}clang"
+BUILD_CXX:toolchain-clang15 = "${CCACHE}clang++"
+BUILD_CPP:toolchain-clang15 = "${CCACHE}clang -E"
+BUILD_CCLD:toolchain-clang15 = "${CCACHE}clang"
+BUILD_RANLIB:toolchain-clang15 = "llvm-ranlib"
+BUILD_AR:toolchain-clang15 = "llvm-ar"
+BUILD_NM:toolchain-clang15 = "llvm-nm"
+
+PACKAGECONFIG ??= ""
+PACKAGECONFIG[crt] = "-DCOMPILER_RT_BUILD_CRT:BOOL=ON,-DCOMPILER_RT_BUILD_CRT:BOOL=OFF"
+PACKAGECONFIG[profile] ="-DCOMPILER_RT_BUILD_PROFILE=ON,-DCOMPILER_RT_BUILD_PROFILE=OFF"
+
+HF = ""
+HF:class-target = "${@ bb.utils.contains('TUNE_CCARGS_MFLOAT', 'hard', 'hf', '', d)}"
+HF[vardepvalue] = "${HF}"
+
+OECMAKE_TARGET_COMPILE = "compiler-rt"
+OECMAKE_TARGET_INSTALL = "install-compiler-rt install-compiler-rt-headers"
+OECMAKE_SOURCEPATH = "${S}/llvm"
+EXTRA_OECMAKE += "-DCMAKE_BUILD_TYPE=RelWithDebInfo \
+                  -DLLVM_ENABLE_PER_TARGET_RUNTIME_DIR=OFF \
+                  -DCOMPILER_RT_STANDALONE_BUILD=OFF \
+                  -DCOMPILER_RT_DEFAULT_TARGET_ONLY=ON \
+                  -DCMAKE_C_COMPILER_TARGET=${HOST_ARCH}${HF}${HOST_VENDOR}-${HOST_OS} \
+                  -DCOMPILER_RT_BUILD_XRAY=OFF \
+                  -DCOMPILER_RT_BUILD_SANITIZERS=OFF \
+                  -DCOMPILER_RT_BUILD_MEMPROF=OFF \
+                  -DCOMPILER_RT_BUILD_LIBFUZZER=OFF \
+                  -DLLVM_ENABLE_PROJECTS='compiler-rt' \
+                  -DLLVM_LIBDIR_SUFFIX=${LLVM_LIBDIR_SUFFIX} \
+"
+EXTRA_OECMAKE:append:class-target = "\
+               -DCMAKE_RANLIB=${STAGING_BINDIR_TOOLCHAIN}/${TARGET_PREFIX}llvm-ranlib \
+               -DCMAKE_AR=${STAGING_BINDIR_TOOLCHAIN}/${TARGET_PREFIX}llvm-ar \
+               -DCMAKE_NM=${STAGING_BINDIR_TOOLCHAIN}/${TARGET_PREFIX}llvm-nm \
+               -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+"
+
+EXTRA_OECMAKE:append:class-nativesdk = "\
+               -DCMAKE_RANLIB=${STAGING_BINDIR_TOOLCHAIN}/${TARGET_PREFIX}llvm-ranlib \
+               -DCMAKE_AR=${STAGING_BINDIR_TOOLCHAIN}/${TARGET_PREFIX}llvm-ar \
+               -DCMAKE_NM=${STAGING_BINDIR_TOOLCHAIN}/${TARGET_PREFIX}llvm-nm \
+               -DLLVM_TABLEGEN=${STAGING_BINDIR_NATIVE}/llvm-tblgen \
+               -DCLANG_TABLEGEN=${STAGING_BINDIR_NATIVE}/clang-tblgen \
+"
+EXTRA_OECMAKE:append:powerpc = " -DCOMPILER_RT_DEFAULT_TARGET_ARCH=powerpc "
+
+do_install:append () {
+    if [ -n "${LLVM_LIBDIR_SUFFIX}" ]; then
+        mkdir -p ${D}${nonarch_libdir}
+        mv ${D}${libdir}/clang ${D}${nonarch_libdir}/clang
+        rmdir --ignore-fail-on-non-empty ${D}${libdir}
+    fi
+}
+
+FILES_SOLIBSDEV = ""
+FILES:${PN} += "${nonarch_libdir}/clang/${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}/lib/linux/lib*${SOLIBSDEV} \
+                ${nonarch_libdir}/clang/${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}/*.txt \
+                ${nonarch_libdir}/clang/${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}/share/*.txt"
+FILES:${PN}-staticdev += "${nonarch_libdir}/clang/${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}/lib/linux/*.a"
+FILES:${PN}-dev += "${datadir} ${nonarch_libdir}/clang/${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}/lib/linux/*.syms \
+                    ${nonarch_libdir}/clang/${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}/include \
+                    ${nonarch_libdir}/clang/${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}/lib/linux/clang_rt.crt*.o \
+                    ${nonarch_libdir}/clang/${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}/lib/linux/libclang_rt.asan-preinit*.a \
+                   "
+INSANE_SKIP:${PN} = "dev-so libdir"
+INSANE_SKIP:${PN}-dbg = "libdir"
+
+#PROVIDES:append:class-target = "\
+#        virtual/${TARGET_PREFIX}compilerlibs \
+#        libgcc \
+#        libgcc-initial \
+#        libgcc-dev \
+#        libgcc-initial-dev \
+#        "
+#
+
+RDEPENDS:${PN}-dev += "${PN}-staticdev"
+
+BBCLASSEXTEND = "native nativesdk"
+
+ALLOW_EMPTY:${PN} = "1"
+ALLOW_EMPTY:${PN}-dev = "1"
+
+TOOLCHAIN:forcevariable = "clang15"
+SYSROOT_DIRS:append:class-target = " ${nonarch_libdir}"

--- a/recipes-devtools/clang15/libclc15_git.bb
+++ b/recipes-devtools/clang15/libclc15_git.bb
@@ -1,0 +1,48 @@
+DESCRIPTION = "LLVM based OpenCL runtime support library"
+HOMEPAGE = "http://libclc.llvm.org/"
+SECTION = "libs"
+
+require clang.inc
+require common-source.inc
+
+TOOLCHAIN = "clang15"
+
+LIC_FILES_CHKSUM = "file://libclc/LICENSE.TXT;md5=7cc795f6cbb2d801d84336b83c8017db"
+
+inherit cmake pkgconfig python3native qemu
+
+DEPENDS += "qemu-native clang15 spirv-tools spirv-llvm-translator spirv-llvm-translator-native ncurses"
+
+OECMAKE_SOURCEPATH = "${S}/libclc"
+
+EXTRA_OECMAKE += " \
+                                -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+                                -DLLVM_ENABLE_PER_TARGET_RUNTIME_DIR=OFF \
+				-DCMAKE_CROSSCOMPILING_EMULATOR=${WORKDIR}/qemuwrapper \
+				-DLLVM_CLANG=${STAGING_BINDIR_NATIVE}/clang \
+				-DLLVM_AS=${STAGING_BINDIR_NATIVE}/llvm-as \
+				-DLLVM_LINK=${STAGING_BINDIR_NATIVE}/llvm-link \
+				-DLLVM_OPT=${STAGING_BINDIR_NATIVE}/opt \
+				-DLLVM_SPIRV=${STAGING_BINDIR_NATIVE}/llvm-spirv \
+				-Dclc_comp_in:FILEPATH=${OECMAKE_SOURCEPATH}/cmake/CMakeCLCCompiler.cmake.in \
+				-Dll_comp_in:FILEPATH=${OECMAKE_SOURCEPATH}/cmake/CMakeLLAsmCompiler.cmake.in \
+				-DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+			"
+
+do_configure:prepend () {
+	# Write out a qemu wrapper that will be used by cmake
+	# so that it can run target helper binaries through that.
+	qemu_binary="${@qemu_wrapper_cmdline(d, d.getVar('STAGING_DIR_HOST'), [d.expand('${STAGING_DIR_HOST}${libdir}'),d.expand('${STAGING_DIR_HOST}${base_libdir}')])}"
+	cat > ${WORKDIR}/qemuwrapper << EOF
+#!/bin/sh
+$qemu_binary "\$@"
+EOF
+	chmod +x ${WORKDIR}/qemuwrapper
+}
+
+FILES:${PN} += "${datadir}/clc"
+
+BBCLASSEXTEND = "native nativesdk"
+
+export YOCTO_ALTERNATE_EXE_PATH
+export YOCTO_ALTERNATE_LIBDIR

--- a/recipes-devtools/clang15/libclc15_git.bb
+++ b/recipes-devtools/clang15/libclc15_git.bb
@@ -11,7 +11,7 @@ LIC_FILES_CHKSUM = "file://libclc/LICENSE.TXT;md5=7cc795f6cbb2d801d84336b83c8017
 
 inherit cmake pkgconfig python3native qemu
 
-DEPENDS += "qemu-native clang15 spirv-tools spirv-llvm-translator spirv-llvm-translator-native ncurses"
+DEPENDS += "qemu-native clang15 spirv-tools spirv-llvm-translator-llvm15 spirv-llvm-translator-llvm15-native ncurses"
 
 OECMAKE_SOURCEPATH = "${S}/libclc"
 

--- a/recipes-devtools/clang15/libcxx15-initial_git.bb
+++ b/recipes-devtools/clang15/libcxx15-initial_git.bb
@@ -1,0 +1,115 @@
+# Copyright (C) 2015 Khem Raj <raj.khem@gmail.com>
+# Released under the MIT license (see COPYING.MIT for the terms)
+
+DESCRIPTION = "libc++ is a new implementation of the C++ standard library, targeting C++11"
+HOMEPAGE = "http://libcxx.llvm.org/"
+SECTION = "base"
+
+require clang.inc
+require common-source.inc
+
+inherit cmake cmake-native clang15 python3native
+
+PACKAGECONFIG ??= "compiler-rt exceptions ${@bb.utils.contains("RUNTIME", "llvm", "unwind unwind-shared", "", d)}"
+PACKAGECONFIG:append:armv5 = " no-atomics"
+PACKAGECONFIG:remove:class-native = "compiler-rt"
+PACKAGECONFIG[unwind] = "-DLIBCXXABI_USE_LLVM_UNWINDER=ON -DLIBCXXABI_ENABLE_STATIC_UNWINDER=ON,-DLIBCXXABI_USE_LLVM_UNWINDER=OFF,,"
+PACKAGECONFIG[exceptions] = "-DLIBCXXABI_ENABLE_EXCEPTIONS=ON -DDLIBCXX_ENABLE_EXCEPTIONS=ON,-DLIBCXXABI_ENABLE_EXCEPTIONS=OFF -DLIBCXX_ENABLE_EXCEPTIONS=OFF -DCMAKE_REQUIRED_FLAGS='-fno-exceptions',"
+PACKAGECONFIG[no-atomics] = "-D_LIBCXXABI_HAS_ATOMIC_BUILTINS=OFF -DCMAKE_SHARED_LINKER_FLAGS='-latomic',,"
+PACKAGECONFIG[compiler-rt] = "-DLIBCXX_USE_COMPILER_RT=ON -DLIBCXXABI_USE_COMPILER_RT=ON -DLIBUNWIND_USE_COMPILER_RT=ON,,compiler-rt15"
+PACKAGECONFIG[unwind-shared] = "-DLIBUNWIND_ENABLE_SHARED=ON,-DLIBUNWIND_ENABLE_SHARED=OFF,,"
+
+DEPENDS += "ninja-native"
+DEPENDS:append:class-target = " clang15-cross-${TARGET_ARCH} virtual/${MLPREFIX}libc virtual/${TARGET_PREFIX}compilerlibs"
+DEPENDS:append:class-nativesdk = " clang15-crosssdk-${SDK_ARCH} nativesdk-compiler-rt15"
+DEPENDS:append:class-native = " clang15-native"
+
+LIBCPLUSPLUS = ""
+COMPILER_RT ?= "-rtlib=compiler-rt"
+
+# Trick clang.bbclass into not creating circular dependencies
+UNWINDLIB:class-nativesdk = "--unwindlib=libgcc"
+COMPILER_RT:class-nativesdk = "-rtlib=libgcc --unwindlib=libgcc"
+LIBCPLUSPLUS:class-nativesdk = "-stdlib=libstdc++"
+
+CC:append:toolchain-clang15:class-native = " -unwindlib=libgcc -rtlib=libgcc"
+CC:append:toolchain-clang15:class-nativesdk = " -unwindlib=libgcc -rtlib=libgcc"
+
+CXXFLAGS += "-stdlib=libstdc++"
+LDFLAGS += "-unwindlib=libgcc -stdlib=libstdc++"
+BUILD_CXXFLAGS += "-stdlib=libstdc++"
+BUILD_LDFLAGS += "-unwindlib=libgcc -rtlib=libgcc -stdlib=libstdc++"
+BUILD_CPPFLAGS:remove = "-stdlib=libc++"
+BUILD_LDFLAGS:remove = "-stdlib=libc++ -lc++abi"
+
+INHIBIT_DEFAULT_DEPS = "1"
+
+LIC_FILES_CHKSUM = "file://libcxx/LICENSE.TXT;md5=55d89dd7eec8d3b4204b680e27da3953 \
+                    file://libcxxabi/LICENSE.TXT;md5=7b9334635b542c56868400a46b272b1e \
+                    file://libunwind/LICENSE.TXT;md5=f66970035d12f196030658b11725e1a1 \
+"
+
+OECMAKE_TARGET_COMPILE = "cxxabi cxx"
+OECMAKE_TARGET_INSTALL = "install-cxx install-cxxabi ${@bb.utils.contains("RUNTIME", "llvm", "install-unwind", "", d)}"
+
+OECMAKE_SOURCEPATH = "${S}/llvm"
+EXTRA_OECMAKE += "\
+                  -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+                  -DLLVM_ENABLE_PER_TARGET_RUNTIME_DIR=OFF \
+                  -DCMAKE_CROSSCOMPILING=ON \
+                  -DLLVM_TEMPORARILY_ALLOW_OLD_TOOLCHAIN=ON \
+                  -DLLVM_ENABLE_RTTI=ON \
+                  -DLIBUNWIND_ENABLE_CROSS_UNWINDING=ON \
+                  -DLIBCXX_ENABLE_STATIC_ABI_LIBRARY=ON \
+                  -DLIBCXXABI_INCLUDE_TESTS=OFF \
+                  -DLIBCXXABI_ENABLE_SHARED=ON \
+                  -DLIBCXXABI_LIBCXX_INCLUDES=${S}/libcxx/include \
+                  -DLIBCXX_CXX_ABI=libcxxabi \
+                  -DLIBCXX_CXX_ABI_INCLUDE_PATHS=${S}/libcxxabi/include \
+                  -DLIBCXX_CXX_ABI_LIBRARY_PATH=${B}/lib${LLVM_LIBDIR_SUFFIX} \
+                  -S ${S}/runtimes \
+                  -DLLVM_ENABLE_RUNTIMES='libcxx;libcxxabi;libunwind' \
+                  -DLLVM_LIBDIR_SUFFIX=${LLVM_LIBDIR_SUFFIX} \
+                  -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON \
+"
+
+EXTRA_OECMAKE:append:class-target = " \
+                  -DCMAKE_AR=${STAGING_BINDIR_TOOLCHAIN}/${AR} \
+                  -DCMAKE_NM=${STAGING_BINDIR_TOOLCHAIN}/${NM} \
+                  -DCMAKE_RANLIB=${STAGING_BINDIR_TOOLCHAIN}/${RANLIB} \
+                  -DLLVM_DEFAULT_TARGET_TRIPLE=${HOST_SYS} \
+                  -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+"
+
+EXTRA_OECMAKE:append:class-nativesdk = " \
+                  -DCMAKE_AR=${STAGING_BINDIR_TOOLCHAIN}/${AR} \
+                  -DCMAKE_NM=${STAGING_BINDIR_TOOLCHAIN}/${NM} \
+                  -DCMAKE_RANLIB=${STAGING_BINDIR_TOOLCHAIN}/${RANLIB} \
+                  -DLLVM_DEFAULT_TARGET_TRIPLE=${HOST_SYS} \
+"
+
+EXTRA_OECMAKE:append:libc-musl = " -DLIBCXX_HAS_MUSL_LIBC=ON "
+
+CXXFLAGS:append:armv5 = " -mfpu=vfp2"
+
+ALLOW_EMPTY:${PN} = "1"
+
+PROVIDES:append:runtime-llvm = " libunwind15"
+
+do_install:append() {
+    if ${@bb.utils.contains("RUNTIME", "llvm", "true", "false", d)}
+    then
+        for f in libunwind.h __libunwind_config.h unwind.h unwind_itanium.h unwind_arm_ehabi.h
+        do
+            install -Dm 0644 ${S}/libunwind/include/$f ${D}${includedir}/$f
+        done
+        install -d ${D}${libdir}/pkgconfig
+        sed -e 's,@LIBDIR@,${libdir},g;s,@VERSION@,${PV},g' ${S}/../libunwind.pc.in > ${D}${libdir}/pkgconfig/libunwind.pc
+    fi
+}
+
+PACKAGES:append:runtime-llvm = " libunwind15"
+FILES:libunwind15:runtime-llvm = "${libdir}/libunwind.so.*"
+
+BBCLASSEXTEND = "native nativesdk"
+TOOLCHAIN:forcevariable = "clang15"

--- a/recipes-devtools/clang15/llvm-project-source.inc
+++ b/recipes-devtools/clang15/llvm-project-source.inc
@@ -1,0 +1,96 @@
+deltask do_configure
+deltask do_compile
+deltask do_install
+deltask do_populate_sysroot
+deltask do_populate_lic
+RM_WORK_EXCLUDE += "${PN}"
+
+inherit nopackages
+
+PN = "llvm-project-source-${PV}"
+WORKDIR = "${TMPDIR}/work-shared/llvm-project-source-${PV}-${PR}"
+SSTATE_SWSPEC = "sstate:llvm-project-source::${PV}:${PR}::${SSTATE_VERSION}:"
+
+STAMP = "${STAMPS_DIR}/work-shared/llvm-project-source-${PV}-${PR}"
+STAMPCLEAN = "${STAMPS_DIR}/work-shared/llvm-project-source-${PV}-*"
+
+INHIBIT_DEFAULT_DEPS = "1"
+DEPENDS = ""
+PACKAGES = ""
+TARGET_ARCH = "allarch"
+TARGET_AS_ARCH = "none"
+TARGET_CC_ARCH = "none"
+TARGET_LD_ARCH = "none"
+TARGET_OS = "linux"
+baselib = "lib"
+PACKAGE_ARCH = "all"
+
+# space separated list of additional distro vendor values we want to support e.g.
+# "yoe webos" or "-yoe -webos" '-' is optional
+CLANG_EXTRA_OE_VENDORS ?= "${TARGET_VENDOR} ${SDK_VENDOR}"
+# Extra OE DISTRO that want to support as build host. space separated list of additional distro.
+# ":" separated the ID in "/etc/os-release" and the triple for finding gcc on this OE DISTRO.
+# eg: "poky:poky wrlinux:wrs"
+CLANG_EXTRA_OE_DISTRO ?= "poky:poky"
+# Match with MULTILIB_GLOBAL_VARIANTS
+MULTILIB_VARIANTS = "lib32 lib64 libx32"
+python add_distro_vendor() {
+    import subprocess
+    case = ""
+    triple = ""
+    vendors = d.getVar('CLANG_EXTRA_OE_VENDORS')
+    multilib_variants = (d.getVar("MULTILIB_VARIANTS") or "").split()
+    vendors_to_add = []
+    for vendor in vendors.split():
+        # convert -yoe into yoe
+        vendor = vendor.lstrip('-')
+        # generate possible multilib vendor names for yoe
+        # such as yoemllib32
+        vendors_to_add.extend([vendor + 'ml' + variant for variant in multilib_variants])
+        # skip oe since already part of the cpp file
+        if vendor != "oe":
+            vendors_to_add.append(vendor)
+
+    for vendor_to_add in vendors_to_add:
+        case += '\\n    .Case("' + vendor_to_add + '", Triple::OpenEmbedded)'
+        triple += ' "x86_64-' + vendor_to_add + '-linux",'
+
+    bb.note("Adding support following TARGET_VENDOR values")
+    bb.note(str(vendors_to_add))
+    bb.note("in llvm/lib/Support/Triple.cpp and ${S}/clang/lib/Driver/ToolChains/Gnu.cpp")
+    cmd = d.expand("sed -i 's#//CLANG_EXTRA_OE_VENDORS_TRIPLES#%s#g' ${S}/clang/lib/Driver/ToolChains/Gnu.cpp" % (triple))
+    subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True)
+    cmd = d.expand("sed -i 's#//CLANG_EXTRA_OE_VENDORS_CASES#%s#g' -i ${S}/llvm/lib/Support/Triple.cpp" % (case))
+    subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True)
+
+
+    case = ""
+    triple = ""
+    name = ""
+    check = ""
+    oe_names = ""
+    distros = d.getVar('CLANG_EXTRA_OE_DISTRO')
+    for distro in distros.split():
+        distro_id = distro.split(":")[0].replace('-','_')
+        distro_triple = distro.split(":")[1]
+        case += '\\n    .Case("' + distro_id + '", Distro::' + distro_id.upper() + ')'
+        triple += '\\n   if (Distro.Is' + distro_id.upper() + '())\\n     return "x86_64-' + distro_triple + '-linux",'
+        name += '\\n    '+ distro_id.upper() + ','
+        check += '\\nbool Is' + distro_id.upper() + '() const { return DistroVal == ' + distro_id.upper() + '; }'
+        oe_names +=  distro_id.upper() + ' ||'
+
+    check += '\\nbool IsOpenEmbedded() const { return DistroVal == ' + oe_names[0:-3] + '; }'
+
+    cmd = d.expand("sed -i 's#//CLANG_EXTRA_OE_DISTRO_NAME#%s#g' ${S}/clang/include/clang/Driver/Distro.h" % (name))
+    subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True)
+    cmd = d.expand("sed -i 's#//CLANG_EXTRA_OE_DISTRO_CHECK#%s#g' ${S}/clang/include/clang/Driver/Distro.h" % (check))
+    subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True)
+    cmd = d.expand("sed -i 's#//CLANG_EXTRA_OE_DISTRO_TRIPLES#%s#g' ${S}/clang/lib/Driver/ToolChains/Linux.cpp" % (triple))
+    subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True)
+    cmd = d.expand("sed -i 's#//CLANG_EXTRA_OE_DISTRO_CASES#%s#g' -i ${S}/clang/lib/Driver/Distro.cpp" % (case))
+    subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True)
+}
+
+do_patch[postfuncs] += "add_distro_vendor"
+do_create_spdx[depends] += "${PN}:do_patch"
+

--- a/recipes-devtools/clang15/llvm15-project-source.bb
+++ b/recipes-devtools/clang15/llvm15-project-source.bb
@@ -1,0 +1,10 @@
+# Copyright (C) 2018 Khem Raj <raj.khem@gmail.com>
+# Released under the MIT license (see COPYING.MIT for the terms)
+
+SUMMARY = "This is the canonical git mirror of the LLVM subversion repository."
+HOMEPAGE = "https://github.com/llvm/llvm-project"
+
+require llvm-project-source.inc
+require clang.inc
+
+EXCLUDE_FROM_WORLD = "1"

--- a/recipes-devtools/clang15/nativesdk-clang15-glue.bb
+++ b/recipes-devtools/clang15/nativesdk-clang15-glue.bb
@@ -1,0 +1,35 @@
+# Copyright (C) 2014 Khem Raj <raj.khem@gmail.com>
+# Released under the MIT license (see COPYING.MIT for the terms)
+
+DESCRIPTION = "SDK Cross compiler wrappers for LLVM based C/C++ compiler"
+HOMEPAGE = "http://clang.llvm.org/"
+LICENSE = "Apache-2.0-with-LLVM-exception"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0-with-LLVM-exception;md5=0bcd48c3bdfef0c9d9fd17726e4b7dab"
+SECTION = "devel"
+
+inherit nativesdk
+DEPENDS += "nativesdk-clang15"
+
+do_install() {
+    install -d ${D}${prefix_nativesdk}
+    cd ${D}${prefix_nativesdk}
+    ln -s ..${libdir} .
+    ln -s ..${includedir} .
+    cd ..
+    ln -s .${base_libdir} .
+}
+
+sysroot_stage_all () {
+	sysroot_stage_dir ${D} ${SYSROOT_DESTDIR}
+}
+
+FILES:${PN} += "${prefix_nativesdk} ${base_libdir_nativesdk}"
+FILES:${PN}-dbg = ""
+
+deltask do_configure
+deltask do_compile
+deltask do_patch
+deltask do_fetch
+deltask do_unpack
+deltask do_create_spdx
+deltask do_create_runtime_spdx

--- a/recipes-devtools/clang15/openmp15_git.bb
+++ b/recipes-devtools/clang15/openmp15_git.bb
@@ -1,0 +1,65 @@
+# Copyright (C) 2017 Khem Raj <raj.khem@gmail.com>
+# Released under the MIT license (see COPYING.MIT for the terms)
+
+DESCRIPTION = "LLVM based C/C++ compiler Runtime"
+HOMEPAGE = "https://openmp.llvm.org/"
+SECTION = "libs"
+
+require clang.inc
+require common-source.inc
+
+TOOLCHAIN = "clang15"
+
+LIC_FILES_CHKSUM = "file://openmp/LICENSE.TXT;md5=d75288d1ce0450b28b8d58a284c09c79"
+
+inherit cmake pkgconfig perlnative python3native python3targetconfig
+
+DEPENDS += "elfutils libffi clang15"
+
+EXTRA_OECMAKE += "-DCMAKE_BUILD_TYPE=RelWithDebInfo \
+                  -DLLVM_ENABLE_PER_TARGET_RUNTIME_DIR=OFF \
+                  -DOPENMP_LIBDIR_SUFFIX=${@d.getVar('baselib').replace('lib', '')} \
+                  -DOPENMP_STANDALONE_BUILD=ON \
+                  -DCLANG_TOOL=${STAGING_BINDIR_NATIVE}/clang \
+                  -DLINK_TOOL=${STAGING_BINDIR_NATIVE}/llvm-link \
+                  -DOPT_TOOL=${STAGING_BINDIR_NATIVE}/opt \
+                  -DOPENMP_LLVM_LIT_EXECUTABLE=${STAGING_BINDIR_NATIVE}/llvm-lit \
+                  -DEXTRACT_TOOL=${STAGING_BINDIR_NATIVE}/llvm-extract \
+                  -DPACKAGER_TOOL=${STAGING_BINDIR_NATIVE}/clang-offload-packager \
+                  -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+                  "
+
+OECMAKE_SOURCEPATH = "${S}/openmp"
+
+PACKAGECONFIG ?= "ompt-tools offloading-plugin"
+
+PACKAGECONFIG:remove:arm = "ompt-tools offloading-plugin"
+PACKAGECONFIG:remove:powerpc = "ompt-tools offloading-plugin"
+
+PACKAGECONFIG:append:mipsarcho32 = " no-atomics"
+
+PACKAGECONFIG[ompt-tools] = "-DOPENMP_ENABLE_OMPT_TOOLS=ON,-DOPENMP_ENABLE_OMPT_TOOLS=OFF,"
+PACKAGECONFIG[aliases] = "-DLIBOMP_INSTALL_ALIASES=ON,-DLIBOMP_INSTALL_ALIASES=OFF,"
+PACKAGECONFIG[offloading-plugin] = ",,elfutils libffi,libelf libffi"
+PACKAGECONFIG[no-atomics] = "-DLIBOMP_HAVE_BUILTIN_ATOMIC=OFF -DLIBOMP_LIBFLAGS='-latomic',,"
+
+PACKAGES += "${PN}-libomptarget ${PN}-gdb-plugin"
+FILES_SOLIBSDEV = ""
+FILES:${PN} += "${libdir}/lib*${SOLIBSDEV}"
+FILES:${PN}-libomptarget = "${libdir}/libomptarget-*.bc"
+FILES:${PN}-gdb-plugin = "${datadir}/gdb/python/ompd"
+
+RDEPENDS:${PN}-gdb-plugin += "python3-core"
+
+INSANE_SKIP:${PN} = "dev-so"
+# Currently the static libraries contain buildpaths
+INSANE_SKIP:${PN}-staticdev += "buildpaths"
+
+COMPATIBLE_HOST:mips64 = "null"
+COMPATIBLE_HOST:riscv32 = "null"
+COMPATIBLE_HOST:powerpc = "null"
+
+BBCLASSEXTEND = "native nativesdk"
+
+# This appears to be specific to the Intel distribution before 2022.1
+CVE_CHECK_IGNORE += "CVE-2022-26345"

--- a/recipes-devtools/clang16/clang.inc
+++ b/recipes-devtools/clang16/clang.inc
@@ -1,0 +1,35 @@
+LLVM_GIT ?= "git://github.com/llvm"
+LLVM_GIT_PROTOCOL ?= "https"
+
+MAJOR_VER = "16"
+MINOR_VER = "0"
+PATCH_VER = "6"
+
+LLVM_RELEASE = "${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}"
+LLVM_DIR = "llvm${LLVM_RELEASE}"
+
+SRCREV ?= "7cbf1a2591520c2491aa35339f227775f4d3adf6"
+
+PV = "${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}"
+BRANCH = "release/16.x"
+
+LLVMMD5SUM = "8a15a0759ef07f2682d2ba4b893c9afe"
+CLANGMD5SUM = "ff42885ed2ab98f1ecb8c1fc41205343"
+LLDMD5SUM = "ae7dc7c027b1fa89b5b013d391d3ee2b"
+LLDBMD5SUM = "2e0d44968471fcde980034dbb826bea9"
+
+LLVM_LIBDIR_SUFFIX="${@d.getVar('baselib').replace('lib', '')}"
+
+# Counteract the instructions given in README.md
+PREFERRED_PROVIDER_llvm = "clang16"
+PREFERRED_PROVIDER_llvm-native = "clang16-native"
+PREFERRED_PROVIDER_nativesdk-llvm = "nativesdk-clang16"
+
+# Don't include these recipes in "bitbake world"
+# as clang16 conflicts with clang.
+EXCLUDE_FROM_WORLD = "1"
+
+# set the default pigz thread
+export PIGZ = "-p ${@oe.utils.cpu_count(at_least=2)}"
+
+require common.inc

--- a/recipes-devtools/clang16/clang/0001-libcxxabi-Find-libunwind-headers-when-LIBCXXABI_LIBU.patch
+++ b/recipes-devtools/clang16/clang/0001-libcxxabi-Find-libunwind-headers-when-LIBCXXABI_LIBU.patch
@@ -1,0 +1,58 @@
+From bfea0b41ba225254c159194e911e2238103f70e4 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Sun, 27 Aug 2017 10:37:49 -0700
+Subject: [PATCH] libcxxabi: Find libunwind headers when
+ LIBCXXABI_LIBUNWIND_INCLUDES is set
+
+Currently, when LIBCXXABI_LIBUNWIND_INCLUDES is set via CMake arguments
+then it ends up not searching the specified dir and unwind.h is not found
+especially for ARM targets
+
+This patch makes the searching synthesized directories and then set
+LIBCXXABI_LIBUNWIND_INCLUDES if its there in environment
+
+Upstream-Status: Pending
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ libcxxabi/CMakeLists.txt | 16 +++++++++++-----
+ 1 file changed, 11 insertions(+), 5 deletions(-)
+
+diff --git a/libcxxabi/CMakeLists.txt b/libcxxabi/CMakeLists.txt
+index 8f48d402bc22..c2470267d8e3 100644
+--- a/libcxxabi/CMakeLists.txt
++++ b/libcxxabi/CMakeLists.txt
+@@ -483,7 +483,7 @@ set(LIBCXXABI_LIBUNWIND_PATH "${LIBCXXABI_LIBUNWIND_PATH}" CACHE PATH
+     "Specify path to libunwind source." FORCE)
+ 
+ if (LIBCXXABI_USE_LLVM_UNWINDER OR LLVM_NATIVE_ARCH MATCHES ARM)
+-  find_path(LIBCXXABI_LIBUNWIND_INCLUDES_INTERNAL libunwind.h
++  find_path(LIBCXXABI_LIBUNWIND_INCLUDES libunwind.h
+     PATHS ${LIBCXXABI_LIBUNWIND_INCLUDES}
+           ${LIBCXXABI_LIBUNWIND_PATH}/include
+           ${CMAKE_BINARY_DIR}/${LIBCXXABI_LIBUNWIND_INCLUDES}
+@@ -494,15 +494,21 @@ if (LIBCXXABI_USE_LLVM_UNWINDER OR LLVM_NATIVE_ARCH MATCHES ARM)
+     NO_CMAKE_FIND_ROOT_PATH
+   )
+ 
+-  if (LIBCXXABI_LIBUNWIND_INCLUDES_INTERNAL STREQUAL "LIBCXXABI_LIBUNWIND_INCLUDES_INTERNAL-NOTFOUND")
+-    set(LIBCXXABI_LIBUNWIND_INCLUDES_INTERNAL "")
++  if (LIBCXXABI_LIBUNWIND_INCLUDES STREQUAL "LIBCXXABI_LIBUNWIND_INCLUDES-NOTFOUND")
++    set(LIBCXXABI_LIBUNWIND_INCLUDES "")
+   endif()
+ 
+-  if (NOT LIBCXXABI_LIBUNWIND_INCLUDES_INTERNAL STREQUAL "")
+-    include_directories("${LIBCXXABI_LIBUNWIND_INCLUDES_INTERNAL}")
++  if (NOT LIBCXXABI_LIBUNWIND_INCLUDES STREQUAL "")
++    include_directories("${LIBCXXABI_LIBUNWIND_INCLUDES}")
+   endif()
+ endif()
+ 
++set(LIBCXXABI_LIBUNWIND_INCLUDES "${LIBCXXABI_LIBUNWIND_INCLUDES}" CACHE PATH
++    "Specify path to libunwind includes." FORCE)
++set(LIBCXXABI_LIBUNWIND_PATH "${LIBCXXABI_LIBUNWIND_PATH}" CACHE PATH
++    "Specify path to libunwind source." FORCE)
++
++
+ # Add source code. This also contains all of the logic for deciding linker flags
+ # soname, etc...
+ add_subdirectory(include)

--- a/recipes-devtools/clang16/clang/0002-compiler-rt-support-a-new-embedded-linux-target.patch
+++ b/recipes-devtools/clang16/clang/0002-compiler-rt-support-a-new-embedded-linux-target.patch
@@ -1,0 +1,309 @@
+From 4aa8c16b7caed1924e7ddafff7dd0c719cac3d7e Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Sun, 19 Apr 2015 15:16:23 -0700
+Subject: [PATCH] compiler-rt: support a new embedded linux target
+
+Upstream-Status: Pending
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ .../make/platform/clang_linux_embedded.mk     | 286 ++++++++++++++++++
+ .../clang_linux_embedded_test_input.c         |   0
+ 2 files changed, 286 insertions(+)
+ create mode 100644 compiler-rt/make/platform/clang_linux_embedded.mk
+ create mode 100644 compiler-rt/make/platform/clang_linux_embedded_test_input.c
+
+diff --git a/compiler-rt/make/platform/clang_linux_embedded.mk b/compiler-rt/make/platform/clang_linux_embedded.mk
+new file mode 100644
+index 000000000000..d0a890075a1c
+--- /dev/null
++++ b/compiler-rt/make/platform/clang_linux_embedded.mk
+@@ -0,0 +1,286 @@
++# These are the functions which clang needs when it is targeting a previous
++# version of the OS. The issue is that the backend may use functions which were
++# not present in the libgcc that shipped on the platform. In such cases, we link
++# with a version of the library which contains private_extern definitions of all
++# the extra functions which might be referenced.
++
++Description := Static runtime libraries for embedded clang/Linux
++
++# A function that ensures we don't try to build for architectures that we
++# don't have working toolchains for.
++CheckArches = \
++  $(shell \
++    result=""; \
++    for arch in $(1); do \
++      if $(CC) -arch $$arch -c \
++	  -integrated-as \
++	  $(ProjSrcRoot)/make/platform/clang_linux_embedded_test_input.c \
++	  -o /dev/null > /dev/null 2> /dev/null; then \
++        result="$$result$$arch "; \
++      else \
++	printf 1>&2 \
++	  "warning: clang_linux_embedded.mk: dropping arch '$$arch' from lib '$(2)'\n"; \
++      fi; \
++    done; \
++    echo $$result)
++
++XCRun = \
++  $(shell \
++    result=`xcrun -find $(1) 2> /dev/null`; \
++    if [ "$$?" != "0" ]; then result=$(1); fi; \
++    echo $$result)
++
++###
++
++CC       := $(call XCRun,clang)
++AR       := $(call XCRun,ar)
++RANLIB   := $(call XCRun,ranlib)
++STRIP    := $(call XCRun,strip)
++LIPO     := $(call XCRun,lipo)
++DSYMUTIL := $(call XCRun,dsymutil)
++Configs :=
++UniversalArchs :=
++
++# Soft-float version of the runtime. No floating-point instructions will be used
++# and the ABI (out of necessity) passes floating values in normal registers:
++# non-VFP variant of the AAPCS.
++UniversalArchs.soft_static := $(call CheckArches,arm armv7m armv7em armv7,soft_static)
++Configs += $(if $(UniversalArchs.soft_static),soft_static)
++
++# Hard-float version of the runtime. On ARM VFP instructions and registers are
++# allowed, and floating point values get passed in them. VFP variant of the
++# AAPCS.
++UniversalArchs.hard_static := $(call CheckArches,armv7em armv7 i386 x86_64,hard_static)
++Configs += $(if $(UniversalArchs.hard_static),hard_static)
++
++UniversalArchs.soft_pic := $(call CheckArches,armv6m armv7m armv7em armv7,soft_pic)
++Configs += $(if $(UniversalArchs.soft_pic),soft_pic)
++
++UniversalArchs.hard_pic := $(call CheckArches,armv7em armv7 i386 x86_64,hard_pic)
++Configs += $(if $(UniversalArchs.hard_pic),hard_pic)
++
++CFLAGS := -Wall -Werror -Oz -fomit-frame-pointer -ffreestanding
++
++PIC_CFLAGS := -fPIC
++STATIC_CFLAGS := -static
++
++CFLAGS_SOFT := -mfloat-abi=soft
++CFLAGS_HARD := -mfloat-abi=hard
++
++CFLAGS_I386  := -march=pentium
++
++CFLAGS.soft_static := $(CFLAGS) $(STATIC_CFLAGS) $(CFLAGS_SOFT)
++CFLAGS.hard_static := $(CFLAGS) $(STATIC_CFLAGS) $(CFLAGS_HARD)
++CFLAGS.soft_pic    := $(CFLAGS) $(PIC_CFLAGS) $(CFLAGS_SOFT)
++CFLAGS.hard_pic    := $(CFLAGS) $(PIC_CFLAGS) $(CFLAGS_HARD)
++
++CFLAGS.soft_static.armv7 := $(CFLAGS.soft_static) $(CFLAGS_ARMV7)
++CFLAGS.hard_static.armv7 := $(CFLAGS.hard_static) $(CFLAGS_ARMV7)
++CFLAGS.soft_pic.armv7    := $(CFLAGS.soft_pic) $(CFLAGS_ARMV7)
++CFLAGS.hard_pic.armv7    := $(CFLAGS.hard_pic) $(CFLAGS_ARMV7)
++
++# x86 platforms ignore -mfloat-abi options and complain about doing so. Despite
++# this they're hard-float.
++CFLAGS.hard_static.i386   := $(CFLAGS) $(STATIC_CFLAGS) $(CFLAGS_I386)
++CFLAGS.hard_pic.i386      := $(CFLAGS) $(PIC_CFLAGS) $(CFLAGS_I386)
++CFLAGS.hard_static.x86_64 := $(CFLAGS) $(STATIC_CFLAGS)
++CFLAGS.hard_pic.x86_64    := $(CFLAGS) $(PIC_CFLAGS)
++
++# Functions not wanted:
++#   + eprintf is obsolete anyway
++#   + *vfp: designed for Thumb1 CPUs with VFPv2
++
++COMMON_FUNCTIONS := \
++	absvdi2 \
++	absvsi2 \
++	addvdi3 \
++	addvsi3 \
++	ashldi3 \
++	ashrdi3 \
++	bswapdi2 \
++	bswapsi2 \
++	clzdi2 \
++	clzsi2 \
++	cmpdi2 \
++	ctzdi2 \
++	ctzsi2 \
++	divdc3 \
++	divdi3 \
++	divsc3 \
++	divmodsi4 \
++	udivmodsi4 \
++	do_global_dtors \
++	ffsdi2 \
++	fixdfdi \
++	fixsfdi \
++	fixunsdfdi \
++	fixunsdfsi \
++	fixunssfdi \
++	fixunssfsi \
++	floatdidf \
++	floatdisf \
++	floatundidf \
++	floatundisf \
++	gcc_bcmp \
++	lshrdi3 \
++	moddi3 \
++	muldc3 \
++	muldi3 \
++	mulsc3 \
++	mulvdi3 \
++	mulvsi3 \
++	negdi2 \
++	negvdi2 \
++	negvsi2 \
++	paritydi2 \
++	paritysi2 \
++	popcountdi2 \
++	popcountsi2 \
++	powidf2 \
++	powisf2 \
++	subvdi3 \
++	subvsi3 \
++	ucmpdi2 \
++	udiv_w_sdiv \
++	udivdi3 \
++	udivmoddi4 \
++	umoddi3 \
++	adddf3 \
++	addsf3 \
++	cmpdf2 \
++	cmpsf2 \
++	div0 \
++	divdf3 \
++	divsf3 \
++	divsi3 \
++	extendsfdf2 \
++	ffssi2 \
++	fixdfsi \
++	fixsfsi \
++	floatsidf \
++	floatsisf \
++	floatunsidf \
++	floatunsisf \
++	comparedf2 \
++	comparesf2 \
++	modsi3 \
++	muldf3 \
++	mulsf3 \
++	negdf2 \
++	negsf2 \
++	subdf3 \
++	subsf3 \
++	truncdfsf2 \
++	udivsi3 \
++	umodsi3 \
++	unorddf2 \
++	unordsf2
++
++ARM_FUNCTIONS := \
++	aeabi_cdcmpeq \
++	aeabi_cdrcmple \
++	aeabi_cfcmpeq \
++	aeabi_cfrcmple \
++	aeabi_dcmpeq \
++	aeabi_dcmpge \
++	aeabi_dcmpgt \
++	aeabi_dcmple \
++	aeabi_dcmplt \
++	aeabi_drsub \
++	aeabi_fcmpeq \
++	aeabi_fcmpge \
++	aeabi_fcmpgt \
++	aeabi_fcmple \
++	aeabi_fcmplt \
++	aeabi_frsub \
++	aeabi_idivmod \
++	aeabi_uidivmod \
++
++# ARM Assembly implementation which requires Thumb2 (i.e. won't work on v6M).
++THUMB2_FUNCTIONS := \
++	switch16 \
++	switch32 \
++	switch8 \
++	switchu8 \
++	sync_fetch_and_add_4 \
++	sync_fetch_and_sub_4 \
++	sync_fetch_and_and_4 \
++	sync_fetch_and_or_4 \
++	sync_fetch_and_xor_4 \
++	sync_fetch_and_nand_4 \
++	sync_fetch_and_max_4 \
++	sync_fetch_and_umax_4 \
++	sync_fetch_and_min_4 \
++	sync_fetch_and_umin_4 \
++	sync_fetch_and_add_8 \
++	sync_fetch_and_sub_8 \
++	sync_fetch_and_and_8 \
++	sync_fetch_and_or_8 \
++	sync_fetch_and_xor_8 \
++	sync_fetch_and_nand_8 \
++	sync_fetch_and_max_8 \
++	sync_fetch_and_umax_8 \
++	sync_fetch_and_min_8 \
++	sync_fetch_and_umin_8
++
++I386_FUNCTIONS :=  \
++	i686.get_pc_thunk.eax \
++	i686.get_pc_thunk.ebp \
++	i686.get_pc_thunk.ebx \
++	i686.get_pc_thunk.ecx \
++	i686.get_pc_thunk.edi \
++	i686.get_pc_thunk.edx \
++	i686.get_pc_thunk.esi
++
++# FIXME: Currently, compiler-rt is missing implementations for a number of the
++# functions. Filter them out for now.
++MISSING_FUNCTIONS := \
++	cmpdf2 cmpsf2 div0 \
++	ffssi2 \
++	udiv_w_sdiv unorddf2 unordsf2 bswapdi2 \
++	bswapsi2 \
++	gcc_bcmp \
++	do_global_dtors \
++	i686.get_pc_thunk.eax i686.get_pc_thunk.ebp i686.get_pc_thunk.ebx \
++	i686.get_pc_thunk.ecx i686.get_pc_thunk.edi i686.get_pc_thunk.edx \
++	i686.get_pc_thunk.esi \
++	aeabi_cdcmpeq aeabi_cdrcmple aeabi_cfcmpeq aeabi_cfrcmple aeabi_dcmpeq \
++	aeabi_dcmpge aeabi_dcmpgt aeabi_dcmple aeabi_dcmplt aeabi_drsub \
++	aeabi_fcmpeq \ aeabi_fcmpge aeabi_fcmpgt aeabi_fcmple aeabi_fcmplt \
++	aeabi_frsub aeabi_idivmod aeabi_uidivmod
++
++FUNCTIONS_ARMV6M  := $(COMMON_FUNCTIONS) $(ARM_FUNCTIONS)
++FUNCTIONS_ARM_ALL := $(COMMON_FUNCTIONS) $(ARM_FUNCTIONS) $(THUMB2_FUNCTIONS)
++FUNCTIONS_I386    := $(COMMON_FUNCTIONS) $(I386_FUNCTIONS)
++FUNCTIONS_X86_64  := $(COMMON_FUNCTIONS)
++
++FUNCTIONS_ARMV6M := \
++	$(filter-out $(MISSING_FUNCTIONS),$(FUNCTIONS_ARMV6M))
++FUNCTIONS_ARM_ALL := \
++	$(filter-out $(MISSING_FUNCTIONS),$(FUNCTIONS_ARM_ALL))
++FUNCTIONS_I386 := \
++	$(filter-out $(MISSING_FUNCTIONS),$(FUNCTIONS_I386))
++FUNCTIONS_X86_64 := \
++	$(filter-out $(MISSING_FUNCTIONS),$(FUNCTIONS_X86_64))
++
++FUNCTIONS.soft_static.armv6m := $(FUNCTIONS_ARMV6M)
++FUNCTIONS.soft_pic.armv6m    := $(FUNCTIONS_ARMV6M)
++
++FUNCTIONS.soft_static.armv7m := $(FUNCTIONS_ARM_ALL)
++FUNCTIONS.soft_pic.armv7m    := $(FUNCTIONS_ARM_ALL)
++
++FUNCTIONS.soft_static.armv7em := $(FUNCTIONS_ARM_ALL)
++FUNCTIONS.hard_static.armv7em := $(FUNCTIONS_ARM_ALL)
++FUNCTIONS.soft_pic.armv7em    := $(FUNCTIONS_ARM_ALL)
++FUNCTIONS.hard_pic.armv7em    := $(FUNCTIONS_ARM_ALL)
++
++FUNCTIONS.soft_static.armv7 := $(FUNCTIONS_ARM_ALL)
++FUNCTIONS.hard_static.armv7 := $(FUNCTIONS_ARM_ALL)
++FUNCTIONS.soft_pic.armv7    := $(FUNCTIONS_ARM_ALL)
++FUNCTIONS.hard_pic.armv7    := $(FUNCTIONS_ARM_ALL)
++
++FUNCTIONS.hard_static.i386 := $(FUNCTIONS_I386)
++FUNCTIONS.hard_pic.i386    := $(FUNCTIONS_I386)
++
++FUNCTIONS.hard_static.x86_64 := $(FUNCTIONS_X86_64)
++FUNCTIONS.hard_pic.x86_64    := $(FUNCTIONS_X86_64)
+diff --git a/compiler-rt/make/platform/clang_linux_embedded_test_input.c b/compiler-rt/make/platform/clang_linux_embedded_test_input.c
+new file mode 100644
+index 000000000000..e69de29bb2d1

--- a/recipes-devtools/clang16/clang/0003-compiler-rt-Simplify-cross-compilation.-Don-t-use-na.patch
+++ b/recipes-devtools/clang16/clang/0003-compiler-rt-Simplify-cross-compilation.-Don-t-use-na.patch
@@ -1,0 +1,44 @@
+From 4c8897954c3a49fd215e7bb1b1777a814c911e60 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Thu, 19 May 2016 23:11:45 -0700
+Subject: [PATCH] compiler-rt: Simplify cross-compilation. Don't use
+ native-compiled llvm-config.
+
+    Note: AddLLVM.cmake does not expose the LLVM source directory.
+    So if you want to run the test suite, you need to either:
+
+    1) set LLVM_MAIN_SRC_DIR explicitly (to find lit.py)
+    2) change AddLLVM.cmake to point to an installed 'lit'.
+    3) add_subdirectory(compiler-rt/test) from clang instead of compiler-rt.
+
+https://us.codeaurora.org/patches/quic/llvm/50683/compiler-rt-cross-compilation.patch
+
+Upstream-Status: Pending
+Signed-off-by: Greg Fitzgerald <gregf@codeaurora.org>
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ compiler-rt/CMakeLists.txt | 11 ++++++++++-
+ 1 file changed, 10 insertions(+), 1 deletion(-)
+
+diff --git a/compiler-rt/CMakeLists.txt b/compiler-rt/CMakeLists.txt
+index 8a13508fcb98..2c2bda5befa5 100644
+--- a/compiler-rt/CMakeLists.txt
++++ b/compiler-rt/CMakeLists.txt
+@@ -89,7 +89,16 @@ if (COMPILER_RT_STANDALONE_BUILD)
+   set(CMAKE_CXX_EXTENSIONS NO)
+ 
+   if (NOT LLVM_RUNTIMES_BUILD)
+-    load_llvm_config()
++    find_package(LLVM REQUIRED)
++    list(APPEND CMAKE_MODULE_PATH "${LLVM_CMAKE_DIR}")
++
++    # Variables that AddLLVM.cmake depends on (included by AddCompilerRT)
++    set(LLVM_TOOLS_BINARY_DIR "${LLVM_INSTALL_PREFIX}/bin")
++    set(LLVM_LIBRARY_DIR "${LLVM_INSTALL_PREFIX}/lib")
++
++    set(LLVM_LIBRARY_OUTPUT_INTDIR
++      ${CMAKE_BINARY_DIR}/${CMAKE_CFG_INTDIR}/lib${LLVM_LIBDIR_SUFFIX})
++
+   endif()
+   if (TARGET intrinsics_gen)
+     # Loading the llvm config causes this target to be imported so place it

--- a/recipes-devtools/clang16/clang/0004-llvm-TargetLibraryInfo-Undefine-libc-functions-if-th.patch
+++ b/recipes-devtools/clang16/clang/0004-llvm-TargetLibraryInfo-Undefine-libc-functions-if-th.patch
@@ -1,0 +1,90 @@
+From d333a8f789767d1aad9288861dbde840fc9de14a Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Sat, 21 May 2016 00:33:20 +0000
+Subject: [PATCH] llvm: TargetLibraryInfo: Undefine libc functions if they are
+ macros
+
+musl defines some functions as macros and not inline functions
+if this is the case then make sure to undefine them
+
+Upstream-Status: Pending
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ .../llvm/Analysis/TargetLibraryInfo.def       | 22 ++++++++++++++++++-
+ 1 file changed, 21 insertions(+), 1 deletion(-)
+
+diff --git a/llvm/include/llvm/Analysis/TargetLibraryInfo.def b/llvm/include/llvm/Analysis/TargetLibraryInfo.def
+index 5f6af3514fc2..9ac2e912590f 100644
+--- a/llvm/include/llvm/Analysis/TargetLibraryInfo.def
++++ b/llvm/include/llvm/Analysis/TargetLibraryInfo.def
+@@ -1303,6 +1303,9 @@ TLI_DEFINE_STRING_INTERNAL("fopen")
+ TLI_DEFINE_SIG_INTERNAL(Ptr, Ptr, Ptr)
+ 
+ /// FILE *fopen64(const char *filename, const char *opentype)
++#ifdef fopen64
++#undef fopen64
++#endif
+ TLI_DEFINE_ENUM_INTERNAL(fopen64)
+ TLI_DEFINE_STRING_INTERNAL("fopen64")
+ TLI_DEFINE_SIG_INTERNAL(Ptr, Ptr, Ptr)
+@@ -1381,7 +1384,9 @@ TLI_DEFINE_SIG_INTERNAL(Int, Ptr, Long, Int)
+ TLI_DEFINE_ENUM_INTERNAL(fseeko)
+ TLI_DEFINE_STRING_INTERNAL("fseeko")
+ TLI_DEFINE_SIG_INTERNAL(Int, Ptr, IntX, Int)
+-
++#ifdef fseeko64
++#undef fseeko64
++#endif
+ /// int fseeko64(FILE *stream, off64_t offset, int whence)
+ TLI_DEFINE_ENUM_INTERNAL(fseeko64)
+ TLI_DEFINE_STRING_INTERNAL("fseeko64")
+@@ -1398,6 +1403,9 @@ TLI_DEFINE_STRING_INTERNAL("fstat")
+ TLI_DEFINE_SIG_INTERNAL(Int, Int, Ptr)
+ 
+ /// int fstat64(int filedes, struct stat64 *buf)
++#ifdef fstat64
++#undef fstat64
++#endif
+ TLI_DEFINE_ENUM_INTERNAL(fstat64)
+ TLI_DEFINE_STRING_INTERNAL("fstat64")
+ TLI_DEFINE_SIG_INTERNAL(Int, Int, Ptr)
+@@ -1423,6 +1431,9 @@ TLI_DEFINE_STRING_INTERNAL("ftello")
+ TLI_DEFINE_SIG_INTERNAL(IntPlus, Ptr)
+ 
+ /// off64_t ftello64(FILE *stream)
++#ifdef ftello64
++#undef ftello64
++#endif
+ TLI_DEFINE_ENUM_INTERNAL(ftello64)
+ TLI_DEFINE_STRING_INTERNAL("ftello64")
+ TLI_DEFINE_SIG_INTERNAL(Int64, Ptr)
+@@ -1633,6 +1644,9 @@ TLI_DEFINE_STRING_INTERNAL("lstat")
+ TLI_DEFINE_SIG_INTERNAL(Int, Ptr, Ptr)
+ 
+ /// int lstat64(const char *path, struct stat64 *buf);
++#ifdef lstat64
++#undef lstat64
++#endif
+ TLI_DEFINE_ENUM_INTERNAL(lstat64)
+ TLI_DEFINE_STRING_INTERNAL("lstat64")
+ TLI_DEFINE_SIG_INTERNAL(Int, Ptr, Ptr)
+@@ -2045,6 +2059,9 @@ TLI_DEFINE_STRING_INTERNAL("stat")
+ TLI_DEFINE_SIG_INTERNAL(Int, Ptr, Ptr)
+ 
+ /// int stat64(const char *path, struct stat64 *buf);
++#ifdef stat64
++#undef stat64
++#endif
+ TLI_DEFINE_ENUM_INTERNAL(stat64)
+ TLI_DEFINE_STRING_INTERNAL("stat64")
+ TLI_DEFINE_SIG_INTERNAL(Int, Ptr, Ptr)
+@@ -2270,6 +2287,9 @@ TLI_DEFINE_STRING_INTERNAL("tmpfile")
+ TLI_DEFINE_SIG_INTERNAL(Ptr)
+ 
+ /// FILE *tmpfile64(void)
++#ifdef tmpfile64
++#undef tmpfile64
++#endif
+ TLI_DEFINE_ENUM_INTERNAL(tmpfile64)
+ TLI_DEFINE_STRING_INTERNAL("tmpfile64")
+ TLI_DEFINE_SIG_INTERNAL(Ptr)

--- a/recipes-devtools/clang16/clang/0005-llvm-allow-env-override-of-exe-and-libdir-path.patch
+++ b/recipes-devtools/clang16/clang/0005-llvm-allow-env-override-of-exe-and-libdir-path.patch
@@ -1,0 +1,71 @@
+From 67c2f3e7f44144a98ce0fb09809d5759405874eb Mon Sep 17 00:00:00 2001
+From: Martin Kelly <mkelly@xevo.com>
+Date: Fri, 19 May 2017 00:22:57 -0700
+Subject: [PATCH] llvm: allow env override of exe and libdir path
+
+When using a native llvm-config from inside a sysroot, we need llvm-config to
+return the libraries, include directories, etc. from inside the sysroot rather
+than from the native sysroot. Thus provide an env override for calling
+llvm-config from a target sysroot.
+
+Add YOCTO_ALTERNATE_LIBDIR and YOCTO_ALTERNATE_EXE_PATH env variables
+
+Upstream-Status: Inappropriate [OE-specific]
+
+Signed-off-by: Martin Kelly <mkelly@xevo.com>
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ llvm/tools/llvm-config/llvm-config.cpp | 25 +++++++++++++++++++------
+ 1 file changed, 19 insertions(+), 6 deletions(-)
+
+diff --git a/llvm/tools/llvm-config/llvm-config.cpp b/llvm/tools/llvm-config/llvm-config.cpp
+index b1d795a0a349..dbeddeb2152e 100644
+--- a/llvm/tools/llvm-config/llvm-config.cpp
++++ b/llvm/tools/llvm-config/llvm-config.cpp
+@@ -246,6 +246,13 @@ Typical components:\n\
+ 
+ /// Compute the path to the main executable.
+ std::string GetExecutablePath(const char *Argv0) {
++  // Hack for Yocto: we need to override the root path when we are using
++  // llvm-config from within a target sysroot.
++  const char *Sysroot = std::getenv("YOCTO_ALTERNATE_EXE_PATH");
++  if (Sysroot != nullptr) {
++    return Sysroot;
++  }
++
+   // This just needs to be some symbol in the binary; C++ doesn't
+   // allow taking the address of ::main however.
+   void *P = (void *)(intptr_t)GetExecutablePath;
+@@ -325,7 +332,7 @@ int main(int argc, char **argv) {
+   // Compute various directory locations based on the derived location
+   // information.
+   std::string ActivePrefix, ActiveBinDir, ActiveIncludeDir, ActiveLibDir,
+-              ActiveCMakeDir;
++              ActiveCMakeDir, BaseLibDir;
+   std::string ActiveIncludeOption;
+   if (IsInDevelopmentTree) {
+     ActiveIncludeDir = std::string(LLVM_SRC_ROOT) + "/include";
+@@ -366,12 +373,18 @@ int main(int argc, char **argv) {
+       sys::fs::make_absolute(ActivePrefix, Path);
+       ActiveBinDir = std::string(Path.str());
+     }
+-    ActiveLibDir = ActivePrefix + "/lib" + LLVM_LIBDIR_SUFFIX;
+-    {
+-      SmallString<256> Path(LLVM_INSTALL_PACKAGE_DIR);
+-      sys::fs::make_absolute(ActivePrefix, Path);
+-      ActiveCMakeDir = std::string(Path.str());
++    // Hack for Yocto: we need to override the lib path when we are using
++    // llvm-config from within a target sysroot since LLVM_LIBDIR_SUFFIX
++    // maybe different for host llvm vs target e.g. ppc64 Libdir=lib64 but
++    // x86_64 Libdir = lib
++    const char *YoctoLibDir = std::getenv("YOCTO_ALTERNATE_LIBDIR");
++    if (YoctoLibDir != nullptr) {
++      BaseLibDir = std::string(YoctoLibDir);
++    } else {
++      BaseLibDir = std::string("/lib") + LLVM_LIBDIR_SUFFIX;
+     }
++    ActiveLibDir = ActivePrefix + BaseLibDir;
++    ActiveCMakeDir = ActiveLibDir + "/cmake/llvm";
+     ActiveIncludeOption = "-I" + ActiveIncludeDir;
+   }
+ 

--- a/recipes-devtools/clang16/clang/0006-clang-driver-Check-sysroot-for-ldso-path.patch
+++ b/recipes-devtools/clang16/clang/0006-clang-driver-Check-sysroot-for-ldso-path.patch
@@ -1,0 +1,75 @@
+From 4e8e066b60a00eb10c70ef9523c55cfc7ab536f8 Mon Sep 17 00:00:00 2001
+From: Dan McGregor <dan.mcgregor@usask.ca>
+Date: Wed, 26 Apr 2017 20:29:41 -0600
+Subject: [PATCH] clang: driver: Check sysroot for ldso path
+
+OE does not necessarily follow the default path for the dynamic linker,
+therefore adjust it for OE. Check for the default path, and if it isn't
+there, check /lib.
+
+Upstream-Status: Pending
+Signed-off-by: Dan McGregor <dan.mcgregor@usask.ca>
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ clang/lib/Driver/ToolChains/Linux.cpp | 22 +++++++++++++++++++++-
+ 1 file changed, 21 insertions(+), 1 deletion(-)
+
+diff --git a/clang/lib/Driver/ToolChains/Linux.cpp b/clang/lib/Driver/ToolChains/Linux.cpp
+index c6fb290ffdb4..897a2da73d54 100644
+--- a/clang/lib/Driver/ToolChains/Linux.cpp
++++ b/clang/lib/Driver/ToolChains/Linux.cpp
+@@ -463,7 +463,11 @@ std::string Linux::getDynamicLinker(const ArgList &Args) const {
+         Triple.getEnvironment() == llvm::Triple::GNUEABIHF ||
+         tools::arm::getARMFloatABI(*this, Args) == tools::arm::FloatABI::Hard;
+ 
+-    LibDir = "lib";
++    LibDir = "lib32";
++    if (!getVFS().exists(getDriver().SysRoot + "/" + LibDir + "/" + Loader) &&
++         getVFS().exists(getDriver().SysRoot + "/lib/" + Loader)) {
++        LibDir = "lib";
++    }
+     Loader = HF ? "ld-linux-armhf.so.3" : "ld-linux.so.3";
+     break;
+   }
+@@ -518,11 +522,19 @@ std::string Linux::getDynamicLinker(const ArgList &Args) const {
+     LibDir = "lib64";
+     Loader =
+         (tools::ppc::hasPPCAbiArg(Args, "elfv2")) ? "ld64.so.2" : "ld64.so.1";
++    if (!getVFS().exists(getDriver().SysRoot + "/" + LibDir + "/" + Loader) &&
++         getVFS().exists(getDriver().SysRoot + "/lib/" + Loader)) {
++        LibDir = "lib";
++    }
+     break;
+   case llvm::Triple::ppc64le:
+     LibDir = "lib64";
+     Loader =
+         (tools::ppc::hasPPCAbiArg(Args, "elfv1")) ? "ld64.so.1" : "ld64.so.2";
++    if (!getVFS().exists(getDriver().SysRoot + "/" + LibDir + "/" + Loader) &&
++         getVFS().exists(getDriver().SysRoot + "/lib/" + Loader)) {
++        LibDir = "lib";
++    }
+     break;
+   case llvm::Triple::riscv32: {
+     StringRef ABIName = tools::riscv::getRISCVABI(Args, Triple);
+@@ -544,6 +556,10 @@ std::string Linux::getDynamicLinker(const ArgList &Args) const {
+   case llvm::Triple::sparcv9:
+     LibDir = "lib64";
+     Loader = "ld-linux.so.2";
++    if (!getVFS().exists(getDriver().SysRoot + "/" + LibDir + "/" + Loader) &&
++         getVFS().exists(getDriver().SysRoot + "/lib/" + Loader)) {
++        LibDir = "lib";
++    }
+     break;
+   case llvm::Triple::systemz:
+     LibDir = "lib";
+@@ -558,6 +574,10 @@ std::string Linux::getDynamicLinker(const ArgList &Args) const {
+ 
+     LibDir = X32 ? "libx32" : "lib64";
+     Loader = X32 ? "ld-linux-x32.so.2" : "ld-linux-x86-64.so.2";
++    if (!getVFS().exists(getDriver().SysRoot + "/" + LibDir + "/" + Loader) &&
++         getVFS().exists(getDriver().SysRoot + "/lib/" + Loader)) {
++        LibDir = "lib";
++    }
+     break;
+   }
+   case llvm::Triple::ve:

--- a/recipes-devtools/clang16/clang/0007-clang-Driver-tools.cpp-Add-lssp_nonshared-on-musl.patch
+++ b/recipes-devtools/clang16/clang/0007-clang-Driver-tools.cpp-Add-lssp_nonshared-on-musl.patch
@@ -1,0 +1,32 @@
+From c6e80e71adaddab21bccc15ff827078d58010a65 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Thu, 19 May 2016 21:11:06 -0700
+Subject: [PATCH] clang: Driver/tools.cpp: Add -lssp_nonshared on musl
+
+musl driver will need to add ssp_nonshared for stack_check_local
+on the linker cmdline when using stack protector commands on
+compiler cmdline
+
+Upstream-Status: Pending
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ clang/lib/Driver/ToolChains/Gnu.cpp | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/clang/lib/Driver/ToolChains/Gnu.cpp b/clang/lib/Driver/ToolChains/Gnu.cpp
+index 4f2340316654..cc9ed4f6b8ac 100644
+--- a/clang/lib/Driver/ToolChains/Gnu.cpp
++++ b/clang/lib/Driver/ToolChains/Gnu.cpp
+@@ -653,6 +653,12 @@ void tools::gnutools::Linker::ConstructJob(Compilation &C, const JobAction &JA,
+       if (IsIAMCU)
+         CmdArgs.push_back("-lgloss");
+ 
++      if (ToolChain.getTriple().isMusl() &&
++          (Args.hasArg(options::OPT_fstack_protector) ||
++          Args.hasArg(options::OPT_fstack_protector_strong) ||
++          Args.hasArg(options::OPT_fstack_protector_all))) {
++        CmdArgs.push_back("-lssp_nonshared");
++      }
+       if (IsStatic || IsStaticPIE)
+         CmdArgs.push_back("--end-group");
+       else

--- a/recipes-devtools/clang16/clang/0008-clang-Prepend-trailing-to-sysroot.patch
+++ b/recipes-devtools/clang16/clang/0008-clang-Prepend-trailing-to-sysroot.patch
@@ -1,0 +1,39 @@
+From 4cf32ee02831483cc999d1e60d401cb301f85bfc Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Thu, 16 Mar 2017 09:02:13 -0700
+Subject: [PATCH] clang: Prepend trailing '/' to sysroot
+
+This is needed to handle a case where clang
+isntall and target sysroot are perilously same
+
+e.g.
+
+sysroot = /mnt/clang/recipe-sysroot
+clang install = /mnt/clang/recipe-sysroot-native
+
+in this case it will mistakenly assume that
+clang is installed under the same sysroot dir
+and it will try to add relative ../lib paths
+to linker steps which would then be wrong
+since they will become relative to clang
+installation and not sysroot
+
+Upstream-Status: Pending
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ clang/lib/Driver/ToolChains/Linux.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/clang/lib/Driver/ToolChains/Linux.cpp b/clang/lib/Driver/ToolChains/Linux.cpp
+index 2a58f876a68d..c68a842b45e0 100644
+--- a/clang/lib/Driver/ToolChains/Linux.cpp
++++ b/clang/lib/Driver/ToolChains/Linux.cpp
+@@ -184,7 +184,7 @@ Linux::Linux(const Driver &D, const llvm::Triple &Triple, const ArgList &Args)
+   Multilibs = GCCInstallation.getMultilibs();
+   SelectedMultilib = GCCInstallation.getMultilib();
+   llvm::Triple::ArchType Arch = Triple.getArch();
+-  std::string SysRoot = computeSysRoot();
++  std::string SysRoot = computeSysRoot() + "/";
+   ToolChain::path_list &PPaths = getProgramPaths();
+ 
+   Generic_GCC::PushPPaths(PPaths);

--- a/recipes-devtools/clang16/clang/0009-clang-Look-inside-the-target-sysroot-for-compiler-ru.patch
+++ b/recipes-devtools/clang16/clang/0009-clang-Look-inside-the-target-sysroot-for-compiler-ru.patch
@@ -1,0 +1,41 @@
+From c865d5064247bfc985bc92409869cd21ca5c74e9 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Thu, 16 Mar 2017 19:06:26 -0700
+Subject: [PATCH] clang: Look inside the target sysroot for compiler runtime
+
+In OE compiler-rt and libc++ are built and staged into target
+sysroot and not into resourcedir which is relative to clang
+driver installation where the libraries are not instlled
+
+Specific to cross compiling the way yocto/OE works
+
+Upstream-Status: Pending
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ clang/lib/Driver/ToolChain.cpp | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/clang/lib/Driver/ToolChain.cpp b/clang/lib/Driver/ToolChain.cpp
+index bc70205a6c01..527efd421e01 100644
+--- a/clang/lib/Driver/ToolChain.cpp
++++ b/clang/lib/Driver/ToolChain.cpp
+@@ -13,6 +13,7 @@
+ #include "ToolChains/InterfaceStubs.h"
+ #include "clang/Basic/ObjCRuntime.h"
+ #include "clang/Basic/Sanitizers.h"
++#include "clang/Basic/Version.h"
+ #include "clang/Config/config.h"
+ #include "clang/Driver/Action.h"
+ #include "clang/Driver/Driver.h"
+@@ -488,7 +489,10 @@ StringRef ToolChain::getOSLibName() const {
+ }
+ 
+ std::string ToolChain::getCompilerRTPath() const {
+-  SmallString<128> Path(getDriver().ResourceDir);
++  SmallString<128> Path(getDriver().SysRoot);
++  StringRef ClangLibdirBasename(CLANG_INSTALL_LIBDIR_BASENAME);
++  llvm::sys::path::append(Path, "/usr/", ClangLibdirBasename, "clang",
++                            CLANG_VERSION_STRING);
+   if (isBareMetal()) {
+     llvm::sys::path::append(Path, "lib", getOSLibName());
+     Path += SelectedMultilib.gccSuffix();

--- a/recipes-devtools/clang16/clang/0010-clang-Define-releative-gcc-installation-dir.patch
+++ b/recipes-devtools/clang16/clang/0010-clang-Define-releative-gcc-installation-dir.patch
@@ -1,0 +1,48 @@
+From cd12100c9acd1b9d57d6386d1e9d4b9baa775866 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Sat, 20 Mar 2021 16:09:16 -0700
+Subject: [PATCH] clang: Define / releative gcc installation dir
+
+This is required for OE gcc installation to work.
+Without this its not able to find the paths for libgcc
+and other standard headers and libraries from gcc
+installation in OE
+
+Upstream-Status: Pending
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ clang/lib/Driver/ToolChains/Gnu.cpp | 14 +++++++-------
+ 1 file changed, 7 insertions(+), 7 deletions(-)
+
+diff --git a/clang/lib/Driver/ToolChains/Gnu.cpp b/clang/lib/Driver/ToolChains/Gnu.cpp
+index cc9ed4f6b8ac..846163329d92 100644
+--- a/clang/lib/Driver/ToolChains/Gnu.cpp
++++ b/clang/lib/Driver/ToolChains/Gnu.cpp
+@@ -2681,19 +2681,19 @@ void Generic_GCC::GCCInstallationDetector::ScanLibDirForGCCTriple(
+     // Whether this library suffix is relevant for the triple.
+     bool Active;
+   } Suffixes[] = {
+-      // This is the normal place.
+-      {"gcc/" + CandidateTriple.str(), "../..", GCCDirExists},
+-
+-      // Debian puts cross-compilers in gcc-cross.
+-      {"gcc-cross/" + CandidateTriple.str(), "../..", GCCCrossDirExists},
+-
+       // The Freescale PPC SDK has the gcc libraries in
+       // <sysroot>/usr/lib/<triple>/x.y.z so have a look there as well. Only do
+       // this on Freescale triples, though, since some systems put a *lot* of
+       // files in that location, not just GCC installation data.
+       {CandidateTriple.str(), "..",
+        TargetTriple.getVendor() == llvm::Triple::Freescale ||
+-           TargetTriple.getVendor() == llvm::Triple::OpenEmbedded}};
++           TargetTriple.getVendor() == llvm::Triple::OpenEmbedded},
++
++      // This is the normal place.
++      {"gcc/" + CandidateTriple.str(), "../..", GCCDirExists},
++
++      // Debian puts cross-compilers in gcc-cross.
++      {"gcc-cross/" + CandidateTriple.str(), "../..", GCCCrossDirExists}};
+ 
+   for (auto &Suffix : Suffixes) {
+     if (!Suffix.Active)

--- a/recipes-devtools/clang16/clang/0011-clang-Add-lpthread-and-ldl-along-with-lunwind-for-st.patch
+++ b/recipes-devtools/clang16/clang/0011-clang-Add-lpthread-and-ldl-along-with-lunwind-for-st.patch
@@ -1,0 +1,35 @@
+From c16c0db65b24497a27fcc89012bfb37000a6e937 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Wed, 31 Jul 2019 22:51:39 -0700
+Subject: [PATCH] clang: Add -lpthread and -ldl along with -lunwind for static
+ linking
+
+When doing static liking with --unwindlib=libunwind -static we encounter
+undefined symbols
+libunwind/src/RWMutex.hpp:68: undefined reference to `pthread_rwlock_wrlock'
+
+and
+
+libunwind/src/AddressSpace.hpp:597: undefined reference to `dladdr'
+
+therefore we need to link in libpthread and libdl to fill these symbols
+
+Upstream-Status: Pending
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ clang/lib/Driver/ToolChains/CommonArgs.cpp | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/clang/lib/Driver/ToolChains/CommonArgs.cpp b/clang/lib/Driver/ToolChains/CommonArgs.cpp
+index 34640b3c450d..580d326935c0 100644
+--- a/clang/lib/Driver/ToolChains/CommonArgs.cpp
++++ b/clang/lib/Driver/ToolChains/CommonArgs.cpp
+@@ -1725,6 +1725,8 @@ static void AddUnwindLibrary(const ToolChain &TC, const Driver &D,
+         CmdArgs.push_back("-lunwind");
+     } else if (LGT == LibGccType::StaticLibGcc) {
+       CmdArgs.push_back("-l:libunwind.a");
++      CmdArgs.push_back("-lpthread");
++      CmdArgs.push_back("-ldl");
+     } else if (LGT == LibGccType::SharedLibGcc) {
+       if (TC.getTriple().isOSCygMing())
+         CmdArgs.push_back("-l:libunwind.dll.a");

--- a/recipes-devtools/clang16/clang/0012-Pass-PYTHON_EXECUTABLE-when-cross-compiling-for-nati.patch
+++ b/recipes-devtools/clang16/clang/0012-Pass-PYTHON_EXECUTABLE-when-cross-compiling-for-nati.patch
@@ -1,0 +1,24 @@
+From 4cfb62329c5b2ef54b7e0db4597fbb188948be65 Mon Sep 17 00:00:00 2001
+From: Anuj Mittal <anuj.mittal@intel.com>
+Date: Thu, 26 Dec 2019 12:56:16 -0800
+Subject: [PATCH] Pass PYTHON_EXECUTABLE when cross compiling for native build
+
+Upstream-Status: Pending
+Signed-off-by: Anuj Mittal <anuj.mittal@intel.com>
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ llvm/cmake/modules/CrossCompile.cmake | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/llvm/cmake/modules/CrossCompile.cmake b/llvm/cmake/modules/CrossCompile.cmake
+index a46a0fd630b0..55f6dba2901a 100644
+--- a/llvm/cmake/modules/CrossCompile.cmake
++++ b/llvm/cmake/modules/CrossCompile.cmake
+@@ -86,6 +86,7 @@ function(llvm_create_cross_target project_name target_name toolchain buildtype)
+         -DLLVM_TEMPORARILY_ALLOW_OLD_TOOLCHAIN="${LLVM_TEMPORARILY_ALLOW_OLD_TOOLCHAIN}"
+         -DLLVM_INCLUDE_BENCHMARKS=OFF
+         -DLLVM_INCLUDE_TESTS=OFF
++        -DPYTHON_EXECUTABLE="${PYTHON_EXECUTABLE}"
+         ${build_type_flags} ${linker_flag} ${external_clang_dir}
+         ${ARGN}
+     WORKING_DIRECTORY ${${project_name}_${target_name}_BUILD}

--- a/recipes-devtools/clang16/clang/0013-Check-for-atomic-double-intrinsics.patch
+++ b/recipes-devtools/clang16/clang/0013-Check-for-atomic-double-intrinsics.patch
@@ -1,0 +1,34 @@
+From 9fc922e61ce39a12e99b4ff66475443b1dc61ab2 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Mon, 18 Nov 2019 17:00:29 -0800
+Subject: [PATCH] Check for atomic<double> intrinsics
+
+On some architectures e.g. x86/32bit gcc decides to inline calls to
+double atomic variables but clang does not and defers it to libatomic
+therefore detect if clang can use built-ins for atomic<double> if not
+then link libatomic, this helps building clangd for x86 on linux systems
+with gcc runtime
+
+Upstream-Status: Pending
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ llvm/cmake/modules/CheckAtomic.cmake | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/llvm/cmake/modules/CheckAtomic.cmake b/llvm/cmake/modules/CheckAtomic.cmake
+index f11cadf39ff6..80a18a92956a 100644
+--- a/llvm/cmake/modules/CheckAtomic.cmake
++++ b/llvm/cmake/modules/CheckAtomic.cmake
+@@ -30,10 +30,11 @@ function(check_working_cxx_atomics64 varname)
+ #include <atomic>
+ #include <cstdint>
+ std::atomic<uint64_t> x (0);
++std::atomic<double> y (0);
+ int main() {
+   uint64_t i = x.load(std::memory_order_relaxed);
+   (void)i;
+-  return 0;
++  return int(y);
+ }
+ " ${varname})
+   set(CMAKE_REQUIRED_FLAGS ${OLD_CMAKE_REQUIRED_FLAGS})

--- a/recipes-devtools/clang16/clang/0014-libcxx-Add-compiler-runtime-library-to-link-step-for.patch
+++ b/recipes-devtools/clang16/clang/0014-libcxx-Add-compiler-runtime-library-to-link-step-for.patch
@@ -1,0 +1,37 @@
+From 4c2d34597815c045615725b185f2e08461a68432 Mon Sep 17 00:00:00 2001
+From: Jeremy Puhlman <jpuhlman@mvista.com>
+Date: Thu, 16 Jan 2020 21:16:10 +0000
+Subject: [PATCH] libcxx: Add compiler runtime library to link step for libcxx
+
+This corrects "undefined reference to __divti3"
+
+Upstream-Status: Inappropriate [configuration]
+
+Signed-off-by: Jeremy Puhlman <jpuhlman@mvista.com>
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ libcxx/src/CMakeLists.txt | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/libcxx/src/CMakeLists.txt b/libcxx/src/CMakeLists.txt
+index 9ff2a62e9394..e76625d5a5ac 100644
+--- a/libcxx/src/CMakeLists.txt
++++ b/libcxx/src/CMakeLists.txt
+@@ -200,7 +200,7 @@ if (LIBCXX_ENABLE_SHARED)
+   add_library(cxx_shared SHARED ${exclude_from_all} ${LIBCXX_SOURCES} ${LIBCXX_HEADERS})
+   target_include_directories(cxx_shared PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+   target_link_libraries(cxx_shared PUBLIC cxx-headers
+-                                   PRIVATE ${LIBCXX_LIBRARIES})
++                                   PRIVATE ${LIBCXX_LIBRARIES} "$$($$CC --print-libgcc-file-name)")
+   set_target_properties(cxx_shared
+     PROPERTIES
+       COMPILE_FLAGS "${LIBCXX_COMPILE_FLAGS}"
+@@ -294,7 +294,7 @@ if (LIBCXX_ENABLE_STATIC)
+   add_library(cxx_static STATIC ${exclude_from_all} ${LIBCXX_SOURCES} ${LIBCXX_HEADERS})
+   target_include_directories(cxx_static PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+   target_link_libraries(cxx_static PUBLIC cxx-headers
+-                                   PRIVATE ${LIBCXX_LIBRARIES}
++                                   PRIVATE ${LIBCXX_LIBRARIES} "$$($$CC --print-libgcc-file-name)"
+                                    PRIVATE libcxx-abi-static)
+   set_target_properties(cxx_static
+     PROPERTIES

--- a/recipes-devtools/clang16/clang/0015-clang-llvm-cmake-Fix-configure-for-packages-using-fi.patch
+++ b/recipes-devtools/clang16/clang/0015-clang-llvm-cmake-Fix-configure-for-packages-using-fi.patch
@@ -1,0 +1,115 @@
+From aafbba9f341d5e6d5293371fad130472bee85c5c Mon Sep 17 00:00:00 2001
+From: Ovidiu Panait <ovidiu.panait@windriver.com>
+Date: Fri, 31 Jan 2020 10:56:11 +0200
+Subject: [PATCH] clang,llvm: cmake: Fix configure for packages using
+ find_package()
+
+Currently, when a package (i.e. bcc [https://github.com/iovisor/bcc.git])
+that depends on LLVM/Clang tries to run cmake find_package() during
+do_configure, it will fail with a similar error:
+
+|   The imported target "llvm-tblgen" references the file
+|      ".../recipe-sysroot/usr/bin/llvm-tblgen"
+|
+|   but this file does not exist.  Possible reasons include:
+|   * The file was deleted, renamed, or moved to another location.
+|   * An install or uninstall procedure did not complete successfully.
+|   * The installation package was faulty and contained
+|      ".../recipe-sysroot/usr/lib/cmake/LLVMExports.cmake"
+|   but not all the files it references.
+
+This is due to the fact that currently the cmake scripts look for target
+binaries in sysroot. Work around this by not exporting the target binaries in
+Exports-* cmake files.
+
+Upstream-Status: Inappropriate [oe-specific]
+
+Signed-off-by: Ovidiu Panait <ovidiu.panait@windriver.com>
+---
+ clang/cmake/modules/AddClang.cmake | 2 --
+ llvm/cmake/modules/AddLLVM.cmake   | 6 ------
+ llvm/cmake/modules/TableGen.cmake  | 6 ------
+ 3 files changed, 14 deletions(-)
+
+diff --git a/clang/cmake/modules/AddClang.cmake b/clang/cmake/modules/AddClang.cmake
+index 75b0080f6715..ddf446a13eca 100644
+--- a/clang/cmake/modules/AddClang.cmake
++++ b/clang/cmake/modules/AddClang.cmake
+@@ -168,7 +168,6 @@ macro(add_clang_tool name)
+     if (CLANG_BUILD_TOOLS)
+       get_target_export_arg(${name} Clang export_to_clangtargets)
+       install(TARGETS ${name}
+-        ${export_to_clangtargets}
+         RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+         COMPONENT ${name})
+ 
+@@ -177,7 +176,6 @@ macro(add_clang_tool name)
+                                  DEPENDS ${name}
+                                  COMPONENT ${name})
+       endif()
+-      set_property(GLOBAL APPEND PROPERTY CLANG_EXPORTS ${name})
+     endif()
+   endif()
+ endmacro()
+diff --git a/llvm/cmake/modules/AddLLVM.cmake b/llvm/cmake/modules/AddLLVM.cmake
+index 93e6d67551de..d8123389957b 100644
+--- a/llvm/cmake/modules/AddLLVM.cmake
++++ b/llvm/cmake/modules/AddLLVM.cmake
+@@ -1335,7 +1335,6 @@ macro(llvm_add_tool project name)
+       if( LLVM_BUILD_TOOLS )
+         get_target_export_arg(${name} LLVM export_to_llvmexports)
+         install(TARGETS ${name}
+-                ${export_to_llvmexports}
+                 RUNTIME DESTINATION ${${project}_TOOLS_INSTALL_DIR}
+                 COMPONENT ${name})
+ 
+@@ -1346,9 +1345,6 @@ macro(llvm_add_tool project name)
+         endif()
+       endif()
+     endif()
+-    if( LLVM_BUILD_TOOLS )
+-      set_property(GLOBAL APPEND PROPERTY LLVM_EXPORTS ${name})
+-    endif()
+     set_target_properties(${name} PROPERTIES FOLDER "Tools")
+   endif()
+ endmacro(llvm_add_tool project name)
+@@ -1393,7 +1389,6 @@ macro(add_llvm_utility name)
+     if (LLVM_INSTALL_UTILS AND LLVM_BUILD_UTILS)
+       get_target_export_arg(${name} LLVM export_to_llvmexports)
+       install(TARGETS ${name}
+-              ${export_to_llvmexports}
+               RUNTIME DESTINATION ${LLVM_UTILS_INSTALL_DIR}
+               COMPONENT ${name})
+ 
+@@ -1402,7 +1397,6 @@ macro(add_llvm_utility name)
+                                  DEPENDS ${name}
+                                  COMPONENT ${name})
+       endif()
+-      set_property(GLOBAL APPEND PROPERTY LLVM_EXPORTS ${name})
+     elseif(LLVM_BUILD_UTILS)
+       set_property(GLOBAL APPEND PROPERTY LLVM_EXPORTS_BUILDTREE_ONLY ${name})
+     endif()
+diff --git a/llvm/cmake/modules/TableGen.cmake b/llvm/cmake/modules/TableGen.cmake
+index 70c2edb8c833..e012fea08982 100644
+--- a/llvm/cmake/modules/TableGen.cmake
++++ b/llvm/cmake/modules/TableGen.cmake
+@@ -189,12 +189,7 @@ macro(add_tablegen target project)
+ 
+   if (ADD_TABLEGEN_DESTINATION AND NOT LLVM_INSTALL_TOOLCHAIN_ONLY AND
+       (LLVM_BUILD_UTILS OR ${target} IN_LIST LLVM_DISTRIBUTION_COMPONENTS))
+-    set(export_arg)
+-    if(ADD_TABLEGEN_EXPORT)
+-      get_target_export_arg(${target} ${ADD_TABLEGEN_EXPORT} export_arg)
+-    endif()
+     install(TARGETS ${target}
+-            ${export_arg}
+             COMPONENT ${target}
+             RUNTIME DESTINATION "${ADD_TABLEGEN_DESTINATION}")
+     if(NOT LLVM_ENABLE_IDE)
+@@ -205,6 +200,5 @@ macro(add_tablegen target project)
+   endif()
+   if(ADD_TABLEGEN_EXPORT)
+     string(TOUPPER ${ADD_TABLEGEN_EXPORT} export_upper)
+-    set_property(GLOBAL APPEND PROPERTY ${export_upper}_EXPORTS ${target})
+   endif()
+ endmacro()

--- a/recipes-devtools/clang16/clang/0016-clang-Fix-resource-dir-location-for-cross-toolchains.patch
+++ b/recipes-devtools/clang16/clang/0016-clang-Fix-resource-dir-location-for-cross-toolchains.patch
@@ -1,0 +1,40 @@
+From 4afad7aec9a18b35e934d50b2f99dc464d6ead0e Mon Sep 17 00:00:00 2001
+From: Jim Broadus <jbroadus@xevo.com>
+Date: Thu, 26 Mar 2020 16:05:53 -0700
+Subject: [PATCH] clang: Fix resource dir location for cross toolchains
+
+When clang looks for the resources directory, it does so based on the binary
+location and assumes that the containing directory is a sibling to lib. The
+Yocto cross.bbclass defines the default bindir as
+${exec_prefix}/bin/${CROSS_TARGET_SYS_DIR}. ex: /usr/bin/aarch64-poky-linux/.
+This causes clang to form a path that looks like /usr/bin/lib/clang/...
+
+As a fix for this, check the parent directory name. If that is "bin", then
+use that directory's parent.
+
+Upstream-Status: Pending
+Signed-off-by: Jim Broadus <jbroadus@xevo.com>
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ clang/lib/Driver/Driver.cpp | 8 +++++++-
+ 1 file changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/clang/lib/Driver/Driver.cpp b/clang/lib/Driver/Driver.cpp
+index a268f2fa8fc5..ab813044dc8c 100644
+--- a/clang/lib/Driver/Driver.cpp
++++ b/clang/lib/Driver/Driver.cpp
+@@ -181,7 +181,13 @@ std::string Driver::GetResourcesPath(StringRef BinaryPath,
+     // With a static-library build of libclang, LibClangPath will contain the
+     // path of the embedding binary, which for LLVM binaries will be in bin/.
+     // ../lib gets us to lib/ in both cases.
+-    P = llvm::sys::path::parent_path(Dir);
++    Dir = std::string(llvm::sys::path::parent_path(Dir));
++
++    // OE cross toolchains are installed, by default, in a subdir of bin.
++    if (llvm::sys::path::filename(Dir) == "bin") {
++      Dir = std::string(llvm::sys::path::parent_path(Dir));
++    }
++    P = Dir;
+     llvm::sys::path::append(P, CLANG_INSTALL_LIBDIR_BASENAME, "clang",
+                             CLANG_VERSION_MAJOR_STRING);
+   }

--- a/recipes-devtools/clang16/clang/0017-clang-driver-Add-dyld-prefix-when-checking-sysroot-f.patch
+++ b/recipes-devtools/clang16/clang/0017-clang-driver-Add-dyld-prefix-when-checking-sysroot-f.patch
@@ -1,0 +1,79 @@
+From a85573b9e7e939b0ab1738dd3b3cc999b7de1547 Mon Sep 17 00:00:00 2001
+From: Oleksandr Ocheretnyi <oocheret@cisco.com>
+Date: Wed, 15 Apr 2020 00:08:39 +0300
+Subject: [PATCH] clang: driver: Add dyld-prefix when checking sysroot for ldso
+ path
+
+ * the dyld-prefix shall be taken into account when the default
+   path for the dynamic linker has to be checked.
+
+ * this patch shall be used as annex to the next patch:
+   'clang: driver: Check sysroot for ldso path' which includes
+   the usrmerge scenario.
+
+Upstream-Status: Pending
+Signed-off-by: Oleksandr Ocheretnyi <oocheret@cisco.com>
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ clang/lib/Driver/ToolChains/Linux.cpp | 20 ++++++++++----------
+ 1 file changed, 10 insertions(+), 10 deletions(-)
+
+diff --git a/clang/lib/Driver/ToolChains/Linux.cpp b/clang/lib/Driver/ToolChains/Linux.cpp
+index de0d5950d2ee..c6acfc8924c9 100644
+--- a/clang/lib/Driver/ToolChains/Linux.cpp
++++ b/clang/lib/Driver/ToolChains/Linux.cpp
+@@ -464,8 +464,8 @@ std::string Linux::getDynamicLinker(const ArgList &Args) const {
+         tools::arm::getARMFloatABI(*this, Args) == tools::arm::FloatABI::Hard;
+ 
+     LibDir = "lib32";
+-    if (!getVFS().exists(getDriver().SysRoot + "/" + LibDir + "/" + Loader) &&
+-         getVFS().exists(getDriver().SysRoot + "/lib/" + Loader)) {
++    if (!getVFS().exists(getDriver().SysRoot + getDriver().DyldPrefix + "/" + LibDir + "/" + Loader) &&
++         getVFS().exists(getDriver().SysRoot + getDriver().DyldPrefix + "/lib/" + Loader)) {
+         LibDir = "lib";
+     }
+     Loader = HF ? "ld-linux-armhf.so.3" : "ld-linux.so.3";
+@@ -522,8 +522,8 @@ std::string Linux::getDynamicLinker(const ArgList &Args) const {
+     LibDir = "lib64";
+     Loader =
+         (tools::ppc::hasPPCAbiArg(Args, "elfv2")) ? "ld64.so.2" : "ld64.so.1";
+-    if (!getVFS().exists(getDriver().SysRoot + "/" + LibDir + "/" + Loader) &&
+-         getVFS().exists(getDriver().SysRoot + "/lib/" + Loader)) {
++    if (!getVFS().exists(getDriver().SysRoot + getDriver().DyldPrefix + "/" + LibDir + "/" + Loader) &&
++         getVFS().exists(getDriver().SysRoot + getDriver().DyldPrefix + "/lib/" + Loader)) {
+         LibDir = "lib";
+     }
+     break;
+@@ -531,8 +531,8 @@ std::string Linux::getDynamicLinker(const ArgList &Args) const {
+     LibDir = "lib64";
+     Loader =
+         (tools::ppc::hasPPCAbiArg(Args, "elfv1")) ? "ld64.so.1" : "ld64.so.2";
+-    if (!getVFS().exists(getDriver().SysRoot + "/" + LibDir + "/" + Loader) &&
+-         getVFS().exists(getDriver().SysRoot + "/lib/" + Loader)) {
++    if (!getVFS().exists(getDriver().SysRoot + getDriver().DyldPrefix + "/" + LibDir + "/" + Loader) &&
++         getVFS().exists(getDriver().SysRoot + getDriver().DyldPrefix + "/lib/" + Loader)) {
+         LibDir = "lib";
+     }
+     break;
+@@ -556,8 +556,8 @@ std::string Linux::getDynamicLinker(const ArgList &Args) const {
+   case llvm::Triple::sparcv9:
+     LibDir = "lib64";
+     Loader = "ld-linux.so.2";
+-    if (!getVFS().exists(getDriver().SysRoot + "/" + LibDir + "/" + Loader) &&
+-         getVFS().exists(getDriver().SysRoot + "/lib/" + Loader)) {
++    if (!getVFS().exists(getDriver().SysRoot + getDriver().DyldPrefix + "/" + LibDir + "/" + Loader) &&
++         getVFS().exists(getDriver().SysRoot + getDriver().DyldPrefix + "/lib/" + Loader)) {
+         LibDir = "lib";
+     }
+     break;
+@@ -574,8 +574,8 @@ std::string Linux::getDynamicLinker(const ArgList &Args) const {
+ 
+     LibDir = X32 ? "libx32" : "lib64";
+     Loader = X32 ? "ld-linux-x32.so.2" : "ld-linux-x86-64.so.2";
+-    if (!getVFS().exists(getDriver().SysRoot + "/" + LibDir + "/" + Loader) &&
+-         getVFS().exists(getDriver().SysRoot + "/lib/" + Loader)) {
++    if (!getVFS().exists(getDriver().SysRoot + getDriver().DyldPrefix + "/" + LibDir + "/" + Loader) &&
++         getVFS().exists(getDriver().SysRoot + getDriver().DyldPrefix + "/lib/" + Loader)) {
+         LibDir = "lib";
+     }
+     break;

--- a/recipes-devtools/clang16/clang/0018-clang-Use-python3-in-python-scripts.patch
+++ b/recipes-devtools/clang16/clang/0018-clang-Use-python3-in-python-scripts.patch
@@ -1,0 +1,46 @@
+From 9c415718a3b38bd19d82b624fa0f564ad0f7a1fa Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Wed, 14 Oct 2020 22:19:57 -0700
+Subject: [PATCH] clang: Use python3 in python scripts
+
+Some scripts ask for python, but they work fine with python3
+and in OE python symlink is not exposed to build, only python3 is
+
+Upstream-Status: Pending
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ .../find-all-symbols/tool/run-find-all-symbols.py               | 2 +-
+ clang-tools-extra/clang-tidy/tool/clang-tidy-diff.py            | 2 +-
+ clang/tools/scan-view/bin/scan-view                             | 2 +-
+ 3 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/clang-tools-extra/clang-include-fixer/find-all-symbols/tool/run-find-all-symbols.py b/clang-tools-extra/clang-include-fixer/find-all-symbols/tool/run-find-all-symbols.py
+index a0fa64592e62..27aa97a35571 100755
+--- a/clang-tools-extra/clang-include-fixer/find-all-symbols/tool/run-find-all-symbols.py
++++ b/clang-tools-extra/clang-include-fixer/find-all-symbols/tool/run-find-all-symbols.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python3
+ #
+ #=- run-find-all-symbols.py - Parallel find-all-symbols runner -*- python  -*-=#
+ #
+diff --git a/clang-tools-extra/clang-tidy/tool/clang-tidy-diff.py b/clang-tools-extra/clang-tidy/tool/clang-tidy-diff.py
+index a26d2144b7f9..396a201b667e 100755
+--- a/clang-tools-extra/clang-tidy/tool/clang-tidy-diff.py
++++ b/clang-tools-extra/clang-tidy/tool/clang-tidy-diff.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python3
+ #
+ #===- clang-tidy-diff.py - ClangTidy Diff Checker -----------*- python -*--===#
+ #
+diff --git a/clang/tools/scan-view/bin/scan-view b/clang/tools/scan-view/bin/scan-view
+index 6165432e7af8..07effbca5969 100755
+--- a/clang/tools/scan-view/bin/scan-view
++++ b/clang/tools/scan-view/bin/scan-view
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python3
+ 
+ from __future__ import print_function
+ 

--- a/recipes-devtools/clang16/clang/0019-For-x86_64-set-Yocto-based-GCC-install-search-path.patch
+++ b/recipes-devtools/clang16/clang/0019-For-x86_64-set-Yocto-based-GCC-install-search-path.patch
@@ -1,0 +1,70 @@
+From 4498ef187dd9a9fc83fb433110c2af7b94f3aac0 Mon Sep 17 00:00:00 2001
+From: Hongxu Jia <hongxu.jia@windriver.com>
+Date: Mon, 25 Jan 2021 16:14:35 +0800
+Subject: [PATCH] For x86_64, set Yocto based GCC install search path
+
+Under Yocto host, while using clang-native to build, it searches
+install host gcc failed which causing the include file not found
+[snip]
+|clang++ -target x86_64-linux  -MMD -MF src/base/files/file_path_constants.o.d -I../../../tools/gn/src -I. \
+-isystem/tmp-glibc/work/x86_64-linux/gn-native/87.0.4280.141-r0/recipe-sysroot-native/usr/include -O2 -pipe \
+-std=c++17 -c ../../../tools/gn/src/base/files/file_path_constants.cc -o src/base/files/file_path_constants.o
+|../../../tools/gn/src/base/files/file_path_constants.cc:7:10: fatal error: 'iterator' file not found
+|#include <iterator>
+|         ^~~~~~~~
+[snip]
+
+Set three Yocto based GCC triple: poky, oe-core and wind river
+
+Before aplly the patch
+[snip]
+$ ../recipe-sysroot-native/usr/bin/clang++ -v
+clang version 11.0.1 (https://github.com/llvm/llvm-project 43ff75f2c3feef64f9d73328230d34dac8832a91)
+Target: x86_64-unknown-linux-gnu
+Thread model: posix
+InstalledDir:tmp-glibc/work/x86_64-linux/gn-native/87.0.4280.141-r0/chromium-87.0.4280.141/../recipe-sysroot-native/usr/bin
+[snip]
+
+After aplly the patch:
+[snip]
+$ ../recipe-sysroot-native/usr/bin/clang++ -v
+clang version 11.0.1 (https://github.com/llvm/llvm-project 22c3241ff9a6224261df48d0258957fd8acc3d64)
+Target: x86_64-unknown-linux-gnu
+Thread model: posix
+InstalledDir:tmp-glibc/work/x86_64-linux/gn-native/87.0.4280.141-r0/chromium-87.0.4280.141/../recipe-sysroot-native/usr/bin
+Found candidate GCC installation: /usr/lib//x86_64-wrs-linux/10.1.0
+Found candidate GCC installation: /usr/lib/gcc/x86_64-wrs-linux/10.1.0
+Selected GCC installation: /usr/lib//x86_64-wrs-linux/10.1.0
+Candidate multilib: .;@m64
+Selected multilib: .;@m64
+[snip]
+
+BTW, it is hardly to insert a triple by the replacement of TARGET_SYS
+(=${TARGET_ARCH}${TARGET_VENDOR}-${TARGET_OS}), since TARGET_VENDOR
+is different between clang and clang-native
+
+The //CLANG_EXTRA_OE_VENDORS_TRIPLES string is replaced with list of
+additional triples based on CLANG_EXTRA_OE_VENDORS variable in
+recipes-devtools/clang/llvm-project-source.inc:add_more_target_vendors()
+
+Upstream-Status: Inappropriate [oe specific]
+
+Signed-off-by: Martin Jansa <martin.jansa@gmail.com>
+Signed-off-by: Hongxu Jia <hongxu.jia@windriver.com>
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ clang/lib/Driver/ToolChains/Gnu.cpp | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/clang/lib/Driver/ToolChains/Gnu.cpp b/clang/lib/Driver/ToolChains/Gnu.cpp
+index 846163329d92..0db37c6ef1a8 100644
+--- a/clang/lib/Driver/ToolChains/Gnu.cpp
++++ b/clang/lib/Driver/ToolChains/Gnu.cpp
+@@ -2254,6 +2254,7 @@ void Generic_GCC::GCCInstallationDetector::AddDefaultGCCPrefixes(
+       "x86_64-redhat-linux",    "x86_64-suse-linux",
+       "x86_64-manbo-linux-gnu", "x86_64-linux-gnu",
+       "x86_64-slackware-linux", "x86_64-unknown-linux",
++      "x86_64-oe-linux",//CLANG_EXTRA_OE_VENDORS_TRIPLES
+       "x86_64-amazon-linux"};
+   static const char *const X32Triples[] = {"x86_64-linux-gnux32",
+                                            "x86_64-pc-linux-gnux32"};

--- a/recipes-devtools/clang16/clang/0020-llvm-Do-not-use-find_library-for-ncurses.patch
+++ b/recipes-devtools/clang16/clang/0020-llvm-Do-not-use-find_library-for-ncurses.patch
@@ -1,0 +1,45 @@
+From 72388158dd0791b597fdc7ffd6913de0401f4b43 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Sun, 7 Feb 2021 23:58:41 -0800
+Subject: [PATCH] llvm: Do not use find_library for ncurses
+
+This ensures that it lets OE to decide which lib to link
+otherwise it adds absolute paths to linker cmdline and confuses it
+horribly with native and target libs when build clang for target
+
+TOPDIR/build/tmp/work/cortexa57-yoe-linux-musl/clang/12.0.0-r0/recipe-sysroot-native/usr/lib/libtinfo.so: error adding symbols: file in wrong format
+clang-12: error: linker command failed with exit code 1 (use -v to see invocation)
+
+Upstream-Status: Pending
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ compiler-rt/cmake/config-ix.cmake     | 2 +-
+ llvm/cmake/modules/FindTerminfo.cmake | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/compiler-rt/cmake/config-ix.cmake b/compiler-rt/cmake/config-ix.cmake
+index 5f51befc1973..55c04b76908e 100644
+--- a/compiler-rt/cmake/config-ix.cmake
++++ b/compiler-rt/cmake/config-ix.cmake
+@@ -179,7 +179,7 @@ else()
+   set(MAYBE_REQUIRED)
+ endif()
+ if(LLVM_ENABLE_TERMINFO)
+-  find_library(COMPILER_RT_TERMINFO_LIB NAMES terminfo tinfo curses ncurses ncursesw ${MAYBE_REQUIRED})
++  find_library(COMPILER_RT_TERMINFO_LIB NAMES terminfo tinfo curses ncurses ncursesw ${MAYBE_REQUIRED} NO_DEFAULT_PATH NO_CMAKE_FIND_ROOT_PATH)
+ endif()
+ if(COMPILER_RT_TERMINFO_LIB)
+   set(LLVM_ENABLE_TERMINFO 1)
+diff --git a/llvm/cmake/modules/FindTerminfo.cmake b/llvm/cmake/modules/FindTerminfo.cmake
+index eef1f95853eb..b3b330dd3d59 100644
+--- a/llvm/cmake/modules/FindTerminfo.cmake
++++ b/llvm/cmake/modules/FindTerminfo.cmake
+@@ -11,7 +11,7 @@
+ # Additionally, the following import target will be defined:
+ # Terminfo::terminfo
+ 
+-find_library(Terminfo_LIBRARIES NAMES terminfo tinfo curses ncurses ncursesw)
++find_library(Terminfo_LIBRARIES NAMES terminfo tinfo curses ncurses ncursesw NO_DEFAULT_PATH NO_CMAKE_FIND_ROOT_PATH)
+ 
+ if(Terminfo_LIBRARIES)
+   include(CMakePushCheckState)

--- a/recipes-devtools/clang16/clang/0021-llvm-Insert-anchor-for-adding-OE-distro-vendor-names.patch
+++ b/recipes-devtools/clang16/clang/0021-llvm-Insert-anchor-for-adding-OE-distro-vendor-names.patch
@@ -1,0 +1,32 @@
+From 9ac3b933821e3cb3fa71985c8a4f6291d1810d92 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Thu, 11 Feb 2021 16:42:49 -0800
+Subject: [PATCH] llvm: Insert anchor for adding OE distro vendor names
+
+This helps in making right detection for OE built gcc toolchains
+
+The //CLANG_EXTRA_OE_VENDORS_CASES string is replaced with list of
+additional Ceses based on CLANG_EXTRA_OE_VENDORS variable in
+recipes-devtools/clang/llvm-project-source.inc:add_more_target_vendors()
+
+Upstream-Status: Inappropriate [OE-specific]
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+Signed-off-by: Martin Jansa <martin.jansa@gmail.com>
+---
+ llvm/lib/TargetParser/Triple.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/llvm/lib/TargetParser/Triple.cpp b/llvm/lib/TargetParser/Triple.cpp
+index a68035989a93..ab1fef23d6fc 100644
+--- a/llvm/lib/TargetParser/Triple.cpp
++++ b/llvm/lib/TargetParser/Triple.cpp
+@@ -551,7 +551,7 @@ static Triple::VendorType parseVendor(StringRef VendorName) {
+     .Case("amd", Triple::AMD)
+     .Case("mesa", Triple::Mesa)
+     .Case("suse", Triple::SUSE)
+-    .Case("oe", Triple::OpenEmbedded)
++    .Case("oe", Triple::OpenEmbedded)//CLANG_EXTRA_OE_VENDORS_CASES
+     .Default(Triple::UnknownVendor);
+ }
+ 

--- a/recipes-devtools/clang16/clang/0022-compiler-rt-Do-not-use-backtrace-APIs-on-non-glibc-l.patch
+++ b/recipes-devtools/clang16/clang/0022-compiler-rt-Do-not-use-backtrace-APIs-on-non-glibc-l.patch
@@ -1,0 +1,68 @@
+From 671ccc83d1e5da6a08ca8bcec2a70df57a955bf8 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Wed, 19 May 2021 17:32:13 -0700
+Subject: [PATCH] compiler-rt: Do not use backtrace APIs on non-glibc linux
+
+musl e.g. does not provide backtrace APIs
+
+Upstream-Status: Pending
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ .../lib/gwp_asan/optional/backtrace_linux_libc.cpp  | 13 ++++++++++++-
+ 1 file changed, 12 insertions(+), 1 deletion(-)
+
+diff --git a/compiler-rt/lib/gwp_asan/optional/backtrace_linux_libc.cpp b/compiler-rt/lib/gwp_asan/optional/backtrace_linux_libc.cpp
+index ea8e72be287d..0344074dd254 100644
+--- a/compiler-rt/lib/gwp_asan/optional/backtrace_linux_libc.cpp
++++ b/compiler-rt/lib/gwp_asan/optional/backtrace_linux_libc.cpp
+@@ -7,7 +7,9 @@
+ //===----------------------------------------------------------------------===//
+ 
+ #include <assert.h>
++#ifdef __GLIBC__
+ #include <execinfo.h>
++#endif
+ #include <stddef.h>
+ #include <stdint.h>
+ #include <stdlib.h>
+@@ -21,8 +23,11 @@
+ namespace {
+ size_t Backtrace(uintptr_t *TraceBuffer, size_t Size) {
+   static_assert(sizeof(uintptr_t) == sizeof(void *), "uintptr_t is not void*");
+-
++#ifdef __GLIBC__
+   return backtrace(reinterpret_cast<void **>(TraceBuffer), Size);
++#else
++  return -1;
++#endif
+ }
+ 
+ // We don't need any custom handling for the Segv backtrace - the libc unwinder
+@@ -30,7 +35,11 @@ size_t Backtrace(uintptr_t *TraceBuffer, size_t Size) {
+ // to avoid the additional frame.
+ GWP_ASAN_ALWAYS_INLINE size_t SegvBacktrace(uintptr_t *TraceBuffer, size_t Size,
+                                             void * /*Context*/) {
++#ifdef __GLIBC__
+   return Backtrace(TraceBuffer, Size);
++#else
++  return -1;
++#endif
+ }
+ 
+ static void PrintBacktrace(uintptr_t *Trace, size_t TraceLength,
+@@ -40,6 +49,7 @@ static void PrintBacktrace(uintptr_t *Trace, size_t TraceLength,
+     return;
+   }
+ 
++#ifdef __GLIBC__
+   char **BacktraceSymbols =
+       backtrace_symbols(reinterpret_cast<void **>(Trace), TraceLength);
+ 
+@@ -53,6 +63,7 @@ static void PrintBacktrace(uintptr_t *Trace, size_t TraceLength,
+   Printf("\n");
+   if (BacktraceSymbols)
+     free(BacktraceSymbols);
++#endif
+ }
+ } // anonymous namespace
+ 

--- a/recipes-devtools/clang16/clang/0023-clang-Fix-x86-triple-for-non-debian-multiarch-linux-.patch
+++ b/recipes-devtools/clang16/clang/0023-clang-Fix-x86-triple-for-non-debian-multiarch-linux-.patch
@@ -1,0 +1,28 @@
+From b51eef97a31d797941c88bc228e220fef13f8e7e Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Wed, 19 May 2021 17:56:03 -0700
+Subject: [PATCH] clang: Fix x86 triple for non-debian multiarch linux distros
+
+OpenEmbedded does not hardcode mutli-arch like debian therefore ensure
+that it still uses the proper tuple
+
+Upstream-Status: Pending
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ clang/lib/Driver/ToolChains/Linux.cpp | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/clang/lib/Driver/ToolChains/Linux.cpp b/clang/lib/Driver/ToolChains/Linux.cpp
+index ca9f5f2e4f74..20c7c7a745be 100644
+--- a/clang/lib/Driver/ToolChains/Linux.cpp
++++ b/clang/lib/Driver/ToolChains/Linux.cpp
+@@ -667,6 +667,9 @@ void Linux::addLibStdCxxIncludePaths(const llvm::opt::ArgList &DriverArgs,
+       GCCInstallation.getTriple().getArch() == llvm::Triple::x86
+           ? "i386-linux-gnu"
+           : TripleStr;
++  // OpenEmbedded does not hardcode the triple to i386-linux-gnu like debian
++  if (GCCInstallation.getTriple().getVendor() == llvm::Triple::OpenEmbedded)
++	  DebianMultiarch = TripleStr;
+ 
+   // Try generic GCC detection first.
+   if (Generic_GCC::addGCCLibStdCxxIncludePaths(DriverArgs, CC1Args,

--- a/recipes-devtools/clang16/clang/0024-libunwind-Added-unw_backtrace-method.patch
+++ b/recipes-devtools/clang16/clang/0024-libunwind-Added-unw_backtrace-method.patch
@@ -1,0 +1,55 @@
+From 841592392822de2d39c0a208b0a2f9fc7e9b184d Mon Sep 17 00:00:00 2001
+From: Maksim Kita <maksim-kita@yandex-team.ru>
+Date: Sun, 23 May 2021 10:27:29 +0000
+Subject: [PATCH] libunwind: Added unw_backtrace method
+
+Source: https://github.com/ClickHouse-Extras/libunwind/commit/52f0f7861926cbfaef7e6c97d8a6d7ba2a1f6747#diff-a82fc885e2e4facf4b92d26171c13aa4aa5db296f77e1158ba2f8664e3bd1f5c
+Upstream-Status: Pending
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ libunwind/include/libunwind.h |  1 +
+ libunwind/src/libunwind.cpp   | 18 ++++++++++++++++++
+ 2 files changed, 19 insertions(+)
+
+diff --git a/libunwind/include/libunwind.h b/libunwind/include/libunwind.h
+index d2ad5ab87122..d735d955aee2 100644
+--- a/libunwind/include/libunwind.h
++++ b/libunwind/include/libunwind.h
+@@ -130,6 +130,7 @@ extern int unw_is_fpreg(unw_cursor_t *, unw_regnum_t) LIBUNWIND_AVAIL;
+ extern int unw_is_signal_frame(unw_cursor_t *) LIBUNWIND_AVAIL;
+ extern int unw_get_proc_name(unw_cursor_t *, char *, size_t, unw_word_t *) LIBUNWIND_AVAIL;
+ //extern int       unw_get_save_loc(unw_cursor_t*, int, unw_save_loc_t*);
++extern int unw_backtrace(void **, int) LIBUNWIND_AVAIL;
+ 
+ extern unw_addr_space_t unw_local_addr_space;
+ 
+diff --git a/libunwind/src/libunwind.cpp b/libunwind/src/libunwind.cpp
+index 0faea2b78570..14bf07d8f470 100644
+--- a/libunwind/src/libunwind.cpp
++++ b/libunwind/src/libunwind.cpp
+@@ -349,7 +349,25 @@ void __unw_remove_dynamic_eh_frame_section(unw_word_t eh_frame_start) {
+ #endif // defined(_LIBUNWIND_SUPPORT_DWARF_UNWIND)
+ #endif // !defined(__USING_SJLJ_EXCEPTIONS__)
+ 
++int unw_backtrace(void **buffer, int size) {
++  unw_context_t context;
++  unw_cursor_t cursor;
++  if (unw_getcontext(&context) || unw_init_local(&cursor, &context)) {
++    return 0;
++  }
++
++  unw_word_t ip;
++  int current = 0;
++  while (unw_step(&cursor) > 0) {
++    if (current >= size || unw_get_reg(&cursor, UNW_REG_IP, &ip)) {
++      break;
++    }
+ 
++    buffer[current++] = reinterpret_cast<void *>(static_cast<uintptr_t>(ip));
++  }
++
++  return current;
++}
+ 
+ // Add logging hooks in Debug builds only
+ #ifndef NDEBUG

--- a/recipes-devtools/clang16/clang/0025-clang-Do-not-use-install-relative-libc-headers.patch
+++ b/recipes-devtools/clang16/clang/0025-clang-Do-not-use-install-relative-libc-headers.patch
@@ -1,0 +1,32 @@
+From 8b052f0c29a83176e4b17e9890e1aa279da9a7cf Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Wed, 11 Aug 2021 18:37:11 -0700
+Subject: [PATCH] clang: Do not use install relative libc++ headers
+
+In OE we use same clang for native and cross builds, therefore we need
+to ensure that native sysroot install of libc++ is not searched for
+headers when doing cross compile instead it searches the target sysroot
+this is especially troublesome when libcxx-native is staged along with
+libcxx e.g. chromium
+
+Upstream-Status: Pending
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ clang/lib/Driver/ToolChains/Gnu.cpp | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/clang/lib/Driver/ToolChains/Gnu.cpp b/clang/lib/Driver/ToolChains/Gnu.cpp
+index 0db37c6ef1a8..80a21d58c86c 100644
+--- a/clang/lib/Driver/ToolChains/Gnu.cpp
++++ b/clang/lib/Driver/ToolChains/Gnu.cpp
+@@ -3093,7 +3093,9 @@ Generic_GCC::addLibCxxIncludePaths(const llvm::opt::ArgList &DriverArgs,
+ 
+   // Android never uses the libc++ headers installed alongside the toolchain,
+   // which are generally incompatible with the NDK libraries anyway.
+-  if (!getTriple().isAndroid())
++  // And also do not add it when --sysroot is specified, since it would expect
++  // libc++ headers from sysroot
++  if (!getTriple().isAndroid() && SysRoot.empty())
+     if (AddIncludePath(getDriver().Dir + "/../include"))
+       return;
+   // If this is a development, non-installed, clang, libcxx will

--- a/recipes-devtools/clang16/clang/0026-clang-Fix-how-driver-finds-GCC-installation-path-on-.patch
+++ b/recipes-devtools/clang16/clang/0026-clang-Fix-how-driver-finds-GCC-installation-path-on-.patch
@@ -1,0 +1,97 @@
+From 96a3194262a641ac20e1bf19f9db7f657e03785f Mon Sep 17 00:00:00 2001
+From: David Abdurachmanov <david.abdurachmanov@sifive.com>
+Date: Wed, 20 Oct 2021 17:30:36 -0700
+Subject: [PATCH] clang: Fix how driver finds GCC installation path on
+ OpenEmbedded
+
+Fix how Clang Driver finds GCC installation path on OpenEmbedded
+
+- For RISCV (riscv{32,64}) we define new two multi-lib options without any
+  subdirectories (e.g., lib32/ilp32d or lib64/lp64d). OpenEmbedded GCC
+  builds don't use them.
+- Modify how Clang Driver finds GCC installation path. This is important
+  because GCC files on OpenEmbedded are in two different directories:
+   (1) /usr/bin/../lib/gcc/riscv64-oe-linux/9.2.0
+   (2) /usr/lib/riscv64-oe-linux/9.2.0
+
+Clang Driver will check (1) first. The directory exist, but will produce
+no valid multi-libs and there will be no multi-lib selected. (2) contains
+actual GCC run-time objects/libraries, but because the path has exact
+same GCC version (9.2.0) it will be skipped.
+
+We modify the approach by allowing to check other directories with the same
+GCC version. We also avoid picking GCC installation path if it results in
+an empty multi-lib list.
+
+Upstream-Status: Pending
+Signed-off-by: David Abdurachmanov <david.abdurachmanov@sifive.com>
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ clang/lib/Driver/ToolChains/Gnu.cpp | 39 +++++++++++++++++++++--------
+ 1 file changed, 28 insertions(+), 11 deletions(-)
+
+diff --git a/clang/lib/Driver/ToolChains/Gnu.cpp b/clang/lib/Driver/ToolChains/Gnu.cpp
+index 80a21d58c86c..77f5c3f58a8b 100644
+--- a/clang/lib/Driver/ToolChains/Gnu.cpp
++++ b/clang/lib/Driver/ToolChains/Gnu.cpp
+@@ -1748,18 +1748,29 @@ static void findRISCVMultilibs(const Driver &D,
+     return findRISCVBareMetalMultilibs(D, TargetTriple, Path, Args, Result);
+ 
+   FilterNonExistent NonExistent(Path, "/crtbegin.o", D.getVFS());
+-  Multilib Ilp32 = makeMultilib("lib32/ilp32").flag("+m32").flag("+mabi=ilp32");
+-  Multilib Ilp32f =
++  MultilibSet RISCVMultilibs;
++
++  if (TargetTriple.getVendor() == llvm::Triple::OpenEmbedded) {
++    Multilib OpenEmbeddedIlp32d = makeMultilib("").flag("+m32").flag("+mabi=ilp32d");
++    Multilib OpenEmbeddedLp64d = makeMultilib("").flag("+m64").flag("+mabi=lp64d");
++    RISCVMultilibs =
++        MultilibSet()
++            .Either({OpenEmbeddedIlp32d, OpenEmbeddedLp64d})
++            .FilterOut(NonExistent);
++  } else {
++    Multilib Ilp32 = makeMultilib("lib32/ilp32").flag("+m32").flag("+mabi=ilp32");
++    Multilib Ilp32f =
+       makeMultilib("lib32/ilp32f").flag("+m32").flag("+mabi=ilp32f");
+-  Multilib Ilp32d =
++    Multilib Ilp32d =
+       makeMultilib("lib32/ilp32d").flag("+m32").flag("+mabi=ilp32d");
+-  Multilib Lp64 = makeMultilib("lib64/lp64").flag("+m64").flag("+mabi=lp64");
+-  Multilib Lp64f = makeMultilib("lib64/lp64f").flag("+m64").flag("+mabi=lp64f");
+-  Multilib Lp64d = makeMultilib("lib64/lp64d").flag("+m64").flag("+mabi=lp64d");
+-  MultilibSet RISCVMultilibs =
+-      MultilibSet()
+-          .Either({Ilp32, Ilp32f, Ilp32d, Lp64, Lp64f, Lp64d})
+-          .FilterOut(NonExistent);
++    Multilib Lp64 = makeMultilib("lib64/lp64").flag("+m64").flag("+mabi=lp64");
++    Multilib Lp64f = makeMultilib("lib64/lp64f").flag("+m64").flag("+mabi=lp64f");
++    Multilib Lp64d = makeMultilib("lib64/lp64d").flag("+m64").flag("+mabi=lp64d");
++    RISCVMultilibs =
++        MultilibSet()
++            .Either({Ilp32, Ilp32f, Ilp32d, Lp64, Lp64f, Lp64d})
++            .FilterOut(NonExistent);
++  }
+ 
+   Multilib::flags_list Flags;
+   bool IsRV64 = TargetTriple.getArch() == llvm::Triple::riscv64;
+@@ -2713,13 +2724,19 @@ void Generic_GCC::GCCInstallationDetector::ScanLibDirForGCCTriple(
+           continue; // Saw this path before; no need to look at it again.
+       if (CandidateVersion.isOlderThan(4, 1, 1))
+         continue;
+-      if (CandidateVersion <= Version)
++      if (CandidateVersion < Version)
+         continue;
+ 
+       if (!ScanGCCForMultilibs(TargetTriple, Args, LI->path(),
+                                NeedsBiarchSuffix))
+         continue;
+ 
++      // We might have found existing directory with GCCVersion, but it
++      // might not have GCC libraries we are looking for (i.e. return an
++      // empty Mulilibs)
++      if (Multilibs.size() == 0)
++        continue;
++
+       Version = CandidateVersion;
+       GCCTriple.setTriple(CandidateTriple);
+       // FIXME: We hack together the directory name here instead of

--- a/recipes-devtools/clang16/clang/0027-Fix-lib-paths-for-OpenEmbedded-Host.patch
+++ b/recipes-devtools/clang16/clang/0027-Fix-lib-paths-for-OpenEmbedded-Host.patch
@@ -1,0 +1,79 @@
+From a7b8523a9f649ca3bdc2759e2bb500bc7f957b48 Mon Sep 17 00:00:00 2001
+From: Changqing Li <changqing.li@windriver.com>
+Date: Tue, 7 Dec 2021 04:08:22 +0000
+Subject: [PATCH] Fix lib paths for OpenEmbedded Host
+
+Under OpenEmbedded Host, while building with clang-native, it cannot find
+the GCCInstallPath, which causing following error:
+[snip]
+compiler-rt-native/13.0.1-r0/recipe-sysroot-native/usr/bin/clang
+-target x86_64-linux
+-isystem/path/to/x86_64-linux/compiler-rt-native/13.0.1-r0/recipe-sysroot-native/usr/include
+-O2 -pipe
+/path/to/compiler-rt-native/13.0.1-r0/recipe-sysroot-native/usr/share/cmake-3.21/Modules/CMakeCCompilerABI.c`
+hosttools/ld: cannot find crtbeginS.o: No such file or directory
+[snip]
+
+Before this patch:
+compiler-rt-native/13.0.1-r0/recipe-sysroot-native/usr/bin/clang
+clang version 13.0.1 (https://github.com/llvm/llvm-project 08e3a5ccd952edee36b3c002e3a29c6b1b5153de)
+Target: x86_64-unknown-linux-gnu
+Thread model: posix
+InstalledDir: /build/tmp-glibc/work/x86_64-linux/compiler-rt-native/13.0.1-r0/recipe-sysroot-native/usr/bin
+Found candidate GCC installation: /usr/lib/gcc/x86_64-wrs-linux/10.2.0
+
+After this patch:
+compiler-rt-native/13.0.1-r0/recipe-sysroot-native/usr/bin/clang
+clang version 13.0.1 (https://github.com/llvm/llvm-project 08e3a5ccd952edee36b3c002e3a29c6b1b5153de)
+Thread model: posix
+InstalledDir: /build/tmp-glibc/work/x86_64-linux/compiler-rt-native/13.0.1-r0/recipe-sysroot-native/usr/bin
+Found candidate GCC installation: /usr/lib/gcc/x86_64-wrs-linux/10.2.0
+Found candidate GCC installation: /usr/lib/x86_64-wrs-linux/10.2.0
+Selected GCC installation: /usr/lib/x86_64-wrs-linux/10.2.0
+Candidate multilib: .;@m64
+Selected multilib: .;@m64
+
+Summary:
+For OpenEmbedded Host, sysroots are of the form<sysroot>/usr/lib/<triple>/x.y.z.
+Take x86-64 as example, the default triple is x86_64-unknown-linux-gnu.
+For clang-native, the target vendor is '-unknown', need to test current distro
+to follow above form.
+
+Upstream-Status: Inappropriate [oe specific]
+
+Signed-off-by: Changqing Li <changqing.li@windriver.com>
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ clang/lib/Driver/ToolChains/Gnu.cpp | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/clang/lib/Driver/ToolChains/Gnu.cpp b/clang/lib/Driver/ToolChains/Gnu.cpp
+index 77f5c3f58a8b..0ec2dadafc05 100644
+--- a/clang/lib/Driver/ToolChains/Gnu.cpp
++++ b/clang/lib/Driver/ToolChains/Gnu.cpp
+@@ -18,6 +18,7 @@
+ #include "Linux.h"
+ #include "clang/Config/config.h" // for GCC_INSTALL_PREFIX
+ #include "clang/Driver/Compilation.h"
++#include "clang/Driver/Distro.h"
+ #include "clang/Driver/Driver.h"
+ #include "clang/Driver/DriverDiagnostic.h"
+ #include "clang/Driver/Options.h"
+@@ -2682,6 +2683,7 @@ void Generic_GCC::GCCInstallationDetector::ScanLibDirForGCCTriple(
+     const llvm::Triple &TargetTriple, const ArgList &Args,
+     const std::string &LibDir, StringRef CandidateTriple,
+     bool NeedsBiarchSuffix, bool GCCDirExists, bool GCCCrossDirExists) {
++  Distro Distro(D.getVFS(), TargetTriple);
+   // Locations relative to the system lib directory where GCC's triple-specific
+   // directories might reside.
+   struct GCCLibSuffix {
+@@ -2699,7 +2701,8 @@ void Generic_GCC::GCCInstallationDetector::ScanLibDirForGCCTriple(
+       // files in that location, not just GCC installation data.
+       {CandidateTriple.str(), "..",
+        TargetTriple.getVendor() == llvm::Triple::Freescale ||
+-           TargetTriple.getVendor() == llvm::Triple::OpenEmbedded},
++           TargetTriple.getVendor() == llvm::Triple::OpenEmbedded ||
++           Distro.IsOpenEmbedded()},
+ 
+       // This is the normal place.
+       {"gcc/" + CandidateTriple.str(), "../..", GCCDirExists},

--- a/recipes-devtools/clang16/clang/0028-Correct-library-search-path-for-OpenEmbedded-Host.patch
+++ b/recipes-devtools/clang16/clang/0028-Correct-library-search-path-for-OpenEmbedded-Host.patch
@@ -1,0 +1,84 @@
+From 18cf3957bb9a0021059c64dc8e640028be821bc3 Mon Sep 17 00:00:00 2001
+From: Changqing Li <changqing.li@windriver.com>
+Date: Tue, 7 Dec 2021 04:55:48 +0000
+Subject: [PATCH] Correct library search path for OpenEmbedded Host
+
+For OpenEmbedded Host, the gcc install path is
+/usr/lib/x86_64-[distroname]-linux/[gcc-version].
+So the library search path is not found with default triple
+'x86_64-linux-gnu' for x86_64. Causing following error:
+[snip]
+compiler-rt-native/13.0.1-r0/recipe-sysroot-native/usr/bin/clang
+-target x86_64-linux
+-isystem/path/to/x86_64-linux/compiler-rt-native/13.0.1-r0/recipe-sysroot-native/usr/include
+-O2 -pipe
+/path/to/compiler-rt-native/13.0.1-r0/recipe-sysroot-native/usr/share/cmake-3.21/Modules/CMakeCCompilerABI.c`
+|     /build/tmp-glibc/hosttools/ld: cannot find -lgcc
+|     /build/tmp-glibc/hosttools/ld: cannot find -lgcc
+|     clang-13: error: linker command failed with exit code 1 (use -v to see invocation)
+[snip]
+
+before this patch:
+b59da142f2b0:$ /path/to/x86_64-linux/compiler-rt-native/13.0.1-r0/recipe-sysroot-native/usr/bin/clang --print-search-dirs
+programs: =/build/tmp-glibc/work/x86_64-linux/compiler-rt-native/13.0.1-r0/recipe-sysroot-native/usr/bin
+libraries: =/build/tmp-glibc/work/x86_64-linux/compiler-rt-native/13.0.1-r0/recipe-sysroot-native/usr/lib/clang/13.0.1:/build/tmp-glibc/work/x86_64-linux/compiler-rt-native/13.0.1-r0/recipe-sysroot-native/usr/bin/../lib://lib://usr/lib
+
+after this patch:
+b59da142f2b0:$ /path/to/x86_64-linux/compiler-rt-native/13.0.1-r0/recipe-sysroot-native/usr/bin/clang --print-search-dirs
+programs: =/build/tmp-glibc/work/x86_64-linux/compiler-rt-native/13.0.1-r0/recipe-sysroot-native/usr/bin
+libraries: =/build/tmp-glibc/work/x84_64-linux/compiler-rt-native/13.0.1-r0/recipe-sysroot-native/usr/lib/clang/13.0.1:/usr/lib/x86_64-wrs-linux/10.2.0://lib/x86_64-wrs-linux://usr/lib/x86_64-wrs-linux:/build/tmp-glibc/work/x86_64-linux/compiler-rt-native/13.0.1-r0/recipe-sysroot-native/usr/bin/../lib://lib://usr/lib
+
+Upstream-Status: Inappropriate [oe specific]
+
+Signed-off-by: Changqing Li <changqing.li@windriver.com>
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ clang/include/clang/Driver/Distro.h   | 2 ++
+ clang/lib/Driver/Distro.cpp           | 1 +
+ clang/lib/Driver/ToolChains/Linux.cpp | 1 +
+ 3 files changed, 4 insertions(+)
+
+diff --git a/clang/include/clang/Driver/Distro.h b/clang/include/clang/Driver/Distro.h
+index 1aaf93ddb7c4..31f03e327b78 100644
+--- a/clang/include/clang/Driver/Distro.h
++++ b/clang/include/clang/Driver/Distro.h
+@@ -45,6 +45,7 @@ public:
+     RHEL7,
+     Fedora,
+     Gentoo,
++    //CLANG_EXTRA_OE_DISTRO_NAME
+     OpenSUSE,
+     UbuntuHardy,
+     UbuntuIntrepid,
+@@ -135,6 +136,7 @@ public:
+ 
+   bool IsGentoo() const { return DistroVal == Gentoo; }
+ 
++  //CLANG_EXTRA_OE_DISTRO_CHECK
+   /// @}
+ };
+ 
+diff --git a/clang/lib/Driver/Distro.cpp b/clang/lib/Driver/Distro.cpp
+index 87a0c5a58511..b607a3f18d1e 100644
+--- a/clang/lib/Driver/Distro.cpp
++++ b/clang/lib/Driver/Distro.cpp
+@@ -44,6 +44,7 @@ static Distro::DistroType DetectOsRelease(llvm::vfs::FileSystem &VFS) {
+                     .Case("sles", Distro::OpenSUSE)
+                     .Case("opensuse", Distro::OpenSUSE)
+                     .Case("exherbo", Distro::Exherbo)
++                    //CLANG_EXTRA_OE_DISTRO_CASE
+                     .Default(Distro::UnknownDistro);
+   return Version;
+ }
+diff --git a/clang/lib/Driver/ToolChains/Linux.cpp b/clang/lib/Driver/ToolChains/Linux.cpp
+index 20c7c7a745be..f5d9b3187cf5 100644
+--- a/clang/lib/Driver/ToolChains/Linux.cpp
++++ b/clang/lib/Driver/ToolChains/Linux.cpp
+@@ -78,6 +78,7 @@ std::string Linux::getMultiarchTriple(const Driver &D,
+       return "x86_64-linux-android";
+     if (TargetEnvironment == llvm::Triple::GNUX32)
+       return "x86_64-linux-gnux32";
++    //CLANG_EXTRA_OE_DISTRO_TRIPLE
+     return "x86_64-linux-gnu";
+   case llvm::Triple::aarch64:
+     if (IsAndroid)

--- a/recipes-devtools/clang16/clang/0029-lldb-Link-with-libatomic-on-x86.patch
+++ b/recipes-devtools/clang16/clang/0029-lldb-Link-with-libatomic-on-x86.patch
@@ -1,0 +1,33 @@
+From 5a16f3cf25bfa15ddccb72f16d296648d6512ede Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Tue, 8 Feb 2022 01:31:26 -0800
+Subject: [PATCH] lldb: Link with libatomic on x86
+
+cmake atomic check is not sufficient for i686 target where clang14 still
+generates __atomic_store calls but the check does not entail this
+function and happily thinks that compiler can resolve all atomic via intrinsics
+on i686, but thats not the case, ideally the check for determining
+atomic operation should be make more robust but until then lets ask to
+link with libatomic on i686/linux
+
+Upstream-Status: Inappropriate [OE-Specific]
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ lldb/source/Utility/CMakeLists.txt | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/lldb/source/Utility/CMakeLists.txt b/lldb/source/Utility/CMakeLists.txt
+index 89acd7cd2eaf..6aa84f9d284d 100644
+--- a/lldb/source/Utility/CMakeLists.txt
++++ b/lldb/source/Utility/CMakeLists.txt
+@@ -19,6 +19,10 @@ if (CMAKE_SYSTEM_NAME MATCHES "Windows")
+   list(APPEND LLDB_SYSTEM_LIBS ws2_32 rpcrt4)
+ endif ()
+ 
++if (CMAKE_SYSTEM_PROCESSOR MATCHES "i686" AND CMAKE_SYSTEM_NAME MATCHES "Linux")
++    list(APPEND LLDB_SYSTEM_LIBS atomic)
++endif()
++
+ if (NOT HAVE_CXX_ATOMICS64_WITHOUT_LIB )
+     list(APPEND LLDB_SYSTEM_LIBS atomic)
+ endif()

--- a/recipes-devtools/clang16/clang/0030-clang-exclude-openembedded-distributions-from-settin.patch
+++ b/recipes-devtools/clang16/clang/0030-clang-exclude-openembedded-distributions-from-settin.patch
@@ -1,0 +1,35 @@
+From 43418cfdfc19953e43c5e1f62fd0720f160de1a2 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Fri, 11 Feb 2022 12:29:14 -0800
+Subject: [PATCH] clang: exclude openembedded distributions from setting rpath
+ on openmp executables
+
+OpenEmbedded based SDKs stage toolchains outsides the target rootfs and
+libomp.so is part of the target rootfs and not part of compiler
+toolchain install or relative to it. It finds the libraries via
+--sysroot during compile. This ensures that -rpath is not added for such
+systems, since it is adding cross-compile paths to rpath which is not
+correct when the binaries are run on real targets.
+
+Upstream-Status: Submitted [https://reviews.llvm.org/D119590]
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ clang/lib/Driver/ToolChains/CommonArgs.cpp | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/clang/lib/Driver/ToolChains/CommonArgs.cpp b/clang/lib/Driver/ToolChains/CommonArgs.cpp
+index 580d326935c0..412218f04df5 100644
+--- a/clang/lib/Driver/ToolChains/CommonArgs.cpp
++++ b/clang/lib/Driver/ToolChains/CommonArgs.cpp
+@@ -801,6 +801,11 @@ void tools::addLTOOptions(const ToolChain &ToolChain, const ArgList &Args,
+ void tools::addOpenMPRuntimeSpecificRPath(const ToolChain &TC,
+                                           const ArgList &Args,
+                                           ArgStringList &CmdArgs) {
++  // OpenEmbedded/Yocto installs libomp.so into <sysroot>/usr/lib
++  // therefore using -rpath is not needed, on the contrary it adds
++  // paths from cross compiler install location which is not correct
++  if (TC.getTriple().getVendor() == llvm::Triple::OpenEmbedded)
++    return;
+ 
+   if (Args.hasFlag(options::OPT_fopenmp_implicit_rpath,
+                    options::OPT_fno_openmp_implicit_rpath, true)) {

--- a/recipes-devtools/clang16/clang/0031-compiler-rt-Enable-__int128-for-ppc32.patch
+++ b/recipes-devtools/clang16/clang/0031-compiler-rt-Enable-__int128-for-ppc32.patch
@@ -1,0 +1,73 @@
+From cd16176a1b45061623ec0219a12a0a7a407fa738 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Wed, 9 Mar 2022 16:28:16 -0800
+Subject: [PATCH] compiler-rt: Enable __int128 for ppc32
+
+Upstream-Status: Pending
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ compiler-rt/lib/builtins/CMakeLists.txt | 15 +++++++--------
+ compiler-rt/lib/builtins/int_types.h    |  2 +-
+ 2 files changed, 8 insertions(+), 9 deletions(-)
+
+diff --git a/compiler-rt/lib/builtins/CMakeLists.txt b/compiler-rt/lib/builtins/CMakeLists.txt
+index 2fc70522895f..55f0ecb20a1f 100644
+--- a/compiler-rt/lib/builtins/CMakeLists.txt
++++ b/compiler-rt/lib/builtins/CMakeLists.txt
+@@ -668,11 +668,9 @@ set(mips64_SOURCES ${GENERIC_TF_SOURCES}
+ set(mips64el_SOURCES ${GENERIC_TF_SOURCES}
+                      ${mips_SOURCES})
+ 
+-set(powerpc_SOURCES ${GENERIC_SOURCES})
+-
+ set(powerpcspe_SOURCES ${GENERIC_SOURCES})
+ 
+-set(powerpc64_SOURCES
++set(powerpc_SOURCES
+   ppc/divtc3.c
+   ppc/fixtfdi.c
+   ppc/fixunstfdi.c
+@@ -687,14 +685,15 @@ set(powerpc64_SOURCES
+ )
+ # These routines require __int128, which isn't supported on AIX.
+ if (NOT ${CMAKE_SYSTEM_NAME} MATCHES "AIX")
+-  set(powerpc64_SOURCES
++  set(powerpc_SOURCES
+     ppc/floattitf.c
+     ppc/fixtfti.c
+     ppc/fixunstfti.c
+-    ${powerpc64_SOURCES}
++    ${powerpc_SOURCES}
+   )
+ endif()
+-set(powerpc64le_SOURCES ${powerpc64_SOURCES})
++set(powerpc64le_SOURCES ${powerpc_SOURCES})
++set(powerpc64_SOURCES ${powerpc_SOURCES})
+ 
+ set(riscv_SOURCES
+   riscv/fp_mode.c
+@@ -818,9 +817,9 @@ else ()
+         list(APPEND BUILTIN_CFLAGS_${arch} -fomit-frame-pointer -DCOMPILER_RT_ARMHF_TARGET)
+       endif()
+ 
+-      # For RISCV32, we must force enable int128 for compiling long
++      # For RISCV32/PPC32, we must force enable int128 for compiling long
+       # double routines.
+-      if("${arch}" STREQUAL "riscv32")
++      if("${arch}" STREQUAL "riscv32" OR "${arch}" STREQUAL "powerpc" )
+         list(APPEND BUILTIN_CFLAGS_${arch} -fforce-enable-int128)
+       endif()
+ 
+diff --git a/compiler-rt/lib/builtins/int_types.h b/compiler-rt/lib/builtins/int_types.h
+index e94d3154c6d4..37b2cb43f932 100644
+--- a/compiler-rt/lib/builtins/int_types.h
++++ b/compiler-rt/lib/builtins/int_types.h
+@@ -64,7 +64,7 @@ typedef union {
+ } udwords;
+ 
+ #if defined(__LP64__) || defined(__wasm__) || defined(__mips64) ||             \
+-    defined(__SIZEOF_INT128__) || defined(_WIN64)
++    defined(__SIZEOF_INT128__) || defined(_WIN64) || defined(__powerpc__)
+ #define CRT_HAS_128BIT
+ #endif
+ 

--- a/recipes-devtools/clang16/clang/0032-llvm-Do-not-use-cmake-infra-to-detect-libzstd.patch
+++ b/recipes-devtools/clang16/clang/0032-llvm-Do-not-use-cmake-infra-to-detect-libzstd.patch
@@ -1,0 +1,62 @@
+From 6f1ddaf3cfca94d3c3d00d0e7e9486eaf98f8b44 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Fri, 12 Aug 2022 11:50:57 -0700
+Subject: [PATCH] llvm: Do not use cmake infra to detect libzstd
+
+OE's version is build using plain make not cmake as a result we do not
+have the cmake support files and this probing method can get this info
+from build host and force linking with libzstd from /usr/lib which is
+not what we want when cross building.
+
+Fixes errors building llvm-config like
+/usr/lib/libzstd.so.1.5.2: error adding symbols: file in wrong
+format
+| clang-15: error: linker command failed with exit code 1 (use -v to see invocation)
+| ninja: build stopped: subcommand failed.
+
+Upstream-Status: Inappropriate [OE-Specific]
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ llvm/lib/Support/CMakeLists.txt | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/llvm/lib/Support/CMakeLists.txt b/llvm/lib/Support/CMakeLists.txt
+index 4cbc3b79f3bb..08c4bfd5efc1 100644
+--- a/llvm/lib/Support/CMakeLists.txt
++++ b/llvm/lib/Support/CMakeLists.txt
+@@ -22,7 +22,7 @@ if (HAS_WERROR_GLOBAL_CTORS)
+ endif()
+ 
+ if(LLVM_ENABLE_ZLIB)
+-  list(APPEND imported_libs ZLIB::ZLIB)
++  list(APPEND imported_libs z)
+ endif()
+ 
+ if(LLVM_ENABLE_ZSTD)
+@@ -34,7 +34,7 @@ if(LLVM_ENABLE_ZSTD)
+ endif()
+ 
+ if(LLVM_ENABLE_ZSTD)
+-  list(APPEND imported_libs ${zstd_target})
++  list(APPEND imported_libs zstd)
+ endif()
+ 
+ if( MSVC OR MINGW )
+@@ -292,7 +292,7 @@ if(LLVM_ENABLE_ZLIB)
+     get_property(zlib_library TARGET ZLIB::ZLIB PROPERTY LOCATION)
+   endif()
+   get_library_name(${zlib_library} zlib_library)
+-  set(llvm_system_libs ${llvm_system_libs} "${zlib_library}")
++  set(llvm_system_libs ${llvm_system_libs} z)
+ endif()
+ 
+ if(LLVM_ENABLE_ZSTD)
+@@ -305,7 +305,7 @@ if(LLVM_ENABLE_ZSTD)
+     get_property(zstd_library TARGET ${zstd_target} PROPERTY LOCATION)
+   endif()
+   get_library_name(${zstd_library} zstd_library)
+-  set(llvm_system_libs ${llvm_system_libs} "${zstd_library}")
++  set(llvm_system_libs ${llvm_system_libs} zstd)
+ endif()
+ 
+ if(LLVM_ENABLE_TERMINFO)

--- a/recipes-devtools/clang16/clang/0033-build-Enable-64bit-off_t-on-32bit-glibc-systems.patch
+++ b/recipes-devtools/clang16/clang/0033-build-Enable-64bit-off_t-on-32bit-glibc-systems.patch
@@ -1,0 +1,53 @@
+From 81298058cd344f695fe22da4a367db08709a85e1 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Sun, 25 Dec 2022 15:13:41 -0800
+Subject: [PATCH] build: Enable 64bit off_t on 32bit glibc systems
+
+Pass -D_FILE_OFFSET_BITS=64 to compiler flags on 32bit glibc based
+systems. This will make sure that 64bit versions of LFS functions are
+used e.g. lseek will behave same as lseek64. Also revert [1] partially
+because this added a cmake test to detect lseek64 but then forgot to
+pass the needed macro during actual compile, this test was incomplete too
+since libc implementations like musl has 64-bit off_t by default on 32-bit
+systems and does not bundle -D_LARGEFILE64_SOURCE [2] under -D_GNU_SOURCE
+like glibc, which means the compile now fails on musl because the cmake
+check passes but we do not have _LARGEFILE64_SOURCE defined. Moreover,
+Using the *64 function was transitional anyways so use
+-D_FILE_OFFSET_BITS=64 instead
+
+[1] https://github.com/llvm/llvm-project/commit/8db7e5e4eed4c4e697dc3164f2c9351d8c3e942b
+[2] https://git.musl-libc.org/cgit/musl/commit/?id=25e6fee27f4a293728dd15b659170e7b9c7db9bc
+
+Upstream-Status: Pending
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ utils/bazel/llvm-project-overlay/llvm/config.bzl               | 1 -
+ .../llvm-project-overlay/llvm/include/llvm/Config/config.h     | 3 ---
+ 2 files changed, 4 deletions(-)
+
+diff --git a/utils/bazel/llvm-project-overlay/llvm/config.bzl b/utils/bazel/llvm-project-overlay/llvm/config.bzl
+index 5507f80efa0b..b15ec9e1bb39 100644
+--- a/utils/bazel/llvm-project-overlay/llvm/config.bzl
++++ b/utils/bazel/llvm-project-overlay/llvm/config.bzl
+@@ -48,7 +48,6 @@ posix_defines = [
+ linux_defines = posix_defines + [
+     "_GNU_SOURCE",
+     "HAVE_LINK_H=1",
+-    "HAVE_LSEEK64=1",
+     "HAVE_MALLINFO=1",
+     "HAVE_SBRK=1",
+     "HAVE_STRUCT_STAT_ST_MTIM_TV_NSEC=1",
+diff --git a/utils/bazel/llvm-project-overlay/llvm/include/llvm/Config/config.h b/utils/bazel/llvm-project-overlay/llvm/include/llvm/Config/config.h
+index 8a30957b6120..6a68ac040bb8 100644
+--- a/utils/bazel/llvm-project-overlay/llvm/include/llvm/Config/config.h
++++ b/utils/bazel/llvm-project-overlay/llvm/include/llvm/Config/config.h
+@@ -144,9 +144,6 @@
+ /* Define to 1 if you have the <link.h> header file. */
+ /* HAVE_LINK_H defined in Bazel */
+ 
+-/* Define to 1 if you have the `lseek64' function. */
+-/* HAVE_LSEEK64 defined in Bazel */
+-
+ /* Define to 1 if you have the <mach/mach.h> header file. */
+ /* HAVE_MACH_MACH_H defined in Bazel */
+ 

--- a/recipes-devtools/clang16/clang/0034-compiler-rt-Undef-_TIME_BITS-along-with-_FILE_OFFSET.patch
+++ b/recipes-devtools/clang16/clang/0034-compiler-rt-Undef-_TIME_BITS-along-with-_FILE_OFFSET.patch
@@ -1,0 +1,36 @@
+From 6c4db3884b0271d80725fc8912083c48e9f3112c Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Sat, 31 Dec 2022 15:03:24 -0800
+Subject: [PATCH] compiler-rt: Undef _TIME_BITS along with _FILE_OFFSET_BITS on
+ linux
+
+On 32bit systems using 64bit time_t build fails because
+_FILE_OFFSET_BITS is undefined here but _TIME_BITS is still set to 64
+
+Fixes
+/usr/include/features-time64.h:26:5: error: "_TIME_BITS=64 is allowed
+ only with _FILE_OFFSET_BITS=64"
+| #   error "_TIME_BITS=64 is allowed only with _FILE_OFFSET_BITS=64"
+|     ^
+| 1 error generated.
+
+Also avoid LFS64 functions on musl
+
+Upstream-Status: Pending
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ .../lib/sanitizer_common/sanitizer_platform_limits_posix.cpp     | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.cpp b/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.cpp
+index fc01498aa228..eb2ee78c2f45 100644
+--- a/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.cpp
++++ b/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.cpp
+@@ -18,6 +18,7 @@
+ // depends on _FILE_OFFSET_BITS setting.
+ // To get this "true" dirent definition, we undefine _FILE_OFFSET_BITS below.
+ #undef _FILE_OFFSET_BITS
++#undef _TIME_BITS
+ #endif
+ 
+ // Must go after undef _FILE_OFFSET_BITS.

--- a/recipes-devtools/clang16/clang/0035-compiler-rt-Fix-stat-struct-s-size-for-O32-ABI.patch
+++ b/recipes-devtools/clang16/clang/0035-compiler-rt-Fix-stat-struct-s-size-for-O32-ABI.patch
@@ -1,0 +1,44 @@
+From eb6c2fe33206567b6a658d74bfd2a906f61893ed Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Tue, 3 Jan 2023 18:44:34 -0800
+Subject: [PATCH] compiler-rt: Fix stat struct's size for O32 ABI
+
+stat struct size differs on glibc based on ABI choices e.g. 64bit off_t
+and/or 64bit time_t will make this size different. Therefore separate
+out the O32 case out, makes it more readable.
+
+Upstream-Status: Pending
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ .../sanitizer_platform_limits_posix.h               | 13 +++++++++++++
+ 1 file changed, 13 insertions(+)
+
+diff --git a/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.h b/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.h
+index fdc69b8a5fba..d2246893f8a5 100644
+--- a/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.h
++++ b/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.h
+@@ -97,11 +97,24 @@ const unsigned struct_kernel_stat64_sz = 104;
+ const unsigned struct_kernel_stat_sz = 144;
+ const unsigned struct_kernel_stat64_sz = 104;
+ #elif defined(__mips__)
++#if defined(__mips_o32) // O32 ABI
++#if _TIME_BITS == 64
++const unsigned struct_kernel_stat_sz = 112;
++const unsigned struct_kernel_stat64_sz = 112;
++#elif _FILE_OFFSET_BITS == 64
++const unsigned struct_kernel_stat_sz = 160;
++const unsigned struct_kernel_stat64_sz = 160;
++#else
++const unsigned struct_kernel_stat_sz = 144;
++const unsigned struct_kernel_stat64_sz = 160;
++#endif
++#else // __mips_o32
+ const unsigned struct_kernel_stat_sz =
+     SANITIZER_ANDROID
+         ? FIRST_32_SECOND_64(104, 128)
+         : FIRST_32_SECOND_64((_MIPS_SIM == _ABIN32) ? 176 : 160, 216);
+ const unsigned struct_kernel_stat64_sz = 104;
++#endif
+ #elif defined(__s390__) && !defined(__s390x__)
+ const unsigned struct_kernel_stat_sz = 64;
+ const unsigned struct_kernel_stat64_sz = 104;

--- a/recipes-devtools/clang16/clang/0036-compiler-rt-Undef-_TIME_BITS-along-with-_FILE_OFFSET.patch
+++ b/recipes-devtools/clang16/clang/0036-compiler-rt-Undef-_TIME_BITS-along-with-_FILE_OFFSET.patch
@@ -1,0 +1,43 @@
+From 46643a33c0889bc6cb4034337b02962c673e0ac4 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Tue, 21 Feb 2023 12:46:10 -0800
+Subject: [PATCH] compiler-rt: Undef _TIME_BITS along with _FILE_OFFSET_BITS in
+ sanitizers
+
+On 32bit systems using 64bit time_t build fails because
+_FILE_OFFSET_BITS is undefined here but _TIME_BITS is still set to 64
+
+Fixes
+In file included from compiler-rt/lib/sanitizer_common/sanitizer_procmaps_solaris.cpp:17:
+In file included from compiler-rt/lib/sanitizer_common/sanitizer_platform.h:25:
+In file included from /usr/include/features.h:393:
+/usr/include/features-time64.h:26:5: error: "_TIME_BITS=64 is allowed only with _FILE_OFFSET_BITS=64"
+    ^
+1 error generated.
+
+Upstream-Status: Submitted [https://reviews.llvm.org/D144514]
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ compiler-rt/lib/sanitizer_common/sanitizer_platform.h | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/compiler-rt/lib/sanitizer_common/sanitizer_platform.h b/compiler-rt/lib/sanitizer_common/sanitizer_platform.h
+index 764996e57355..df3d165ecdb6 100644
+--- a/compiler-rt/lib/sanitizer_common/sanitizer_platform.h
++++ b/compiler-rt/lib/sanitizer_common/sanitizer_platform.h
+@@ -22,6 +22,15 @@
+ // function declarations into a .S file which doesn't compile.
+ // https://crbug.com/1162741
+ #if __has_include(<features.h>) && !defined(__ANDROID__)
++// Some sources undefine _FILE_OFFSET_BITS deliberately e.g.
++// sanitizer_procmaps_solaris.cpp. This is problematic on glibc systems with
++// 32-bit architectures using 64-bit time_t and users passing _TIME_BITS=64
++// from build environment, therefore both _FILE_OFFSET_BITS and _TIME_BITS
++// need to be undefined together since features.h will check for both being 64
++// if one is set to 64
++#  if !defined(_FILE_OFFSET_BITS)
++#    undef _TIME_BITS
++#  endif
+ #  include <features.h>
+ #endif
+ 

--- a/recipes-devtools/clang16/clang/0037-Call-printName-to-get-name-of-Decl.patch
+++ b/recipes-devtools/clang16/clang/0037-Call-printName-to-get-name-of-Decl.patch
@@ -1,0 +1,71 @@
+From ab8b6331592fb92a2dc1c689483a4772d51aed8b Mon Sep 17 00:00:00 2001
+From: Dan McGregor <dan.mcgregor@usask.ca>
+Date: Tue, 21 Mar 2023 13:04:51 -0600
+Subject: [PATCH] Call printName to get name of Decl
+
+Rather than sending a name directly to the stream, use printName
+to preserve any PrintingPolicy. This ensures that names are properly
+affected by path remapping.
+
+Differential Revision: https://reviews.llvm.org/D149272
+
+Upstream-Status: Pending
+Signed-off-by: Dan McGregor <dan.mcgregor@usask.ca>
+---
+ clang/lib/AST/Decl.cpp                  |  4 ++--
+ clang/lib/AST/DeclarationName.cpp       |  4 ++--
+ clang/test/CodeGen/debug-prefix-map.cpp | 11 +++++++++++
+ 3 files changed, 15 insertions(+), 4 deletions(-)
+ create mode 100644 clang/test/CodeGen/debug-prefix-map.cpp
+
+diff --git a/clang/lib/AST/Decl.cpp b/clang/lib/AST/Decl.cpp
+index e60cc28f6e0f..24de6156c0f5 100644
+--- a/clang/lib/AST/Decl.cpp
++++ b/clang/lib/AST/Decl.cpp
+@@ -1626,8 +1626,8 @@ Module *Decl::getOwningModuleForLinkage(bool IgnoreLinkage) const {
+   llvm_unreachable("unknown module kind");
+ }
+ 
+-void NamedDecl::printName(raw_ostream &OS, const PrintingPolicy&) const {
+-  OS << Name;
++void NamedDecl::printName(raw_ostream &OS, const PrintingPolicy &Policy) const {
++  Name.print(OS, Policy);
+ }
+ 
+ void NamedDecl::printName(raw_ostream &OS) const {
+diff --git a/clang/lib/AST/DeclarationName.cpp b/clang/lib/AST/DeclarationName.cpp
+index c1219041a466..da8b3886c340 100644
+--- a/clang/lib/AST/DeclarationName.cpp
++++ b/clang/lib/AST/DeclarationName.cpp
+@@ -117,12 +117,12 @@ static void printCXXConstructorDestructorName(QualType ClassType,
+   Policy.adjustForCPlusPlus();
+ 
+   if (const RecordType *ClassRec = ClassType->getAs<RecordType>()) {
+-    OS << *ClassRec->getDecl();
++    ClassRec->getDecl()->printName(OS, Policy);
+     return;
+   }
+   if (Policy.SuppressTemplateArgsInCXXConstructors) {
+     if (auto *InjTy = ClassType->getAs<InjectedClassNameType>()) {
+-      OS << *InjTy->getDecl();
++      InjTy->getDecl()->printName(OS, Policy);
+       return;
+     }
+   }
+diff --git a/clang/test/CodeGen/debug-prefix-map.cpp b/clang/test/CodeGen/debug-prefix-map.cpp
+new file mode 100644
+index 000000000000..5e90aedd8ed7
+--- /dev/null
++++ b/clang/test/CodeGen/debug-prefix-map.cpp
+@@ -0,0 +1,11 @@
++// RUN: %clang_cc1 -debug-info-kind=standalone -fdebug-prefix-map=%p=./UNLIKELY_PATH/empty -S %s -emit-llvm -o - | FileCheck %s
++
++struct alignas(64) an {
++  struct {
++    unsigned char x{0};
++  } arr[64];
++};
++
++struct an *pan = new an;
++
++// CHECK: !DISubprogram(name: "(unnamed struct at ./UNLIKELY_PATH/empty{{/|\\\\}}{{.*}}",

--- a/recipes-devtools/clang16/clang/0038-Apply-fmacro-prefix-map-to-anonymous-tags-in-templat.patch
+++ b/recipes-devtools/clang16/clang/0038-Apply-fmacro-prefix-map-to-anonymous-tags-in-templat.patch
@@ -1,0 +1,84 @@
+From 648ef1a807d27d51b7cddbf2df7499984c857ba4 Mon Sep 17 00:00:00 2001
+From: Dan McGregor <dan.mcgregor@usask.ca>
+Date: Fri, 16 Jun 2023 08:47:00 -0700
+Subject: [PATCH] Apply -fmacro-prefix-map to anonymous tags in template
+ arguments
+
+When expanding template arguments for pretty function printing,
+such as for __PRETTY_FUNCTION__, make TypePrinter apply
+macro-prefix-map remapping to anonymous tags such as lambdas.
+
+Fixes https://github.com/llvm/llvm-project/issues/63219
+
+Reviewed By: MaskRay, aaron.ballman
+
+Differential Revision: https://reviews.llvm.org/D152570
+
+Upstream-Status: Backport [https://reviews.llvm.org/D152570]
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ clang/docs/ReleaseNotes.rst                       |  2 ++
+ clang/lib/AST/Expr.cpp                            | 14 ++++++++++++++
+ clang/test/CodeGenCXX/macro-prefix-map-lambda.cpp | 14 ++++++++++++++
+ 3 files changed, 30 insertions(+)
+ create mode 100644 clang/test/CodeGenCXX/macro-prefix-map-lambda.cpp
+
+diff --git a/clang/docs/ReleaseNotes.rst b/clang/docs/ReleaseNotes.rst
+index 8d67ff904469..bf3ea4a54d01 100644
+--- a/clang/docs/ReleaseNotes.rst
++++ b/clang/docs/ReleaseNotes.rst
+@@ -724,6 +724,8 @@ Bug Fixes in This Version
+ - Fix crash when passing a braced initializer list to a parentehsized aggregate
+   initialization expression.
+   (`#63008 <https://github.com/llvm/llvm-project/issues/63008>`_).
++- Apply ``-fmacro-prefix-map`` to anonymous tags in template arguments
++  (`#63219 <https://github.com/llvm/llvm-project/issues/63219>`_).
+ 
+ Bug Fixes to Compiler Builtins
+ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+diff --git a/clang/lib/AST/Expr.cpp b/clang/lib/AST/Expr.cpp
+index e45ae68cd5fe..a65678f5998c 100644
+--- a/clang/lib/AST/Expr.cpp
++++ b/clang/lib/AST/Expr.cpp
+@@ -783,7 +783,21 @@ std::string PredefinedExpr::ComputeName(IdentKind IK, const Decl *CurrentDecl) {
+         Out << "static ";
+     }
+ 
++    class PrettyCallbacks final : public PrintingCallbacks {
++    public:
++      PrettyCallbacks(const LangOptions &LO) : LO(LO) {}
++      std::string remapPath(StringRef Path) const override {
++        SmallString<128> p(Path);
++        LO.remapPathPrefix(p);
++        return std::string(p);
++      }
++
++    private:
++      const LangOptions &LO;
++    };
+     PrintingPolicy Policy(Context.getLangOpts());
++    PrettyCallbacks PrettyCB(Context.getLangOpts());
++    Policy.Callbacks = &PrettyCB;
+     std::string Proto;
+     llvm::raw_string_ostream POut(Proto);
+ 
+diff --git a/clang/test/CodeGenCXX/macro-prefix-map-lambda.cpp b/clang/test/CodeGenCXX/macro-prefix-map-lambda.cpp
+new file mode 100644
+index 000000000000..e87f0ab484dc
+--- /dev/null
++++ b/clang/test/CodeGenCXX/macro-prefix-map-lambda.cpp
+@@ -0,0 +1,14 @@
++// RUN: %clang_cc1 -triple %itanium_abi_triple -fmacro-prefix-map=%p=./UNLIKELY_PATH/empty %s -emit-llvm -o - | FileCheck %s
++
++template<typename f>
++auto lambdatest(f&& cb) {
++  const char *s = __PRETTY_FUNCTION__;
++  return s;
++}
++
++int main() {
++  auto *s = lambdatest([](){});
++// CHECK: @"__PRETTY_FUNCTION__._Z10lambdatestIZ4mainE3$_0EDaOT_" = private unnamed_addr constant [{{[0-9]+}} x i8] c"auto lambdatest(f &&) [f = (lambda at ./UNLIKELY_PATH/empty{{/|\\\\}}{{.*}}.cpp:[[#@LINE-1]]:24)]\00", align 1
++
++  return 0;
++}

--- a/recipes-devtools/clang16/clang/0039-lld-RISCV-Handle-relaxation-reductions-of-more-than-.patch
+++ b/recipes-devtools/clang16/clang/0039-lld-RISCV-Handle-relaxation-reductions-of-more-than-.patch
@@ -1,0 +1,78 @@
+From 1405446343007159cdbef39b37427b3cc2e94266 Mon Sep 17 00:00:00 2001
+From: Roland McGrath <mcgrathr@google.com>
+Date: Tue, 16 May 2023 13:35:35 -0700
+Subject: [PATCH] [lld][RISCV] Handle relaxation reductions of more than 65536
+ bytes
+
+In a real-world case with functions that have many, many
+R_RISCV_CALL_PLT relocations due to asan and ubsan
+instrumentation, all these can be relaxed by an instruction and
+the net result is more than 65536 bytes of reduction in the
+output .text section that totals about 1.2MiB in final size.
+
+This changes InputSection to use a 32-bit field for bytesDropped.
+The RISCV relaxation keeps track in a 64-bit field and detects
+32-bit overflow as it previously detected 16-bit overflow. It
+doesn't seem likely that 32-bit overflow will arise, but it's not
+inconceivable and it's cheap enough to detect it.
+
+This unfortunately increases the size of InputSection on 64-bit
+hosts by a word, but that seems hard to avoid.
+
+Reviewed By: MaskRay
+
+Differential Revision: https://reviews.llvm.org/D150722
+
+Upstream-Status: Backport [https://github.com/llvm/llvm-project/commit/9d37ea95df1b84cca9b5e954d8964c976a5e303e]
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ lld/ELF/Arch/RISCV.cpp | 6 +++---
+ lld/ELF/InputSection.h | 4 ++--
+ 2 files changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/lld/ELF/Arch/RISCV.cpp b/lld/ELF/Arch/RISCV.cpp
+index 87887b314a5a..80754e37d3ed 100644
+--- a/lld/ELF/Arch/RISCV.cpp
++++ b/lld/ELF/Arch/RISCV.cpp
+@@ -621,7 +621,7 @@ static bool relax(InputSection &sec) {
+   // iteration.
+   DenseMap<const Defined *, uint64_t> valueDelta;
+   ArrayRef<SymbolAnchor> sa = ArrayRef(aux.anchors);
+-  uint32_t delta = 0;
++  uint64_t delta = 0;
+   for (auto [i, r] : llvm::enumerate(sec.relocs())) {
+     for (; sa.size() && sa[0].offset <= r.offset; sa = sa.slice(1))
+       if (!sa[0].end)
+@@ -688,8 +688,8 @@ static bool relax(InputSection &sec) {
+       a.d->value -= delta - valueDelta.find(a.d)->second;
+   }
+   // Inform assignAddresses that the size has changed.
+-  if (!isUInt<16>(delta))
+-    fatal("section size decrease is too large");
++  if (!isUInt<32>(delta))
++    fatal("section size decrease is too large: " + Twine(delta));
+   sec.bytesDropped = delta;
+   return changed;
+ }
+diff --git a/lld/ELF/InputSection.h b/lld/ELF/InputSection.h
+index 356ccda2d743..143384b3ba7b 100644
+--- a/lld/ELF/InputSection.h
++++ b/lld/ELF/InputSection.h
+@@ -137,7 +137,7 @@ public:
+   // Used by --optimize-bb-jumps and RISC-V linker relaxation temporarily to
+   // indicate the number of bytes which is not counted in the size. This should
+   // be reset to zero after uses.
+-  uint16_t bytesDropped = 0;
++  uint32_t bytesDropped = 0;
+ 
+   mutable bool compressed = false;
+ 
+@@ -401,7 +401,7 @@ private:
+   template <class ELFT> void copyShtGroup(uint8_t *buf);
+ };
+ 
+-static_assert(sizeof(InputSection) <= 152, "InputSection is too big");
++static_assert(sizeof(InputSection) <= 160, "InputSection is too big");
+ 
+ class SyntheticSection : public InputSection {
+ public:

--- a/recipes-devtools/clang16/clang/0040-ToolChains-Gnu.cpp-ARMLibDirs-search-also-in-lib32.patch
+++ b/recipes-devtools/clang16/clang/0040-ToolChains-Gnu.cpp-ARMLibDirs-search-also-in-lib32.patch
@@ -1,0 +1,80 @@
+From 0f5f2e8e84d37e94aad0a6bf90bb3406e289b5e5 Mon Sep 17 00:00:00 2001
+From: Martin Jansa <Martin.Jansa@gmail.com>
+Date: Thu, 31 Aug 2023 18:14:47 +0200
+Subject: [PATCH] ToolChains/Gnu.cpp: ARMLibDirs search also in lib32
+
+* in some strange multilib configs we build lib32-image where
+  32bit libs are in /usr/lib32 and 64bit in /usr/lib64 but in such
+  setup the clang search for GCC candidate installation doesn't
+  check lib32 directory in sysroot and fails to find the installation
+
+  X86LibDirs was already searching in lib32 for very long time:
+  https://github.com/llvm/llvm-project/commit/621fed5f5a051a0333415aaed75b8f2ed2350dbd
+  but ARMLibDirs didn't include it for some reason.
+
+* if we don't add lib32 for arm in getOSLibDir(), then it will
+  find -lgcc, crtbeginS.o, crtendS.o, but still fail to find
+  -lgcc_s, -lc, Scrt1.o, crti.o, crtn.o
+
+* fixes lib32-compiler-rt build failure:
+
+-- Configuring incomplete, errors occurred!
+CMake Error at TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/recipe-sysroot-native/usr/share/cmake-3.26/Modules/CMakeTestCCompiler.cmake:67 (message):
+  The C compiler
+
+    "TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/recipe-sysroot-native/usr/bin/arm-oemllib32-linux-gnueabi/arm-oemllib32-linux-gnueabi-clang"
+
+  is not able to compile a simple test program.
+
+  It fails with the following output:
+
+    Change Dir: TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/build/CMakeFiles/CMakeScratch/TryCompile-rWXyQZ
+
+    Run Build Command(s):ninja -v cmTC_84d18 && [1/2] TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/recipe-sysroot-native/usr/bin/arm-oemllib32-linux-gnueabi/arm-oemllib32-linux-gnueabi-clang --target=arm-oemllib32-linux-gnueabi --sysroot=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/lib32-recipe-sysroot   -target arm-oemllib32-linux-gnueabi  -march=armv7ve -mthumb -mfpu=neon-vfpv4 -mfloat-abi=softfp -mlittle-endian --dyld-prefix=/usr -Qunused-arguments -funwind-tables -fstack-protector-strong  -O2 -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Werror=format-security -Werror=return-type -D_TIME_BITS=64 -D_FILE_OFFSET_BITS=64  --sysroot=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/lib32-recipe-sysroot  -O2 -pipe -g -feliminate-unused-debug-types   -fmacro-prefix-map=TOPDIR/BUILD/work-shared/llvm-project-source-16.0.6-r0/git=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fdebug-prefix-map=TOPDIR/BUILD/work-shared/llvm-project-source-16.0.6-r0/git=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fmacro-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/build=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fdebug-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/build=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fdebug-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/lib32-recipe-sysroot=  -fmacro-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/lib32-recipe-sysroot=  -fdebug-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/recipe-sysroot-native=    -fPIE -MD -MT CMakeFiles/cmTC_84d18.dir/testCCompiler.c.o -MF CMakeFiles/cmTC_84d18.dir/testCCompiler.c.o.d -o CMakeFiles/cmTC_84d18.dir/testCCompiler.c.o -c TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/build/CMakeFiles/CMakeScratch/TryCompile-rWXyQZ/testCCompiler.c
+    [2/2] : && TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/recipe-sysroot-native/usr/bin/arm-oemllib32-linux-gnueabi/arm-oemllib32-linux-gnueabi-clang --target=arm-oemllib32-linux-gnueabi --sysroot=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/lib32-recipe-sysroot -target arm-oemllib32-linux-gnueabi  -march=armv7ve -mthumb -mfpu=neon-vfpv4 -mfloat-abi=softfp -mlittle-endian --dyld-prefix=/usr -Qunused-arguments -funwind-tables -fstack-protector-strong  -O2 -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Werror=format-security -Werror=return-type -D_TIME_BITS=64 -D_FILE_OFFSET_BITS=64  --sysroot=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/lib32-recipe-sysroot  -O2 -pipe -g -feliminate-unused-debug-types   -fmacro-prefix-map=TOPDIR/BUILD/work-shared/llvm-project-source-16.0.6-r0/git=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fdebug-prefix-map=TOPDIR/BUILD/work-shared/llvm-project-source-16.0.6-r0/git=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fmacro-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/build=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fdebug-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/build=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fdebug-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/lib32-recipe-sysroot=  -fmacro-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/lib32-recipe-sysroot=  -fdebug-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/recipe-sysroot-native= -target arm-oemllib32-linux-gnueabi  -march=armv7ve -mthumb -mfpu=neon-vfpv4 -mfloat-abi=softfp -mlittle-endian --dyld-prefix=/usr -Qunused-arguments -funwind-tables -fstack-protector-strong  -O2 -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Werror=format-security -Werror=return-type -D_TIME_BITS=64 -D_FILE_OFFSET_BITS=64  --sysroot=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/lib32-recipe-sysroot  -Wl,-O1 -Wl,--hash-style=gnu -Wl,--as-needed   -fmacro-prefix-map=TOPDIR/BUILD/work-shared/llvm-project-source-16.0.6-r0/git=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fdebug-prefix-map=TOPDIR/BUILD/work-shared/llvm-project-source-16.0.6-r0/git=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fmacro-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/build=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fdebug-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/build=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fdebug-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/lib32-recipe-sysroot=  -fmacro-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/lib32-recipe-sysroot=  -fdebug-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/recipe-sysroot-native=  -Wl,-z,relro,-z,now -unwindlib=libgcc -rtlib=libgcc -stdlib=libstdc++   -fuse-ld=lld -Wl,-O1 -Wl,--hash-style=gnu -Wl,--as-needed   -fmacro-prefix-map=TOPDIR/BUILD/work-shared/llvm-project-source-16.0.6-r0/git=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fdebug-prefix-map=TOPDIR/BUILD/work-shared/llvm-project-source-16.0.6-r0/git=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fmacro-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/build=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fdebug-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/build=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fdebug-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/lib32-recipe-sysroot=  -fmacro-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/lib32-recipe-sysroot=  -fdebug-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/recipe-sysroot-native=  -Wl,-z,relro,-z,now -unwindlib=libgcc -rtlib=libgcc -stdlib=libstdc++   -fuse-ld=lld CMakeFiles/cmTC_84d18.dir/testCCompiler.c.o -o cmTC_84d18   && :
+    FAILED: cmTC_84d18
+    : && TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/recipe-sysroot-native/usr/bin/arm-oemllib32-linux-gnueabi/arm-oemllib32-linux-gnueabi-clang --target=arm-oemllib32-linux-gnueabi --sysroot=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/lib32-recipe-sysroot -target arm-oemllib32-linux-gnueabi  -march=armv7ve -mthumb -mfpu=neon-vfpv4 -mfloat-abi=softfp -mlittle-endian --dyld-prefix=/usr -Qunused-arguments -funwind-tables -fstack-protector-strong  -O2 -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Werror=format-security -Werror=return-type -D_TIME_BITS=64 -D_FILE_OFFSET_BITS=64  --sysroot=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/lib32-recipe-sysroot  -O2 -pipe -g -feliminate-unused-debug-types   -fmacro-prefix-map=TOPDIR/BUILD/work-shared/llvm-project-source-16.0.6-r0/git=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fdebug-prefix-map=TOPDIR/BUILD/work-shared/llvm-project-source-16.0.6-r0/git=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fmacro-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/build=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fdebug-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/build=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fdebug-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/lib32-recipe-sysroot=  -fmacro-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/lib32-recipe-sysroot=  -fdebug-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/recipe-sysroot-native= -target arm-oemllib32-linux-gnueabi  -march=armv7ve -mthumb -mfpu=neon-vfpv4 -mfloat-abi=softfp -mlittle-endian --dyld-prefix=/usr -Qunused-arguments -funwind-tables -fstack-protector-strong  -O2 -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Werror=format-security -Werror=return-type -D_TIME_BITS=64 -D_FILE_OFFSET_BITS=64  --sysroot=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/lib32-recipe-sysroot  -Wl,-O1 -Wl,--hash-style=gnu -Wl,--as-needed   -fmacro-prefix-map=TOPDIR/BUILD/work-shared/llvm-project-source-16.0.6-r0/git=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fdebug-prefix-map=TOPDIR/BUILD/work-shared/llvm-project-source-16.0.6-r0/git=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fmacro-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/build=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fdebug-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/build=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fdebug-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/lib32-recipe-sysroot=  -fmacro-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/lib32-recipe-sysroot=  -fdebug-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/recipe-sysroot-native=  -Wl,-z,relro,-z,now -unwindlib=libgcc -rtlib=libgcc -stdlib=libstdc++   -fuse-ld=lld -Wl,-O1 -Wl,--hash-style=gnu -Wl,--as-needed   -fmacro-prefix-map=TOPDIR/BUILD/work-shared/llvm-project-source-16.0.6-r0/git=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fdebug-prefix-map=TOPDIR/BUILD/work-shared/llvm-project-source-16.0.6-r0/git=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fmacro-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/build=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fdebug-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/build=/usr/src/debug/lib32-compiler-rt/16.0.6-r0  -fdebug-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/lib32-recipe-sysroot=  -fmacro-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/lib32-recipe-sysroot=  -fdebug-prefix-map=TOPDIR/BUILD/work/raspberrypi4_64-oemllib32-linux-gnueabi/lib32-compiler-rt/16.0.6/recipe-sysroot-native=  -Wl,-z,relro,-z,now -unwindlib=libgcc -rtlib=libgcc -stdlib=libstdc++   -fuse-ld=lld CMakeFiles/cmTC_84d18.dir/testCCompiler.c.o -o cmTC_84d18   && :
+    arm-oemllib32-linux-gnueabi-ld.lld: error: cannot open Scrt1.o: No such file or directory
+    arm-oemllib32-linux-gnueabi-ld.lld: error: cannot open crti.o: No such file or directory
+    arm-oemllib32-linux-gnueabi-ld.lld: error: cannot open crtbeginS.o: No such file or directory
+    arm-oemllib32-linux-gnueabi-ld.lld: error: unable to find library -lgcc
+    arm-oemllib32-linux-gnueabi-ld.lld: error: unable to find library -lgcc_s
+    arm-oemllib32-linux-gnueabi-ld.lld: error: unable to find library -lc
+    arm-oemllib32-linux-gnueabi-ld.lld: error: unable to find library -lgcc
+    arm-oemllib32-linux-gnueabi-ld.lld: error: unable to find library -lgcc_s
+    arm-oemllib32-linux-gnueabi-ld.lld: error: cannot open crtendS.o: No such file or directory
+    arm-oemllib32-linux-gnueabi-ld.lld: error: cannot open crtn.o: No such file or directory
+    clang-16: error: linker command failed with exit code 1 (use -v to see invocation)
+    ninja: build stopped: subcommand failed.
+
+Upstream-Status: Pending
+Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>
+---
+ clang/lib/Driver/ToolChains/Gnu.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/clang/lib/Driver/ToolChains/Gnu.cpp b/clang/lib/Driver/ToolChains/Gnu.cpp
+index 0ec2dadafc05..a67e87365a7a 100644
+--- a/clang/lib/Driver/ToolChains/Gnu.cpp
++++ b/clang/lib/Driver/ToolChains/Gnu.cpp
+@@ -2241,7 +2241,7 @@ void Generic_GCC::GCCInstallationDetector::AddDefaultGCCPrefixes(
+   static const char *const AArch64beTriples[] = {"aarch64_be-none-linux-gnu",
+                                                  "aarch64_be-linux-gnu"};
+ 
+-  static const char *const ARMLibDirs[] = {"/lib"};
++  static const char *const ARMLibDirs[] = {"/lib", "/lib32"};
+   static const char *const ARMTriples[] = {"arm-linux-gnueabi"};
+   static const char *const ARMHFTriples[] = {"arm-linux-gnueabihf",
+                                              "armv7hl-redhat-linux-gnueabi",
+diff --git a/clang/lib/Driver/ToolChains/Linux.cpp b/clang/lib/Driver/ToolChains/Linux.cpp
+index c6fb290ffdb4..82acaf8a4bfd 100644
+--- a/clang/lib/Driver/ToolChains/Linux.cpp
++++ b/clang/lib/Driver/ToolChains/Linux.cpp
+@@ -166,6 +166,7 @@ static StringRef getOSLibDir(const llvm::Triple &Triple, const ArgList &Args) {
+   // reasoning about oslibdir spellings with the lib dir spellings in the
+   // GCCInstallationDetector, but that is a more significant refactoring.
+   if (Triple.getArch() == llvm::Triple::x86 || Triple.isPPC32() ||
++      Triple.getArch() == llvm::Triple::arm || Triple.getArch() == llvm::Triple::thumb ||
+       Triple.getArch() == llvm::Triple::sparc)
+     return "lib32";
+ 

--- a/recipes-devtools/clang16/clang/libunwind.pc.in
+++ b/recipes-devtools/clang16/clang/libunwind.pc.in
@@ -1,0 +1,9 @@
+prefix=/usr
+exec_prefix=/usr
+libdir=@LIBDIR@
+includedir=/usr/include
+
+Name: libunwind
+Description: libunwind base library
+Version: @VERSION@
+Libs: -lunwind

--- a/recipes-devtools/clang16/clang/llvm-config
+++ b/recipes-devtools/clang16/clang/llvm-config
@@ -1,0 +1,52 @@
+#!/bin/bash
+#
+# Wrapper script for llvm-config. Supplies the right environment variables
+# for the target and delegates to the native llvm-config for anything else. This
+# is needed because arguments like --ldflags, --cxxflags, etc. are set by the
+# native compile rather than the target compile.
+#
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+NEXT_LLVM_CONFIG="$(which -a llvm-config | sed -n 2p)"
+export YOCTO_ALTERNATE_EXE_PATH="${YOCTO_ALTERNATE_EXE_PATH:="$(readlink -f "$SCRIPT_DIR/../llvm-config")"}"
+if [ -n "$( echo $base_libdir | sed -n '/lib64/p')" ]; then
+    export YOCTO_ALTERNATE_LIBDIR="${YOCTO_ALTERNATE_LIBDIR:="/lib64"}"
+else
+    export YOCTO_ALTERNATE_LIBDIR="${YOCTO_ALTERNATE_LIBDIR:="/lib"}"
+fi
+if [[ $# == 0 ]]; then
+  exec "$NEXT_LLVM_CONFIG"
+fi
+
+if [[ $1 == "--libs" ]]; then
+  exec "$NEXT_LLVM_CONFIG" $@
+fi
+
+if [[ $1 == "--bindir" ]]; then
+  unset YOCTO_ALTERNATE_EXE_PATH
+  exec "$NEXT_LLVM_CONFIG" $@
+fi
+
+if [[ $1 == "--libfiles" ]]; then
+  exec "$NEXT_LLVM_CONFIG" $@
+fi
+
+
+for arg in "$@"; do
+  case "$arg" in
+    --cppflags)
+      echo $CPPFLAGS
+      ;;
+    --cflags)
+      echo $CFLAGS
+      ;;
+    --cxxflags)
+      echo $CXXFLAGS
+      ;;
+    --ldflags)
+      echo $LDFLAGS
+      ;;
+    *)
+      echo "$("$NEXT_LLVM_CONFIG" "$arg")"
+      ;;
+  esac
+done

--- a/recipes-devtools/clang16/clang16-cross-canadian_git.bb
+++ b/recipes-devtools/clang16/clang16-cross-canadian_git.bb
@@ -1,0 +1,36 @@
+# Copyright (C) 2014 Khem Raj <raj.khem@gmail.com>
+# Released under the MIT license (see COPYING.MIT for the terms)
+
+DESCRIPTION = "Clang/LLVM based C/C++ compiler (cross-canadian for ${TARGET_ARCH} target)"
+HOMEPAGE = "http://clang.llvm.org/"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0-with-LLVM-exception;md5=0bcd48c3bdfef0c9d9fd17726e4b7dab"
+SECTION = "devel"
+
+PN = "clang16-cross-canadian-${TRANSLATED_TARGET_ARCH}"
+
+require clang.inc
+require common-source.inc
+inherit cross-canadian
+
+DEPENDS += "nativesdk-clang16 binutils-cross-canadian-${TRANSLATED_TARGET_ARCH} virtual/${HOST_PREFIX}binutils virtual/nativesdk-libc"
+# We have to point gcc at a sysroot but we don't need to rebuild if this changes
+# e.g. we switch between different machines with different tunes.
+EXTRA_OECONF_PATHS[vardepsexclude] = "TUNE_PKGARCH"
+TARGET_ARCH[vardepsexclude] = "TUNE_ARCH"
+
+do_install() {
+        install -d ${D}${bindir}
+	for tool in clang clang++ clang-tidy lld ld.lld llvm-profdata \
+            llvm-nm llvm-ar llvm-as llvm-ranlib llvm-strip llvm-objcopy llvm-objdump llvm-readelf \
+            llvm-addr2line llvm-dwp llvm-size llvm-strings llvm-cov
+	do
+		ln -sf ../$tool ${D}${bindir}/${TARGET_PREFIX}$tool
+	done
+}
+SSTATE_SCAN_FILES += "*-clang *-clang++ *-llvm-profdata *-llvm-ar \
+                      *-llvm-ranlib *-llvm-nm *-lld *-ld.lld *-llvm-as *-llvm-strip \
+                      *-llvm-objcopy *-llvm-objdump *-llvm-readelf *-llvm-addr2line \
+                      *-llvm-dwp *-llvm-size *-llvm-strings *-llvm-cov"
+do_install:append() {
+        cross_canadian_bindirlinks
+}

--- a/recipes-devtools/clang16/clang16-cross_git.bb
+++ b/recipes-devtools/clang16/clang16-cross_git.bb
@@ -1,0 +1,35 @@
+# Copyright (C) 2014 Khem Raj <raj.khem@gmail.com>
+# Released under the MIT license (see COPYING.MIT for the terms)
+
+DESCRIPTION = "Cross compiler wrappers for LLVM based C/C++ compiler"
+HOMEPAGE = "http://clang.llvm.org/"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0-with-LLVM-exception;md5=0bcd48c3bdfef0c9d9fd17726e4b7dab"
+SECTION = "devel"
+
+PN = "clang16-cross-${TARGET_ARCH}"
+
+require clang.inc
+require common-source.inc
+inherit cross
+DEPENDS += "clang16-native virtual/${TARGET_PREFIX}binutils"
+
+do_install() {
+        install -d ${D}${bindir}
+	for tool in clang clang++ clang-tidy lld ld.lld llvm-profdata \
+            llvm-nm llvm-ar llvm-as llvm-ranlib llvm-strip llvm-objcopy llvm-objdump llvm-readelf \
+            llvm-addr2line llvm-dwp llvm-size llvm-strings llvm-cov
+	do
+		ln -sf ../$tool ${D}${bindir}/${TARGET_PREFIX}$tool
+	done
+}
+SSTATE_SCAN_FILES += "*-clang *-clang++ *-llvm-profdata *-lld *-ld.lld \
+                      *-llvm-nm *-llvm-ar *-llvm-as *-llvm-ranlib *-llvm-strip \
+                      *-llvm-objcopy *-llvm-objdump *-llvm-readelf *-llvm-addr2line \
+                      *-llvm-dwp *-llvm-size *-llvm-strings *-llvm-cov"
+
+SYSROOT_PREPROCESS_FUNCS += "clangcross_sysroot_preprocess"
+
+clangcross_sysroot_preprocess () {
+        sysroot_stage_dir ${D}${bindir} ${SYSROOT_DESTDIR}${bindir}
+}
+PACKAGES = ""

--- a/recipes-devtools/clang16/clang16-crosssdk_git.bb
+++ b/recipes-devtools/clang16/clang16-crosssdk_git.bb
@@ -1,0 +1,34 @@
+# Copyright (C) 2014 Khem Raj <raj.khem@gmail.com>
+# Released under the MIT license (see COPYING.MIT for the terms)
+
+DESCRIPTION = "SDK Cross compiler wrappers for LLVM based C/C++ compiler"
+HOMEPAGE = "http://clang.llvm.org/"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0-with-LLVM-exception;md5=0bcd48c3bdfef0c9d9fd17726e4b7dab"
+SECTION = "devel"
+
+PN = "clang16-crosssdk-${TARGET_ARCH}"
+
+require clang.inc
+require common-source.inc
+inherit crosssdk
+DEPENDS += "clang16-native nativesdk-clang16-glue virtual/${TARGET_PREFIX}binutils virtual/nativesdk-libc"
+
+do_install() {
+        install -d ${D}${bindir}
+	for tool in clang clang++ clang-tidy lld ld.lld llvm-profdata \
+            llvm-nm llvm-ar llvm-as llvm-ranlib llvm-strip llvm-objcopy llvm-objdump llvm-readelf \
+            llvm-addr2line llvm-dwp llvm-size llvm-strings llvm-cov
+	do
+		ln -sf ../$tool ${D}${bindir}/${TARGET_PREFIX}$tool
+	done
+}
+SSTATE_SCAN_FILES += "*-clang *-clang++ *-llvm-profdata *-lld *-ld.lld \
+                      *-llvm-nm *-llvm-ar *-llvm-as *-llvm-ranlib *-llvm-strip \
+                      *-llvm-objcopy *-llvm-objdump *-llvm-readelf *-llvm-addr2line \
+                      *-llvm-dwp *-llvm-size *-llvm-strings *-llvm-cov"
+sysroot_stage_all () {
+        sysroot_stage_dir ${D}${bindir} ${SYSROOT_DESTDIR}${bindir}
+}
+
+PACKAGES = ""
+

--- a/recipes-devtools/clang16/clang16_git.bb
+++ b/recipes-devtools/clang16/clang16_git.bb
@@ -1,0 +1,443 @@
+# Copyright (C) 2014 Khem Raj <raj.khem@gmail.com>
+# Released under the MIT license (see COPYING.MIT for the terms)
+
+DESCRIPTION = "LLVM based C/C++ compiler"
+HOMEPAGE = "http://clang.llvm.org/"
+SECTION = "devel"
+
+require clang.inc
+require common-source.inc
+
+INHIBIT_DEFAULT_DEPS = "1"
+
+BUILD_CC:class-nativesdk = "clang"
+BUILD_CXX:class-nativesdk = "clang++"
+BUILD_AR:class-nativesdk = "llvm-ar"
+BUILD_RANLIB:class-nativesdk = "llvm-ranlib"
+BUILD_NM:class-nativesdk = "llvm-nm"
+LDFLAGS:remove:class-nativesdk = "-fuse-ld=lld"
+
+LDFLAGS:append:class-target:riscv32 = " -Wl,--no-as-needed -latomic -Wl,--as-needed"
+LDFLAGS:append:class-target:mips = " -Wl,--no-as-needed -latomic -Wl,--as-needed"
+
+inherit cmake cmake-native pkgconfig python3native python3targetconfig
+
+OECMAKE_FIND_ROOT_PATH_MODE_PROGRAM = "BOTH"
+
+def get_clang_experimental_arch(bb, d, arch_var):
+    import re
+    a = d.getVar(arch_var, True)
+    return ""
+
+def get_clang_arch(bb, d, arch_var):
+    import re
+    a = d.getVar(arch_var, True)
+    if   re.match('(i.86|athlon|x86.64)$', a):         return 'X86'
+    elif re.match('arm$', a):                          return 'ARM'
+    elif re.match('armeb$', a):                        return 'ARM'
+    elif re.match('aarch64$', a):                      return 'AArch64'
+    elif re.match('aarch64_be$', a):                   return 'AArch64'
+    elif re.match('mips(isa|)(32|64|)(r6|)(el|)$', a): return 'Mips'
+    elif re.match('riscv32$', a):                      return 'riscv32'
+    elif re.match('riscv64$', a):                      return 'riscv64'
+    elif re.match('p(pc|owerpc)(|64)', a):             return 'PowerPC'
+    elif re.match('loongarch64$', a):                  return 'loongarch64'
+    else:
+        bb.note("'%s' is not a primary llvm architecture" % a)
+    return ""
+
+def get_clang_host_arch(bb, d):
+    return get_clang_arch(bb, d, 'HOST_ARCH')
+
+def get_clang_target_arch(bb, d):
+    return get_clang_arch(bb, d, 'TARGET_ARCH')
+
+def get_clang_experimental_target_arch(bb, d):
+    return get_clang_experimental_arch(bb, d, 'TARGET_ARCH')
+
+PACKAGECONFIG ??= "compiler-rt libcplusplus shared-libs lldb-wchar \
+                   ${@bb.utils.filter('DISTRO_FEATURES', 'thin-lto lto', d)} \
+                   ${@bb.utils.contains('RUNTIME', 'llvm', 'compiler-rt libcplusplus unwindlib libomp', '', d)} \
+                   rtti eh libedit terminfo \
+                   "
+PACKAGECONFIG:class-native = "rtti eh libedit shared-libs ${@bb.utils.contains('RUNTIME', 'llvm', 'compiler-rt libcplusplus unwindlib libomp', '', d)}"
+PACKAGECONFIG:class-nativesdk = "rtti eh libedit shared-libs ${@bb.utils.filter('DISTRO_FEATURES', 'thin-lto lto', d)} ${@bb.utils.contains('RUNTIME', 'llvm', 'compiler-rt libcplusplus unwindlib libomp', '', d)}"
+
+PACKAGECONFIG[compiler-rt] = "-DCLANG_DEFAULT_RTLIB=compiler-rt,,"
+PACKAGECONFIG[libcplusplus] = "-DCLANG_DEFAULT_CXX_STDLIB=libc++,,"
+PACKAGECONFIG[unwindlib] = "-DCLANG_DEFAULT_UNWINDLIB=libunwind,-DCLANG_DEFAULT_UNWINDLIB=libgcc,,"
+PACKAGECONFIG[libomp] = "-DCLANG_DEFAULT_OPENMP_RUNTIME=libomp,,"
+PACKAGECONFIG[thin-lto] = "-DLLVM_ENABLE_LTO=Thin -DLLVM_BINUTILS_INCDIR=${STAGING_INCDIR},,binutils,"
+PACKAGECONFIG[lto] = "-DLLVM_ENABLE_LTO=Full -DLLVM_BINUTILS_INCDIR=${STAGING_INCDIR},,binutils,"
+PACKAGECONFIG[shared-libs] = "-DLLVM_BUILD_LLVM_DYLIB=ON -DLLVM_LINK_LLVM_DYLIB=ON,,,"
+PACKAGECONFIG[terminfo] = "-DLLVM_ENABLE_TERMINFO=ON -DCOMPILER_RT_TERMINFO_LIB=ON,-DLLVM_ENABLE_TERMINFO=OFF -DCOMPILER_RT_TERMINFO_LIB=OFF,ncurses,"
+PACKAGECONFIG[pfm] = "-DLLVM_ENABLE_LIBPFM=ON,-DLLVM_ENABLE_LIBPFM=OFF,libpfm,"
+PACKAGECONFIG[lldb-wchar] = "-DLLDB_EDITLINE_USE_WCHAR=1,-DLLDB_EDITLINE_USE_WCHAR=0,"
+PACKAGECONFIG[lldb-lua] = "-DLLDB_ENABLE_LUA=ON,-DLLDB_ENABLE_LUA=OFF,lua"
+PACKAGECONFIG[bootstrap] = "-DCLANG_ENABLE_BOOTSTRAP=On -DCLANG_BOOTSTRAP_PASSTHROUGH='${PASSTHROUGH}' -DBOOTSTRAP_LLVM_ENABLE_LTO=Thin -DBOOTSTRAP_LLVM_ENABLE_LLD=ON,,,"
+PACKAGECONFIG[eh] = "-DLLVM_ENABLE_EH=ON,-DLLVM_ENABLE_EH=OFF,,"
+PACKAGECONFIG[rtti] = "-DLLVM_ENABLE_RTTI=ON,-DLLVM_ENABLE_RTTI=OFF,,"
+PACKAGECONFIG[split-dwarf] = "-DLLVM_USE_SPLIT_DWARF=ON,-DLLVM_USE_SPLIT_DWARF=OFF,,"
+PACKAGECONFIG[libedit] = "-DLLVM_ENABLE_LIBEDIT=ON -DLLDB_ENABLE_LIBEDIT=ON,-DLLVM_ENABLE_LIBEDIT=OFF -DLLDB_ENABLE_LIBEDIT=OFF,libedit libedit-native"
+
+OECMAKE_SOURCEPATH = "${S}/llvm"
+
+OECMAKE_TARGET_COMPILE = "${@bb.utils.contains('PACKAGECONFIG', 'bootstrap', 'stage2', 'all', d)}"
+OECMAKE_TARGET_INSTALL = "${@bb.utils.contains('PACKAGECONFIG', 'bootstrap', 'stage2-install', 'install', d)}"
+BINPATHPREFIX = "${@bb.utils.contains('PACKAGECONFIG', 'bootstrap', '/tools/clang/stage2-bins/NATIVE', '', d)}"
+
+PASSTHROUGH = "\
+CLANG_DEFAULT_RTLIB;CLANG_DEFAULT_CXX_STDLIB;LLVM_BUILD_LLVM_DYLIB;LLVM_LINK_LLVM_DYLIB;\
+LLVM_ENABLE_ASSERTIONS;LLVM_ENABLE_EXPENSIVE_CHECKS;LLVM_ENABLE_PIC;\
+LLVM_BINDINGS_LIST;LLVM_ENABLE_FFI;FFI_INCLUDE_DIR;LLVM_OPTIMIZED_TABLEGEN;\
+LLVM_ENABLE_RTTI;LLVM_ENABLE_EH;LLVM_BUILD_EXTERNAL_COMPILER_RT;CMAKE_SYSTEM_NAME;\
+CMAKE_BUILD_TYPE;BUILD_SHARED_LIBS;LLVM_ENABLE_PROJECTS;LLVM_BINUTILS_INCDIR;\
+LLVM_TARGETS_TO_BUILD;LLVM_EXPERIMENTAL_TARGETS_TO_BUILD;PYTHON_EXECUTABLE;\
+PYTHON_LIBRARY;PYTHON_INCLUDE_DIR;LLVM_TEMPORARILY_ALLOW_OLD_TOOLCHAIN;LLDB_EDITLINE_USE_WCHAR;\
+LLVM_ENABLE_LIBEDIT;LLDB_ENABLE_LIBEDIT;LLDB_PYTHON_RELATIVE_PATH;LLDB_PYTHON_EXE_RELATIVE_PATH;\
+LLDB_PYTHON_EXT_SUFFIX;CMAKE_C_FLAGS_RELEASE;CMAKE_CXX_FLAGS_RELEASE;CMAKE_ASM_FLAGS_RELEASE;\
+CLANG_DEFAULT_CXX_STDLIB;CLANG_DEFAULT_RTLIB;CLANG_DEFAULT_UNWINDLIB;\
+CLANG_DEFAULT_OPENMP_RUNTIME;LLVM_ENABLE_PER_TARGET_RUNTIME_DIR;\
+LLVM_BUILD_TOOLS;LLVM_USE_HOST_TOOLS;LLVM_CONFIG_PATH;\
+"
+#
+# Default to build all OE-Core supported target arches (user overridable).
+# Gennerally setting LLVM_TARGETS_TO_BUILD = "" in local.conf is ok in most simple situations
+# where only one target architecture is needed along with just one build arch (usually X86)
+#
+LLVM_TARGETS_TO_BUILD ?= "AMDGPU;AArch64;ARM;BPF;Mips;PowerPC;RISCV;X86;LoongArch"
+
+LLVM_EXPERIMENTAL_TARGETS_TO_BUILD ?= ""
+LLVM_EXPERIMENTAL_TARGETS_TO_BUILD:append = ";${@get_clang_experimental_target_arch(bb, d)}"
+
+HF = ""
+HF:class-target = "${@ bb.utils.contains('TUNE_CCARGS_MFLOAT', 'hard', 'hf', '', d)}"
+HF[vardepvalue] = "${HF}"
+
+LLVM_PROJECTS ?= "clang;clang-tools-extra;lld${LLDB}"
+LLDB ?= ";lldb"
+# LLDB support for RISCV/Mips32 does not work yet
+LLDB:riscv32 = ""
+LLDB:riscv64 = ""
+LLDB:mips = ""
+LLDB:mipsel = ""
+LLDB:powerpc = ""
+
+# linux hosts (.so) on Windows .pyd
+SOLIBSDEV:mingw32 = ".pyd"
+
+#CMAKE_VERBOSE = "VERBOSE=1"
+
+EXTRA_OECMAKE += "-DLLVM_ENABLE_ASSERTIONS=OFF \
+                  -DLLVM_ENABLE_PER_TARGET_RUNTIME_DIR=OFF \
+                  -DLLVM_ENABLE_EXPENSIVE_CHECKS=OFF \
+                  -DLLVM_ENABLE_PIC=ON \
+                  -DCLANG_DEFAULT_PIE_ON_LINUX=ON \
+                  -DLLVM_BINDINGS_LIST='' \
+                  -DLLVM_ENABLE_FFI=ON \
+                  -DLLVM_ENABLE_ZSTD=ON \
+                  -DFFI_INCLUDE_DIR=$(pkg-config --variable=includedir libffi) \
+                  -DLLVM_OPTIMIZED_TABLEGEN=ON \
+                  -DLLVM_BUILD_EXTERNAL_COMPILER_RT=ON \
+                  -DCMAKE_SYSTEM_NAME=Linux \
+                  -DCMAKE_BUILD_TYPE=Release \
+                  -DCMAKE_CXX_FLAGS_RELEASE='${CXXFLAGS} -DNDEBUG -g0' \
+                  -DCMAKE_C_FLAGS_RELEASE='${CFLAGS} -DNDEBUG -g0' \
+                  -DBUILD_SHARED_LIBS=OFF \
+                  -DLLVM_ENABLE_PROJECTS='${LLVM_PROJECTS}' \
+                  -DLLVM_BINUTILS_INCDIR=${STAGING_INCDIR} \
+                  -DLLVM_TEMPORARILY_ALLOW_OLD_TOOLCHAIN=ON \
+                  -DLLVM_TARGETS_TO_BUILD='${LLVM_TARGETS_TO_BUILD}' \
+                  -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD='${LLVM_EXPERIMENTAL_TARGETS_TO_BUILD}' \
+"
+
+EXTRA_OECMAKE:append:class-native = "\
+                  -DPYTHON_EXECUTABLE='${PYTHON}' \
+"
+EXTRA_OECMAKE:append:class-nativesdk = "\
+                  -DCMAKE_CROSSCOMPILING:BOOL=ON \
+                  -DCROSS_TOOLCHAIN_FLAGS_NATIVE='-DLLDB_PYTHON_RELATIVE_PATH=${PYTHON_SITEPACKAGES_DIR} \
+                                                  -DLLDB_PYTHON_EXE_RELATIVE_PATH=${PYTHON} \
+                                                  -DLLDB_PYTHON_EXT_SUFFIX=${SOLIBSDEV} \
+                                                  -DCMAKE_TOOLCHAIN_FILE=${WORKDIR}/toolchain-native.cmake' \
+                  -DCMAKE_RANLIB=${STAGING_BINDIR_TOOLCHAIN}/${TARGET_PREFIX}llvm-ranlib \
+                  -DCMAKE_AR=${STAGING_BINDIR_TOOLCHAIN}/${TARGET_PREFIX}llvm-ar \
+                  -DCMAKE_NM=${STAGING_BINDIR_TOOLCHAIN}/${TARGET_PREFIX}llvm-nm \
+                  -DCMAKE_STRIP=${STAGING_BINDIR_TOOLCHAIN}/${TARGET_PREFIX}llvm-strip \
+                  -DLLVM_USE_HOST_TOOLS=OFF \
+                  -DLLVM_CONFIG_PATH=${STAGING_BINDIR_NATIVE}/llvm-config \
+                  -DLLVM_TABLEGEN=${STAGING_BINDIR_NATIVE}/llvm-tblgen \
+                  -DLLDB_TABLEGEN=${STAGING_BINDIR_NATIVE}/lldb-tblgen \
+                  -DCLANG_TABLEGEN=${STAGING_BINDIR_NATIVE}/clang-tblgen \
+                  -DCLANG_TIDY_CONFUSABLE_CHARS_GEN=${STAGING_BINDIR_NATIVE}/clang-tidy-confusable-chars-gen \
+                  -DCLANG_PSEUDO_GEN=${STAGING_BINDIR_NATIVE}/clang-pseudo-gen \
+                  -DPYTHON_LIBRARY=${STAGING_LIBDIR}/lib${PYTHON_DIR}${PYTHON_ABI}.so \
+                  -DLLDB_PYTHON_RELATIVE_PATH=${PYTHON_SITEPACKAGES_DIR} \
+                  -DLLDB_PYTHON_EXE_RELATIVE_PATH=${PYTHON} \
+                  -DLLDB_PYTHON_EXT_SUFFIX=${SOLIBSDEV} \
+                  -DPYTHON_INCLUDE_DIR=${STAGING_INCDIR}/${PYTHON_DIR}${PYTHON_ABI} \
+                  -DPYTHON_EXECUTABLE='${PYTHON}' \
+"
+EXTRA_OECMAKE:append:class-target = "\
+                  -DCMAKE_CROSSCOMPILING:BOOL=ON \
+                  -DLLVM_USE_HOST_TOOLS=OFF \
+                  -DLLVM_CONFIG_PATH=${STAGING_BINDIR_NATIVE}/llvm-config \
+                  -DLLVM_TABLEGEN=${STAGING_BINDIR_NATIVE}/llvm-tblgen \
+                  -DLLDB_TABLEGEN=${STAGING_BINDIR_NATIVE}/lldb-tblgen \
+                  -DCLANG_TABLEGEN=${STAGING_BINDIR_NATIVE}/clang-tblgen \
+                  -DCLANG_TIDY_CONFUSABLE_CHARS_GEN=${STAGING_BINDIR_NATIVE}/clang-tidy-confusable-chars-gen \
+                  -DCLANG_PSEUDO_GEN=${STAGING_BINDIR_NATIVE}/clang-pseudo-gen \
+                  -DCMAKE_RANLIB=${STAGING_BINDIR_TOOLCHAIN}/${TARGET_PREFIX}llvm-ranlib \
+                  -DCMAKE_AR=${STAGING_BINDIR_TOOLCHAIN}/${TARGET_PREFIX}llvm-ar \
+                  -DCMAKE_NM=${STAGING_BINDIR_TOOLCHAIN}/${TARGET_PREFIX}llvm-nm \
+                  -DCMAKE_STRIP=${STAGING_BINDIR_TOOLCHAIN}/${TARGET_PREFIX}llvm-strip \
+                  -DLLVM_TARGET_ARCH=${@get_clang_target_arch(bb, d)} \
+                  -DLLVM_DEFAULT_TARGET_TRIPLE=${TARGET_SYS}${HF} \
+                  -DLLVM_HOST_TRIPLE=${TARGET_SYS}${HF} \
+                  -DPYTHON_LIBRARY=${STAGING_LIBDIR}/lib${PYTHON_DIR}${PYTHON_ABI}.so \
+                  -DPYTHON_INCLUDE_DIR=${STAGING_INCDIR}/${PYTHON_DIR}${PYTHON_ABI} \
+                  -DLLVM_LIBDIR_SUFFIX=${@d.getVar('baselib').replace('lib', '')} \
+                  -DLLDB_PYTHON_RELATIVE_PATH=${PYTHON_SITEPACKAGES_DIR} \
+                  -DLLDB_PYTHON_EXE_RELATIVE_PATH=${bindir} \
+                  -DLLDB_PYTHON_EXT_SUFFIX=${SOLIBSDEV} \
+"
+
+DEPENDS = "binutils zlib zstd libffi libxml2 libxml2-native ninja-native swig-native"
+DEPENDS:append:class-nativesdk = " clang16-crosssdk-${SDK_ARCH} virtual/${TARGET_PREFIX}binutils nativesdk-python3"
+DEPENDS:append:class-target = " clang16-cross-${TARGET_ARCH} gcc-cross-${TARGET_ARCH} python3 compiler-rt16 libcxx16-initial"
+
+RRECOMMENDS:${PN} = "binutils"
+RRECOMMENDS:${PN}:append:class-target = " libcxx-dev"
+
+# patch out build host paths for reproducibility
+do_compile:prepend:class-target() {
+    sed -i -e "s,${STAGING_DIR_NATIVE},,g" \
+        -e "s,${STAGING_DIR_TARGET},,g" \
+        -e "s,${S},,g"  \
+        -e "s,${B},,g" \
+        ${B}/tools/llvm-config/BuildVariables.inc
+}
+
+do_install:append() {
+    rm -rf ${D}${libdir}/python*/site-packages/six.py
+}
+
+do_install:append:class-target () {
+    # Allow bin path to change based on YOCTO_ALTERNATE_EXE_PATH
+    sed -i 's;${_IMPORT_PREFIX}/bin;${_IMPORT_PREFIX_BIN};g' ${D}${libdir}/cmake/llvm/LLVMExports-release.cmake
+
+    # Insert function to populate Import Variables
+    sed -i "4i\
+if(DEFINED ENV{YOCTO_ALTERNATE_EXE_PATH})\n\
+  execute_process(COMMAND \"llvm-config\" \"--bindir\" OUTPUT_VARIABLE _IMPORT_PREFIX_BIN OUTPUT_STRIP_TRAILING_WHITESPACE)\n\
+else()\n\
+  set(_IMPORT_PREFIX_BIN \"\${_IMPORT_PREFIX}/bin\")\n\
+endif()\n" ${D}${libdir}/cmake/llvm/LLVMExports-release.cmake
+
+    if [ -n "${LLVM_LIBDIR_SUFFIX}" ]; then
+        mkdir -p ${D}${nonarch_libdir}
+        mv ${D}${libdir}/clang ${D}${nonarch_libdir}/clang
+        ln -rs ${D}${nonarch_libdir}/clang ${D}${libdir}/clang
+        rmdir --ignore-fail-on-non-empty ${D}${libdir}
+    fi
+    for t in clang clang++ llvm-nm llvm-ar llvm-as llvm-ranlib llvm-strip llvm-objcopy llvm-objdump llvm-readelf \
+        llvm-addr2line llvm-dwp llvm-size llvm-strings llvm-cov; do
+        ln -sf $t ${D}${bindir}/${TARGET_PREFIX}$t
+    done
+
+    # reproducibility
+    sed -i -e 's,${B},,g' ${D}${libdir}/cmake/llvm/LLVMConfig.cmake
+}
+
+do_install:append:class-native () {
+    install -Dm 0755 ${B}${BINPATHPREFIX}/bin/clang-tblgen ${D}${bindir}/clang-tblgen
+    install -Dm 0755 ${B}${BINPATHPREFIX}/bin/clang-pseudo-gen ${D}${bindir}/clang-pseudo-gen
+    install -Dm 0755 ${B}${BINPATHPREFIX}/bin/lldb-tblgen ${D}${bindir}/lldb-tblgen
+    install -Dm 0755 ${B}${BINPATHPREFIX}/bin/clang-tidy-confusable-chars-gen ${D}${bindir}/clang-tidy-confusable-chars-gen
+    for f in `find ${D}${bindir} -executable -type f -not -type l`; do
+        test -n "`file -b $f|grep -i ELF`" && ${STRIP} $f
+        echo "stripped $f"
+    done
+    ln -sf clang-tblgen ${D}${bindir}/clang-tblgen${PV}
+    ln -sf llvm-tblgen ${D}${bindir}/llvm-tblgen${PV}
+    ln -sf llvm-config ${D}${bindir}/llvm-config${PV}
+}
+
+do_install:append:class-nativesdk () {
+    install -Dm 0755 ${B}${BINPATHPREFIX}/bin/clang-tblgen ${D}${bindir}/clang-tblgen
+    install -Dm 0755 ${B}${BINPATHPREFIX}/bin/clang-pseudo-gen ${D}${bindir}/clang-pseudo-gen
+    install -Dm 0755 ${B}${BINPATHPREFIX}/bin/lldb-tblgen ${D}${bindir}/lldb-tblgen
+    install -Dm 0755 ${B}${BINPATHPREFIX}/bin/clang-tidy-confusable-chars-gen ${D}${bindir}/clang-tidy-confusable-chars-gen
+    for f in `find ${D}${bindir} -executable -type f -not -type l`; do
+        test -n "`file -b $f|grep -i ELF`" && ${STRIP} $f
+    done
+    ln -sf clang-tblgen ${D}${bindir}/clang-tblgen${PV}
+    ln -sf llvm-tblgen ${D}${bindir}/llvm-tblgen${PV}
+    ln -sf llvm-config ${D}${bindir}/llvm-config${PV}
+    rm -rf ${D}${datadir}/llvm/cmake
+    rm -rf ${D}${datadir}/llvm
+}
+
+PACKAGES =+ "${PN}-libllvm ${PN}-lldb-python ${PN}-libclang-cpp ${PN}-tidy ${PN}-format ${PN}-tools \
+             libclang16 lldb16 lldb16-server liblldb16 llvm16-linker-tools"
+
+PROVIDES += "llvm16 llvm16-${PV}"
+PROVIDES:append:class-native = " llvm16-native"
+
+BBCLASSEXTEND = "native nativesdk"
+
+RDEPENDS:lldb16 += "${PN}-lldb-python lldb16-server"
+
+RDEPENDS:${PN}-tools += "\
+  perl-module-digest-md5 \
+  perl-module-file-basename \
+  perl-module-file-copy \
+  perl-module-file-find \
+  perl-module-file-path \
+  perl-module-findbin \
+  perl-module-hash-util \
+  perl-module-sys-hostname \
+  perl-module-term-ansicolor \
+"
+
+RRECOMMENDS:${PN}-tidy += "${PN}-tools"
+
+FILES:llvm16-linker-tools = "${libdir}/LLVMgold* ${libdir}/libLTO.so.* ${libdir}/LLVMPolly*"
+
+FILES:${PN}-libclang-cpp = "${libdir}/libclang-cpp.so.*"
+
+FILES:${PN}-lldb-python = "${libdir}/python*/site-packages/lldb/*"
+
+FILES:${PN}-tidy = "${bindir}/*clang-tidy*"
+FILES:${PN}-format = "${bindir}/*clang-format*"
+
+FILES:${PN}-tools = "${bindir}/analyze-build \
+  ${bindir}/c-index-test \
+  ${bindir}/clang-apply-replacements \
+  ${bindir}/clang-change-namespace \
+  ${bindir}/clang-check \
+  ${bindir}/clang-doc \
+  ${bindir}/clang-extdef-mapping \
+  ${bindir}/clang-include-fixer \
+  ${bindir}/clang-linker-wrapper \
+  ${bindir}/clang-move \
+  ${bindir}/clang-nvlink-wrapper \
+  ${bindir}/clang-offload-bundler \
+  ${bindir}/clang-offload-packager \
+  ${bindir}/clang-pseudo \
+  ${bindir}/clang-query \
+  ${bindir}/clang-refactor \
+  ${bindir}/clang-rename \
+  ${bindir}/clang-reorder-fields \
+  ${bindir}/clang-repl \
+  ${bindir}/clang-scan-deps \
+  ${bindir}/diagtool \
+  ${bindir}/find-all-symbols \
+  ${bindir}/hmaptool \
+  ${bindir}/hwasan_symbolize \
+  ${bindir}/intercept-build \
+  ${bindir}/modularize \
+  ${bindir}/pp-trace \
+  ${bindir}/sancov \
+  ${bindir}/scan-build \
+  ${bindir}/scan-build-py \
+  ${bindir}/scan-view \
+  ${bindir}/split-file \
+  ${libdir}/libscanbuild/* \
+  ${libdir}/libear/* \
+  ${libexecdir}/analyze-c++ \
+  ${libexecdir}/analyze-cc \
+  ${libexecdir}/c++-analyzer \
+  ${libexecdir}/ccc-analyzer \
+  ${libexecdir}/intercept-c++ \
+  ${libexecdir}/intercept-cc \
+  ${datadir}/scan-build/* \
+  ${datadir}/scan-view/* \
+  ${datadir}/opt-viewer/* \
+  ${datadir}/clang/* \
+"
+
+FILES:${PN} += "\
+  ${bindir}/clang-cl \
+  ${libdir}/BugpointPasses.so \
+  ${libdir}/LLVMHello.so \
+  ${libdir}/*Plugin.so \
+  ${libdir}/${BPN} \
+  ${nonarch_libdir}/clang/*/include/ \
+"
+
+FILES:lldb16 = "\
+  ${bindir}/lldb \
+  ${bindir}/lldb-argdumper \
+  ${bindir}/lldb-instr \
+  ${bindir}/lldb-vscode \
+"
+
+FILES:lldb16-server = "\
+  ${bindir}/lldb-server \
+"
+
+FILES:liblldb16 = "\
+  ${libdir}/liblldbIntelFeatures.so.* \
+  ${libdir}/liblldb.so.* \
+"
+
+FILES:${PN}-libllvm =+ "\
+  ${libdir}/libLLVM-${MAJOR_VER}.${MINOR_VER}.so \
+  ${libdir}/libLLVM-${MAJOR_VER}.so \
+  ${libdir}/libLLVM-${MAJOR_VER}git.so \
+  ${libdir}/libLLVM-${MAJOR_VER}.${MINOR_VER}git.so \
+  ${libdir}/libRemarks.so.* \
+"
+
+FILES:libclang16 = "\
+  ${libdir}/libclang.so.* \
+"
+
+FILES:${PN}-dev += "\
+  ${datadir}/llvm/cmake \
+  ${libdir}/cmake \
+  ${nonarch_libdir}/libear \
+  ${nonarch_libdir}/${BPN}/*.la \
+"
+
+FILES:${PN}-staticdev += "${nonarch_libdir}/${BPN}/*.a"
+
+FILES:${PN}-staticdev:remove = "${libdir}/${BPN}/*.a"
+FILES:${PN}-dev:remove = "${libdir}/${BPN}/*.la"
+FILES:${PN}:remove = "${libdir}/${BPN}/*"
+
+
+INSANE_SKIP:${PN} += "already-stripped"
+#INSANE_SKIP:${PN}-dev += "dev-elf"
+INSANE_SKIP:${PN}-lldb-python += "dev-so dev-deps"
+INSANE_SKIP:${MLPREFIX}liblldb = "dev-so"
+
+#Avoid SSTATE_SCAN_COMMAND running sed over llvm-config.
+SSTATE_SCAN_FILES:remove = "*-config"
+
+TOOLCHAIN = "clang16"
+TOOLCHAIN:class-native = "gcc"
+TOOLCHAIN:class-nativesdk = "clang16"
+COMPILER_RT:class-nativesdk:toolchain-clang:runtime-llvm = "-rtlib=libgcc --unwindlib=libgcc"
+LIBCPLUSPLUS:class-nativesdk:toolchain-clang:runtime-llvm = "-stdlib=libstdc++"
+
+SYSROOT_DIRS:append:class-target = " ${nonarch_libdir}"
+
+SYSROOT_PREPROCESS_FUNCS:append:class-target = " clang_sysroot_preprocess"
+
+clang_sysroot_preprocess() {
+	install -d ${SYSROOT_DESTDIR}${bindir_crossscripts}/
+	install -m 0755 ${S}/../llvm-config ${SYSROOT_DESTDIR}${bindir_crossscripts}/
+	ln -sf llvm-config ${SYSROOT_DESTDIR}${bindir_crossscripts}/llvm-config${PV}
+	# LLDTargets.cmake references the lld executable(!) that some modules/plugins link to
+	install -d ${SYSROOT_DESTDIR}${bindir}
+	for f in lld diagtool clang-${MAJOR_VER} clang-format clang-offload-packager \
+            clang-offload-bundler clang-scan-deps clang-repl \
+            clang-rename clang-refactor clang-check clang-extdef-mapping clang-apply-replacements \
+            clang-reorder-fields clang-tidy clang-change-namespace clang-doc clang-include-fixer \
+            find-all-symbols clang-move clang-query pp-trace clang-pseudo clangd modularize
+	do
+		install -m 755 ${D}${bindir}/$f ${SYSROOT_DESTDIR}${bindir}/
+	done
+}

--- a/recipes-devtools/clang16/common-source.inc
+++ b/recipes-devtools/clang16/common-source.inc
@@ -1,0 +1,17 @@
+do_fetch() {
+        :
+}
+do_fetch[noexec] = "1"
+deltask do_unpack
+deltask do_patch
+
+SRC_URI = ""
+
+do_configure[depends] += "llvm-project-source-${PV}:do_patch"
+do_populate_lic[depends] += "llvm-project-source-${PV}:do_unpack"
+do_create_spdx[depends] += "llvm-project-source-${PV}:do_patch"
+
+# spdx shared workdir detection fails as not WORKDIR is altered but S and B
+# return always true to fix that
+def is_work_shared_spdx(d):
+    return True

--- a/recipes-devtools/clang16/common.inc
+++ b/recipes-devtools/clang16/common.inc
@@ -1,0 +1,63 @@
+FILESEXTRAPATHS =. "${FILE_DIRNAME}/clang:"
+
+LIC_FILES_CHKSUM = "file://llvm/LICENSE.TXT;md5=${LLVMMD5SUM} \
+                    file://clang/LICENSE.TXT;md5=${CLANGMD5SUM} \
+"
+LICENSE = "Apache-2.0-with-LLVM-exception"
+
+BASEURI ??= "${LLVM_GIT}/llvm-project;protocol=${LLVM_GIT_PROTOCOL};branch=${BRANCH}"
+SRC_URI = "\
+    ${BASEURI} \
+    file://llvm-config \
+    file://libunwind.pc.in \
+    file://0001-libcxxabi-Find-libunwind-headers-when-LIBCXXABI_LIBU.patch \
+    file://0002-compiler-rt-support-a-new-embedded-linux-target.patch \
+    file://0003-compiler-rt-Simplify-cross-compilation.-Don-t-use-na.patch \
+    file://0004-llvm-TargetLibraryInfo-Undefine-libc-functions-if-th.patch \
+    file://0005-llvm-allow-env-override-of-exe-and-libdir-path.patch \
+    file://0006-clang-driver-Check-sysroot-for-ldso-path.patch \
+    file://0007-clang-Driver-tools.cpp-Add-lssp_nonshared-on-musl.patch \
+    file://0008-clang-Prepend-trailing-to-sysroot.patch \
+    file://0009-clang-Look-inside-the-target-sysroot-for-compiler-ru.patch \
+    file://0010-clang-Define-releative-gcc-installation-dir.patch \
+    file://0011-clang-Add-lpthread-and-ldl-along-with-lunwind-for-st.patch \
+    file://0012-Pass-PYTHON_EXECUTABLE-when-cross-compiling-for-nati.patch \
+    file://0013-Check-for-atomic-double-intrinsics.patch \
+    file://0014-libcxx-Add-compiler-runtime-library-to-link-step-for.patch \
+    file://0015-clang-llvm-cmake-Fix-configure-for-packages-using-fi.patch \
+    file://0016-clang-Fix-resource-dir-location-for-cross-toolchains.patch \
+    file://0017-clang-driver-Add-dyld-prefix-when-checking-sysroot-f.patch \
+    file://0018-clang-Use-python3-in-python-scripts.patch \
+    file://0019-For-x86_64-set-Yocto-based-GCC-install-search-path.patch \
+    file://0020-llvm-Do-not-use-find_library-for-ncurses.patch \
+    file://0021-llvm-Insert-anchor-for-adding-OE-distro-vendor-names.patch \
+    file://0022-compiler-rt-Do-not-use-backtrace-APIs-on-non-glibc-l.patch \
+    file://0023-clang-Fix-x86-triple-for-non-debian-multiarch-linux-.patch \
+    file://0024-libunwind-Added-unw_backtrace-method.patch \
+    file://0025-clang-Do-not-use-install-relative-libc-headers.patch \
+    file://0026-clang-Fix-how-driver-finds-GCC-installation-path-on-.patch \
+    file://0027-Fix-lib-paths-for-OpenEmbedded-Host.patch \
+    file://0028-Correct-library-search-path-for-OpenEmbedded-Host.patch \
+    file://0029-lldb-Link-with-libatomic-on-x86.patch \
+    file://0030-clang-exclude-openembedded-distributions-from-settin.patch \
+    file://0031-compiler-rt-Enable-__int128-for-ppc32.patch \
+    file://0032-llvm-Do-not-use-cmake-infra-to-detect-libzstd.patch \
+    file://0033-build-Enable-64bit-off_t-on-32bit-glibc-systems.patch \
+    file://0034-compiler-rt-Undef-_TIME_BITS-along-with-_FILE_OFFSET.patch \
+    file://0035-compiler-rt-Fix-stat-struct-s-size-for-O32-ABI.patch \
+    file://0036-compiler-rt-Undef-_TIME_BITS-along-with-_FILE_OFFSET.patch \
+    file://0037-Call-printName-to-get-name-of-Decl.patch \
+    file://0038-Apply-fmacro-prefix-map-to-anonymous-tags-in-templat.patch \
+    file://0039-lld-RISCV-Handle-relaxation-reductions-of-more-than-.patch \
+    file://0040-ToolChains-Gnu.cpp-ARMLibDirs-search-also-in-lib32.patch \
+    "
+# Fallback to no-PIE if not set
+GCCPIE ??= ""
+
+S = "${TMPDIR}/work-shared/llvm-project-source-${PV}-${PR}/git"
+B = "${WORKDIR}/llvm-project-source-${PV}/build.${HOST_SYS}.${TARGET_SYS}"
+
+# We need to ensure that for the shared work directory, the do_patch signatures match
+# The real WORKDIR location isn't a dependency for the shared workdir.
+src_patches[vardepsexclude] = "WORKDIR"
+should_apply[vardepsexclude] += "PN"

--- a/recipes-devtools/clang16/compiler-rt16-sanitizers_git.bb
+++ b/recipes-devtools/clang16/compiler-rt16-sanitizers_git.bb
@@ -1,0 +1,116 @@
+# Copyright (C) 2021 Khem Raj <raj.khem@gmail.com>
+# Released under the MIT license (see COPYING.MIT for the terms)
+
+DESCRIPTION = "LLVM based C/C++ compiler Runtime"
+HOMEPAGE = "http://compiler-rt.llvm.org/"
+SECTION = "base"
+
+require clang.inc
+require common-source.inc
+
+inherit cmake pkgconfig python3native
+
+
+LIC_FILES_CHKSUM = "file://compiler-rt/LICENSE.TXT;md5=d846d1d65baf322d4c485d6ee54e877a"
+
+TUNE_CCARGS:remove = "-no-integrated-as"
+
+DEPENDS += "ninja-native virtual/crypt"
+DEPENDS:append:class-native = " clang16-native libxcrypt-native"
+DEPENDS:append:class-nativesdk = " clang16-native clang16-crosssdk-${SDK_ARCH} nativesdk-libxcrypt"
+
+PACKAGECONFIG ??= ""
+PACKAGECONFIG[crt] = "-DCOMPILER_RT_BUILD_CRT:BOOL=ON,-DCOMPILER_RT_BUILD_CRT:BOOL=OFF"
+PACKAGECONFIG[static-libcxx] = "-DSANITIZER_USE_STATIC_CXX_ABI=ON -DSANITIZER_USE_STATIC_LLVM_UNWINDER=ON -DCOMPILER_RT_ENABLE_STATIC_UNWINDER=ON,,"
+
+HF = ""
+HF:class-target = "${@ bb.utils.contains('TUNE_CCARGS_MFLOAT', 'hard', 'hf', '', d)}"
+HF[vardepvalue] = "${HF}"
+
+CXXFLAGS:append:libc-musl = " -D_LARGEFILE64_SOURCE"
+
+OECMAKE_TARGET_COMPILE = "compiler-rt"
+OECMAKE_TARGET_INSTALL = "install-compiler-rt install-compiler-rt-headers"
+OECMAKE_SOURCEPATH = "${S}/llvm"
+EXTRA_OECMAKE += "-DCMAKE_BUILD_TYPE=RelWithDebInfo \
+                  -DLLVM_ENABLE_PER_TARGET_RUNTIME_DIR=OFF \
+                  -DCOMPILER_RT_STANDALONE_BUILD=OFF \
+                  -DCOMPILER_RT_DEFAULT_TARGET_ONLY=ON \
+                  -DCOMPILER_RT_USE_BUILTINS_LIBRARY=ON \
+                  -DCMAKE_C_COMPILER_TARGET=${HOST_ARCH}${HOST_VENDOR}-${HOST_OS}${HF} \
+                  -DCOMPILER_RT_BUILD_BUILTINS=OFF \
+                  -DCOMPILER_RT_INCLUDE_TESTS=OFF \
+                  -DSANITIZER_CXX_ABI_LIBNAME=${@bb.utils.contains("RUNTIME", "llvm", "libc++", "libstdc++", d)} \
+                  -DCOMPILER_RT_BUILD_XRAY=ON \
+                  -DCOMPILER_RT_BUILD_SANITIZERS=ON \
+                  -DCOMPILER_RT_BUILD_LIBFUZZER=ON \
+                  -DCOMPILER_RT_BUILD_PROFILE=ON \
+                  -DCOMPILER_RT_BUILD_MEMPROF=ON \
+                  -DLLVM_ENABLE_PROJECTS='compiler-rt' \
+                  -DCMAKE_RANLIB=${STAGING_BINDIR_TOOLCHAIN}/${TARGET_PREFIX}llvm-ranlib \
+                  -DCMAKE_AR=${STAGING_BINDIR_TOOLCHAIN}/${TARGET_PREFIX}llvm-ar \
+                  -DCMAKE_NM=${STAGING_BINDIR_TOOLCHAIN}/${TARGET_PREFIX}llvm-nm \
+                  -DLLVM_LIBDIR_SUFFIX=${LLVM_LIBDIR_SUFFIX} \
+"
+
+EXTRA_OECMAKE:append:class-nativesdk = "\
+               -DLLVM_TABLEGEN=${STAGING_BINDIR_NATIVE}/llvm-tblgen \
+               -DCLANG_TABLEGEN=${STAGING_BINDIR_NATIVE}/clang-tblgen \
+"
+
+EXTRA_OECMAKE:append:class-target = "\
+               -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+"
+
+EXTRA_OECMAKE:append:libc-musl = " -DLIBCXX_HAS_MUSL_LIBC=ON "
+EXTRA_OECMAKE:append:powerpc = " -DCOMPILER_RT_DEFAULT_TARGET_ARCH=powerpc "
+
+do_install:append () {
+    if [ -n "${LLVM_LIBDIR_SUFFIX}" ]; then
+        mkdir -p ${D}${nonarch_libdir}/clang
+        mv ${D}${libdir}/clang/${MAJOR_VER} ${D}${nonarch_libdir}/clang/${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}
+        rmdir --ignore-fail-on-non-empty ${D}${libdir}
+    else
+        mv ${D}${libdir}/clang/${MAJOR_VER} ${D}${libdir}/clang/${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}
+    fi
+    # Already shipped with compile-rt Orc support
+    rm -rf ${D}${nonarch_libdir}/clang/${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}/lib/linux/libclang_rt.orc-*.a
+    rm -rf ${D}${nonarch_libdir}/clang/${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}/include/orc/
+}
+
+FILES_SOLIBSDEV = ""
+FILES:${PN} += "${nonarch_libdir}/clang/${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}/lib/linux/lib*${SOLIBSDEV} \
+                ${nonarch_libdir}/clang/${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}/*.txt \
+                ${nonarch_libdir}/clang/${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}/share/*.txt"
+FILES:${PN}-staticdev += "${nonarch_libdir}/clang/${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}/lib/linux/*.a"
+FILES:${PN}-dev += "${datadir} ${nonarch_libdir}/clang/${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}/lib/linux/*.syms \
+                    ${nonarch_libdir}/clang/${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}/include \
+                    ${nonarch_libdir}/clang/${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}/lib/linux/clang_rt.crt*.o \
+                    ${nonarch_libdir}/clang/${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}/lib/linux/libclang_rt.asan-preinit*.a"
+INSANE_SKIP:${PN} = "dev-so libdir"
+INSANE_SKIP:${PN}-dbg = "libdir"
+
+#PROVIDES:append:class-target = "\
+#        virtual/${TARGET_PREFIX}compilerlibs \
+#        libgcc \
+#        libgcc-initial \
+#        libgcc-dev \
+#        libgcc-initial-dev \
+#        "
+#
+
+RDEPENDS:${PN}-dev += "${PN}-staticdev"
+
+BBCLASSEXTEND = "native nativesdk"
+
+ALLOW_EMPTY:${PN} = "1"
+ALLOW_EMPTY:${PN}-dev = "1"
+
+TOOLCHAIN:forcevariable = "clang16"
+SYSROOT_DIRS:append:class-target = " ${nonarch_libdir}"
+
+# riscv and x86_64 Sanitizers work on musl too
+COMPATIBLE_HOST:libc-musl:x86-64 = "(.*)"
+COMPATIBLE_HOST:libc-musl:riscv64 = "(.*)"
+COMPATIBLE_HOST:libc-musl:riscv32 = "(.*)"
+COMPATIBLE_HOST:libc-musl = "null"

--- a/recipes-devtools/clang16/compiler-rt16_git.bb
+++ b/recipes-devtools/clang16/compiler-rt16_git.bb
@@ -1,0 +1,128 @@
+# Copyright (C) 2015 Khem Raj <raj.khem@gmail.com>
+# Released under the MIT license (see COPYING.MIT for the terms)
+
+DESCRIPTION = "LLVM based C/C++ compiler Runtime"
+HOMEPAGE = "http://compiler-rt.llvm.org/"
+SECTION = "base"
+
+require clang.inc
+require common-source.inc
+
+inherit cmake cmake-native clang16 pkgconfig python3native
+
+LIC_FILES_CHKSUM = "file://compiler-rt/LICENSE.TXT;md5=d846d1d65baf322d4c485d6ee54e877a"
+
+LIBCPLUSPLUS = ""
+COMPILER_RT = ""
+
+TUNE_CCARGS:remove = "-no-integrated-as"
+
+INHIBIT_DEFAULT_DEPS = "1"
+
+DEPENDS += "ninja-native libgcc"
+DEPENDS:append:class-target = " clang16-cross-${TARGET_ARCH} virtual/${MLPREFIX}libc gcc-runtime"
+DEPENDS:append:class-nativesdk = " clang16-native clang16-crosssdk-${SDK_ARCH} nativesdk-gcc-runtime"
+DEPENDS:append:class-native = " clang16-native"
+
+# Trick clang.bbclass into not creating circular dependencies
+UNWINDLIB:class-nativesdk = "--unwindlib=libgcc"
+COMPILER_RT:class-nativesdk:toolchain-clang16:runtime-llvm = "-rtlib=libgcc --unwindlib=libgcc"
+LIBCPLUSPLUS:class-nativesdk:toolchain-clang16:runtime-llvm = "-stdlib=libstdc++"
+
+CXXFLAGS += "-stdlib=libstdc++"
+LDFLAGS += "-unwindlib=libgcc -rtlib=libgcc -stdlib=libstdc++"
+BUILD_CXXFLAGS += "-stdlib=libstdc++"
+BUILD_LDFLAGS += "-unwindlib=libgcc -rtlib=libgcc -stdlib=libstdc++"
+BUILD_CPPFLAGS:remove = "-stdlib=libc++"
+BUILD_LDFLAGS:remove = "-stdlib=libc++ -lc++abi"
+
+BUILD_CC:toolchain-clang16  = "${CCACHE}clang"
+BUILD_CXX:toolchain-clang16 = "${CCACHE}clang++"
+BUILD_CPP:toolchain-clang16 = "${CCACHE}clang -E"
+BUILD_CCLD:toolchain-clang16 = "${CCACHE}clang"
+BUILD_RANLIB:toolchain-clang16 = "llvm-ranlib"
+BUILD_AR:toolchain-clang16 = "llvm-ar"
+BUILD_NM:toolchain-clang16 = "llvm-nm"
+
+PACKAGECONFIG ??= ""
+PACKAGECONFIG[crt] = "-DCOMPILER_RT_BUILD_CRT:BOOL=ON,-DCOMPILER_RT_BUILD_CRT:BOOL=OFF"
+PACKAGECONFIG[profile] ="-DCOMPILER_RT_BUILD_PROFILE=ON,-DCOMPILER_RT_BUILD_PROFILE=OFF"
+
+HF = ""
+HF:class-target = "${@ bb.utils.contains('TUNE_CCARGS_MFLOAT', 'hard', 'hf', '', d)}"
+HF[vardepvalue] = "${HF}"
+
+OECMAKE_TARGET_COMPILE = "compiler-rt"
+OECMAKE_TARGET_INSTALL = "install-compiler-rt install-compiler-rt-headers"
+OECMAKE_SOURCEPATH = "${S}/llvm"
+EXTRA_OECMAKE += "-DCMAKE_BUILD_TYPE=RelWithDebInfo \
+                  -DLLVM_ENABLE_PER_TARGET_RUNTIME_DIR=OFF \
+                  -DCOMPILER_RT_STANDALONE_BUILD=OFF \
+                  -DCOMPILER_RT_DEFAULT_TARGET_ONLY=ON \
+                  -DCOMPILER_RT_INCLUDE_TESTS=OFF \
+                  -DCMAKE_C_COMPILER_TARGET=${HOST_ARCH}${HOST_VENDOR}-${HOST_OS}${HF} \
+                  -DCOMPILER_RT_BUILD_XRAY=OFF \
+                  -DCOMPILER_RT_BUILD_SANITIZERS=OFF \
+                  -DCOMPILER_RT_BUILD_MEMPROF=OFF \
+                  -DCOMPILER_RT_BUILD_LIBFUZZER=OFF \
+                  -DLLVM_ENABLE_PROJECTS='compiler-rt' \
+                  -DLLVM_LIBDIR_SUFFIX=${LLVM_LIBDIR_SUFFIX} \
+"
+EXTRA_OECMAKE:append:class-target = "\
+               -DCMAKE_RANLIB=${STAGING_BINDIR_TOOLCHAIN}/${TARGET_PREFIX}llvm-ranlib \
+               -DCMAKE_AR=${STAGING_BINDIR_TOOLCHAIN}/${TARGET_PREFIX}llvm-ar \
+               -DCMAKE_NM=${STAGING_BINDIR_TOOLCHAIN}/${TARGET_PREFIX}llvm-nm \
+               -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+"
+
+EXTRA_OECMAKE:append:class-nativesdk = "\
+               -DCMAKE_RANLIB=${STAGING_BINDIR_TOOLCHAIN}/${TARGET_PREFIX}llvm-ranlib \
+               -DCMAKE_AR=${STAGING_BINDIR_TOOLCHAIN}/${TARGET_PREFIX}llvm-ar \
+               -DCMAKE_NM=${STAGING_BINDIR_TOOLCHAIN}/${TARGET_PREFIX}llvm-nm \
+               -DLLVM_TABLEGEN=${STAGING_BINDIR_NATIVE}/llvm-tblgen \
+               -DCLANG_TABLEGEN=${STAGING_BINDIR_NATIVE}/clang-tblgen \
+"
+EXTRA_OECMAKE:append:powerpc = " -DCOMPILER_RT_DEFAULT_TARGET_ARCH=powerpc "
+
+do_install:append () {
+    if [ -n "${LLVM_LIBDIR_SUFFIX}" ]; then
+        mkdir -p ${D}${nonarch_libdir}/clang
+        mv ${D}${libdir}/clang/${MAJOR_VER} ${D}${nonarch_libdir}/clang/${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}
+        rmdir --ignore-fail-on-non-empty ${D}${libdir}/clang ${D}${libdir}
+    else
+        mv ${D}${libdir}/clang/${MAJOR_VER} ${D}${libdir}/clang/${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}
+    fi
+}
+
+FILES_SOLIBSDEV = ""
+
+FILES:${PN} += "${nonarch_libdir}/clang/${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}/lib/linux/lib*${SOLIBSDEV} \
+                ${nonarch_libdir}/clang/${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}/*.txt \
+                ${nonarch_libdir}/clang/${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}/share/*.txt"
+FILES:${PN}-staticdev += "${nonarch_libdir}/clang/${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}/lib/linux/*.a"
+FILES:${PN}-dev += "${datadir} ${nonarch_libdir}/clang/${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}/lib/linux/*.syms \
+                    ${nonarch_libdir}/clang/${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}/include \
+                    ${nonarch_libdir}/clang/${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}/lib/linux/clang_rt.crt*.o \
+                    ${nonarch_libdir}/clang/${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}/lib/linux/libclang_rt.asan-preinit*.a"
+
+INSANE_SKIP:${PN} = "dev-so libdir"
+INSANE_SKIP:${PN}-dbg = "libdir"
+
+#PROVIDES:append:class-target = "\
+#        virtual/${TARGET_PREFIX}compilerlibs \
+#        libgcc \
+#        libgcc-initial \
+#        libgcc-dev \
+#        libgcc-initial-dev \
+#        "
+#
+
+RDEPENDS:${PN}-dev += "${PN}-staticdev"
+
+BBCLASSEXTEND = "native nativesdk"
+
+ALLOW_EMPTY:${PN} = "1"
+ALLOW_EMPTY:${PN}-dev = "1"
+
+TOOLCHAIN:forcevariable = "clang16"
+SYSROOT_DIRS:append:class-target = " ${nonarch_libdir}"

--- a/recipes-devtools/clang16/libclc16_git.bb
+++ b/recipes-devtools/clang16/libclc16_git.bb
@@ -11,7 +11,7 @@ LIC_FILES_CHKSUM = "file://libclc/LICENSE.TXT;md5=7cc795f6cbb2d801d84336b83c8017
 
 inherit cmake pkgconfig python3native qemu
 
-DEPENDS += "qemu-native clang16 spirv-tools spirv-llvm-translator spirv-llvm-translator-native ncurses"
+DEPENDS += "qemu-native clang16 spirv-tools spirv-llvm-translator-llvm16 spirv-llvm-translator-llvm16-native ncurses"
 
 OECMAKE_SOURCEPATH = "${S}/libclc"
 

--- a/recipes-devtools/clang16/libclc16_git.bb
+++ b/recipes-devtools/clang16/libclc16_git.bb
@@ -1,0 +1,48 @@
+DESCRIPTION = "LLVM based OpenCL runtime support library"
+HOMEPAGE = "http://libclc.llvm.org/"
+SECTION = "libs"
+
+require clang.inc
+require common-source.inc
+
+TOOLCHAIN = "clang16"
+
+LIC_FILES_CHKSUM = "file://libclc/LICENSE.TXT;md5=7cc795f6cbb2d801d84336b83c8017db"
+
+inherit cmake pkgconfig python3native qemu
+
+DEPENDS += "qemu-native clang16 spirv-tools spirv-llvm-translator spirv-llvm-translator-native ncurses"
+
+OECMAKE_SOURCEPATH = "${S}/libclc"
+
+EXTRA_OECMAKE += " \
+                                -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+                                -DLLVM_ENABLE_PER_TARGET_RUNTIME_DIR=OFF \
+				-DCMAKE_CROSSCOMPILING_EMULATOR=${WORKDIR}/qemuwrapper \
+				-DLLVM_CLANG=${STAGING_BINDIR_NATIVE}/clang \
+				-DLLVM_AS=${STAGING_BINDIR_NATIVE}/llvm-as \
+				-DLLVM_LINK=${STAGING_BINDIR_NATIVE}/llvm-link \
+				-DLLVM_OPT=${STAGING_BINDIR_NATIVE}/opt \
+				-DLLVM_SPIRV=${STAGING_BINDIR_NATIVE}/llvm-spirv \
+				-Dclc_comp_in:FILEPATH=${OECMAKE_SOURCEPATH}/cmake/CMakeCLCCompiler.cmake.in \
+				-Dll_comp_in:FILEPATH=${OECMAKE_SOURCEPATH}/cmake/CMakeLLAsmCompiler.cmake.in \
+				-DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+			"
+
+do_configure:prepend () {
+	# Write out a qemu wrapper that will be used by cmake
+	# so that it can run target helper binaries through that.
+	qemu_binary="${@qemu_wrapper_cmdline(d, d.getVar('STAGING_DIR_HOST'), [d.expand('${STAGING_DIR_HOST}${libdir}'),d.expand('${STAGING_DIR_HOST}${base_libdir}')])}"
+	cat > ${WORKDIR}/qemuwrapper << EOF
+#!/bin/sh
+$qemu_binary "\$@"
+EOF
+	chmod +x ${WORKDIR}/qemuwrapper
+}
+
+FILES:${PN} += "${datadir}/clc"
+
+BBCLASSEXTEND = "native nativesdk"
+
+export YOCTO_ALTERNATE_EXE_PATH
+export YOCTO_ALTERNATE_LIBDIR

--- a/recipes-devtools/clang16/libcxx16-initial_git.bb
+++ b/recipes-devtools/clang16/libcxx16-initial_git.bb
@@ -1,0 +1,115 @@
+# Copyright (C) 2015 Khem Raj <raj.khem@gmail.com>
+# Released under the MIT license (see COPYING.MIT for the terms)
+
+DESCRIPTION = "libc++ is a new implementation of the C++ standard library, targeting C++11"
+HOMEPAGE = "http://libcxx.llvm.org/"
+SECTION = "base"
+
+require clang.inc
+require common-source.inc
+
+inherit cmake cmake-native clang16 python3native
+
+PACKAGECONFIG ??= "compiler-rt exceptions ${@bb.utils.contains("RUNTIME", "llvm", "unwind unwind-shared", "", d)}"
+PACKAGECONFIG:append:armv5 = " no-atomics"
+PACKAGECONFIG:remove:class-native = "compiler-rt"
+PACKAGECONFIG[unwind] = "-DLIBCXXABI_USE_LLVM_UNWINDER=ON -DLIBCXXABI_ENABLE_STATIC_UNWINDER=ON,-DLIBCXXABI_USE_LLVM_UNWINDER=OFF,,"
+PACKAGECONFIG[exceptions] = "-DLIBCXXABI_ENABLE_EXCEPTIONS=ON -DDLIBCXX_ENABLE_EXCEPTIONS=ON,-DLIBCXXABI_ENABLE_EXCEPTIONS=OFF -DLIBCXX_ENABLE_EXCEPTIONS=OFF -DCMAKE_REQUIRED_FLAGS='-fno-exceptions',"
+PACKAGECONFIG[no-atomics] = "-D_LIBCXXABI_HAS_ATOMIC_BUILTINS=OFF -DCMAKE_SHARED_LINKER_FLAGS='-latomic',,"
+PACKAGECONFIG[compiler-rt] = "-DLIBCXX_USE_COMPILER_RT=ON -DLIBCXXABI_USE_COMPILER_RT=ON -DLIBUNWIND_USE_COMPILER_RT=ON,,compiler-rt16"
+PACKAGECONFIG[unwind-shared] = "-DLIBUNWIND_ENABLE_SHARED=ON,-DLIBUNWIND_ENABLE_SHARED=OFF,,"
+
+DEPENDS += "ninja-native"
+DEPENDS:append:class-target = " clang16-cross-${TARGET_ARCH} virtual/${MLPREFIX}libc virtual/${TARGET_PREFIX}compilerlibs"
+DEPENDS:append:class-nativesdk = " clang16-crosssdk-${SDK_ARCH} nativesdk-compiler-rt16"
+DEPENDS:append:class-native = " clang16-native"
+
+LIBCPLUSPLUS = ""
+COMPILER_RT ?= "-rtlib=compiler-rt"
+
+# Trick clang.bbclass into not creating circular dependencies
+UNWINDLIB:class-nativesdk = "--unwindlib=libgcc"
+COMPILER_RT:class-nativesdk = "-rtlib=libgcc --unwindlib=libgcc"
+LIBCPLUSPLUS:class-nativesdk = "-stdlib=libstdc++"
+
+CC:append:toolchain-clang16:class-native = " -unwindlib=libgcc -rtlib=libgcc"
+CC:append:toolchain-clang16:class-nativesdk = " -unwindlib=libgcc -rtlib=libgcc"
+
+CXXFLAGS += "-stdlib=libstdc++"
+LDFLAGS += "-unwindlib=libgcc -stdlib=libstdc++"
+BUILD_CXXFLAGS += "-stdlib=libstdc++"
+BUILD_LDFLAGS += "-unwindlib=libgcc -rtlib=libgcc -stdlib=libstdc++"
+BUILD_CPPFLAGS:remove = "-stdlib=libc++"
+BUILD_LDFLAGS:remove = "-stdlib=libc++ -lc++abi"
+
+INHIBIT_DEFAULT_DEPS = "1"
+
+LIC_FILES_CHKSUM = "file://libcxx/LICENSE.TXT;md5=55d89dd7eec8d3b4204b680e27da3953 \
+                    file://libcxxabi/LICENSE.TXT;md5=7b9334635b542c56868400a46b272b1e \
+                    file://libunwind/LICENSE.TXT;md5=f66970035d12f196030658b11725e1a1 \
+"
+
+OECMAKE_TARGET_COMPILE = "cxxabi cxx"
+OECMAKE_TARGET_INSTALL = "install-cxx install-cxxabi ${@bb.utils.contains("RUNTIME", "llvm", "install-unwind", "", d)}"
+
+OECMAKE_SOURCEPATH = "${S}/llvm"
+EXTRA_OECMAKE += "\
+                  -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+                  -DLLVM_ENABLE_PER_TARGET_RUNTIME_DIR=OFF \
+                  -DCMAKE_CROSSCOMPILING=ON \
+                  -DLLVM_TEMPORARILY_ALLOW_OLD_TOOLCHAIN=ON \
+                  -DLLVM_ENABLE_RTTI=ON \
+                  -DLIBUNWIND_ENABLE_CROSS_UNWINDING=ON \
+                  -DLIBCXX_ENABLE_STATIC_ABI_LIBRARY=ON \
+                  -DLIBCXXABI_INCLUDE_TESTS=OFF \
+                  -DLIBCXXABI_ENABLE_SHARED=ON \
+                  -DLIBCXXABI_LIBCXX_INCLUDES=${S}/libcxx/include \
+                  -DLIBCXX_CXX_ABI=libcxxabi \
+                  -DLIBCXX_CXX_ABI_INCLUDE_PATHS=${S}/libcxxabi/include \
+                  -DLIBCXX_CXX_ABI_LIBRARY_PATH=${B}/lib${LLVM_LIBDIR_SUFFIX} \
+                  -S ${S}/runtimes \
+                  -DLLVM_ENABLE_RUNTIMES='libcxx;libcxxabi;libunwind' \
+                  -DLLVM_LIBDIR_SUFFIX=${LLVM_LIBDIR_SUFFIX} \
+                  -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON \
+"
+
+EXTRA_OECMAKE:append:class-target = " \
+                  -DCMAKE_AR=${STAGING_BINDIR_TOOLCHAIN}/${AR} \
+                  -DCMAKE_NM=${STAGING_BINDIR_TOOLCHAIN}/${NM} \
+                  -DCMAKE_RANLIB=${STAGING_BINDIR_TOOLCHAIN}/${RANLIB} \
+                  -DLLVM_DEFAULT_TARGET_TRIPLE=${HOST_SYS} \
+                  -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+"
+
+EXTRA_OECMAKE:append:class-nativesdk = " \
+                  -DCMAKE_AR=${STAGING_BINDIR_TOOLCHAIN}/${AR} \
+                  -DCMAKE_NM=${STAGING_BINDIR_TOOLCHAIN}/${NM} \
+                  -DCMAKE_RANLIB=${STAGING_BINDIR_TOOLCHAIN}/${RANLIB} \
+                  -DLLVM_DEFAULT_TARGET_TRIPLE=${HOST_SYS} \
+"
+
+EXTRA_OECMAKE:append:libc-musl = " -DLIBCXX_HAS_MUSL_LIBC=ON "
+
+CXXFLAGS:append:armv5 = " -mfpu=vfp2"
+
+ALLOW_EMPTY:${PN} = "1"
+
+PROVIDES:append:runtime-llvm = " libunwind16"
+
+do_install:append() {
+    if ${@bb.utils.contains("RUNTIME", "llvm", "true", "false", d)}
+    then
+        for f in libunwind.h __libunwind_config.h unwind.h unwind_itanium.h unwind_arm_ehabi.h
+        do
+            install -Dm 0644 ${S}/libunwind/include/$f ${D}${includedir}/$f
+        done
+        install -d ${D}${libdir}/pkgconfig
+        sed -e 's,@LIBDIR@,${libdir},g;s,@VERSION@,${PV},g' ${S}/../libunwind.pc.in > ${D}${libdir}/pkgconfig/libunwind.pc
+    fi
+}
+
+PACKAGES:append:runtime-llvm = " libunwind16"
+FILES:libunwind16:runtime-llvm = "${libdir}/libunwind.so.*"
+
+BBCLASSEXTEND = "native nativesdk"
+TOOLCHAIN:forcevariable = "clang16"

--- a/recipes-devtools/clang16/llvm-project-source.inc
+++ b/recipes-devtools/clang16/llvm-project-source.inc
@@ -1,0 +1,96 @@
+deltask do_configure
+deltask do_compile
+deltask do_install
+deltask do_populate_sysroot
+deltask do_populate_lic
+RM_WORK_EXCLUDE += "${PN}"
+
+inherit nopackages
+
+PN = "llvm-project-source-${PV}"
+WORKDIR = "${TMPDIR}/work-shared/llvm-project-source-${PV}-${PR}"
+SSTATE_SWSPEC = "sstate:llvm-project-source::${PV}:${PR}::${SSTATE_VERSION}:"
+
+STAMP = "${STAMPS_DIR}/work-shared/llvm-project-source-${PV}-${PR}"
+STAMPCLEAN = "${STAMPS_DIR}/work-shared/llvm-project-source-${PV}-*"
+
+INHIBIT_DEFAULT_DEPS = "1"
+DEPENDS = ""
+PACKAGES = ""
+TARGET_ARCH = "allarch"
+TARGET_AS_ARCH = "none"
+TARGET_CC_ARCH = "none"
+TARGET_LD_ARCH = "none"
+TARGET_OS = "linux"
+baselib = "lib"
+PACKAGE_ARCH = "all"
+
+# space separated list of additional distro vendor values we want to support e.g.
+# "yoe webos" or "-yoe -webos" '-' is optional
+CLANG_EXTRA_OE_VENDORS ?= "${TARGET_VENDOR} ${SDK_VENDOR}"
+# Extra OE DISTRO that want to support as build host. space separated list of additional distro.
+# ":" separated the ID in "/etc/os-release" and the triple for finding gcc on this OE DISTRO.
+# eg: "poky:poky wrlinux:wrs"
+CLANG_EXTRA_OE_DISTRO ?= "poky:poky"
+# Match with MULTILIB_GLOBAL_VARIANTS
+MULTILIB_VARIANTS = "lib32 lib64 libx32"
+python add_distro_vendor() {
+    import subprocess
+    case = ""
+    triple = ""
+    vendors = d.getVar('CLANG_EXTRA_OE_VENDORS')
+    multilib_variants = (d.getVar("MULTILIB_VARIANTS") or "").split()
+    vendors_to_add = []
+    for vendor in vendors.split():
+        # convert -yoe into yoe
+        vendor = vendor.lstrip('-')
+        # generate possible multilib vendor names for yoe
+        # such as yoemllib32
+        vendors_to_add.extend([vendor + 'ml' + variant for variant in multilib_variants])
+        # skip oe since already part of the cpp file
+        if vendor != "oe":
+            vendors_to_add.append(vendor)
+
+    for vendor_to_add in vendors_to_add:
+        case += '\\n    .Case("' + vendor_to_add + '", Triple::OpenEmbedded)'
+        triple += ' "x86_64-' + vendor_to_add + '-linux",'
+
+    bb.note("Adding support following TARGET_VENDOR values")
+    bb.note(str(vendors_to_add))
+    bb.note("in llvm/lib/TargetParser/Triple.cpp and ${S}/clang/lib/Driver/ToolChains/Gnu.cpp")
+    cmd = d.expand("sed -i 's#//CLANG_EXTRA_OE_VENDORS_TRIPLES#%s#g' ${S}/clang/lib/Driver/ToolChains/Gnu.cpp" % (triple))
+    subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True)
+    cmd = d.expand("sed -i 's#//CLANG_EXTRA_OE_VENDORS_CASES#%s#g' -i ${S}/llvm/lib/TargetParser/Triple.cpp" % (case))
+    subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True)
+
+
+    case = ""
+    triple = ""
+    name = ""
+    check = ""
+    oe_names = ""
+    distros = d.getVar('CLANG_EXTRA_OE_DISTRO')
+    for distro in distros.split():
+        distro_id = distro.split(":")[0].replace('-','_')
+        distro_triple = distro.split(":")[1]
+        case += '\\n    .Case("' + distro_id + '", Distro::' + distro_id.upper() + ')'
+        triple += '\\n   if (Distro.Is' + distro_id.upper() + '())\\n     return "x86_64-' + distro_triple + '-linux",'
+        name += '\\n    '+ distro_id.upper() + ','
+        check += '\\nbool Is' + distro_id.upper() + '() const { return DistroVal == ' + distro_id.upper() + '; }'
+        oe_names +=  distro_id.upper() + ' ||'
+
+    check += '\\nbool IsOpenEmbedded() const { return DistroVal == ' + oe_names[0:-3] + '; }'
+
+    cmd = d.expand("sed -i 's#//CLANG_EXTRA_OE_DISTRO_NAME#%s#g' ${S}/clang/include/clang/Driver/Distro.h" % (name))
+    subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True)
+    cmd = d.expand("sed -i 's#//CLANG_EXTRA_OE_DISTRO_CHECK#%s#g' ${S}/clang/include/clang/Driver/Distro.h" % (check))
+    subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True)
+    cmd = d.expand("sed -i 's#//CLANG_EXTRA_OE_DISTRO_TRIPLES#%s#g' ${S}/clang/lib/Driver/ToolChains/Linux.cpp" % (triple))
+    subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True)
+    cmd = d.expand("sed -i 's#//CLANG_EXTRA_OE_DISTRO_CASES#%s#g' -i ${S}/clang/lib/Driver/Distro.cpp" % (case))
+    subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True)
+}
+
+do_patch[vardepsexclude] = "MULTILIBS"
+do_patch[postfuncs] += "add_distro_vendor"
+do_create_spdx[depends] += "${PN}:do_patch"

--- a/recipes-devtools/clang16/llvm16-project-source.bb
+++ b/recipes-devtools/clang16/llvm16-project-source.bb
@@ -1,0 +1,10 @@
+# Copyright (C) 2018 Khem Raj <raj.khem@gmail.com>
+# Released under the MIT license (see COPYING.MIT for the terms)
+
+SUMMARY = "This is the canonical git mirror of the LLVM subversion repository."
+HOMEPAGE = "https://github.com/llvm/llvm-project"
+
+require llvm-project-source.inc
+require clang.inc
+
+EXCLUDE_FROM_WORLD = "1"

--- a/recipes-devtools/clang16/nativesdk-clang16-glue.bb
+++ b/recipes-devtools/clang16/nativesdk-clang16-glue.bb
@@ -1,0 +1,35 @@
+# Copyright (C) 2014 Khem Raj <raj.khem@gmail.com>
+# Released under the MIT license (see COPYING.MIT for the terms)
+
+DESCRIPTION = "SDK Cross compiler wrappers for LLVM based C/C++ compiler"
+HOMEPAGE = "http://clang.llvm.org/"
+LICENSE = "Apache-2.0-with-LLVM-exception"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0-with-LLVM-exception;md5=0bcd48c3bdfef0c9d9fd17726e4b7dab"
+SECTION = "devel"
+
+inherit nativesdk
+DEPENDS += "nativesdk-clang16"
+
+do_install() {
+    install -d ${D}${prefix_nativesdk}
+    cd ${D}${prefix_nativesdk}
+    ln -s ..${libdir} .
+    ln -s ..${includedir} .
+    cd ..
+    ln -s .${base_libdir} .
+}
+
+sysroot_stage_all () {
+	sysroot_stage_dir ${D} ${SYSROOT_DESTDIR}
+}
+
+FILES:${PN} += "${prefix_nativesdk} ${base_libdir_nativesdk}"
+FILES:${PN}-dbg = ""
+
+deltask do_configure
+deltask do_compile
+deltask do_patch
+deltask do_fetch
+deltask do_unpack
+deltask do_create_spdx
+deltask do_create_runtime_spdx

--- a/recipes-devtools/clang16/openmp16_git.bb
+++ b/recipes-devtools/clang16/openmp16_git.bb
@@ -1,0 +1,65 @@
+# Copyright (C) 2017 Khem Raj <raj.khem@gmail.com>
+# Released under the MIT license (see COPYING.MIT for the terms)
+
+DESCRIPTION = "LLVM based C/C++ compiler Runtime"
+HOMEPAGE = "https://openmp.llvm.org/"
+SECTION = "libs"
+
+require clang.inc
+require common-source.inc
+
+TOOLCHAIN = "clang16"
+
+LIC_FILES_CHKSUM = "file://openmp/LICENSE.TXT;md5=d75288d1ce0450b28b8d58a284c09c79"
+
+inherit cmake pkgconfig perlnative python3native python3targetconfig
+
+DEPENDS += "elfutils libffi clang16"
+
+EXTRA_OECMAKE += "-DCMAKE_BUILD_TYPE=RelWithDebInfo \
+                  -DLLVM_ENABLE_PER_TARGET_RUNTIME_DIR=OFF \
+                  -DOPENMP_LIBDIR_SUFFIX=${@d.getVar('baselib').replace('lib', '')} \
+                  -DOPENMP_STANDALONE_BUILD=ON \
+                  -DCLANG_TOOL=${STAGING_BINDIR_NATIVE}/clang \
+                  -DLINK_TOOL=${STAGING_BINDIR_NATIVE}/llvm-link \
+                  -DOPT_TOOL=${STAGING_BINDIR_NATIVE}/opt \
+                  -DOPENMP_LLVM_LIT_EXECUTABLE=${STAGING_BINDIR_NATIVE}/llvm-lit \
+                  -DEXTRACT_TOOL=${STAGING_BINDIR_NATIVE}/llvm-extract \
+                  -DPACKAGER_TOOL=${STAGING_BINDIR_NATIVE}/clang-offload-packager \
+                  -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+                  "
+
+OECMAKE_SOURCEPATH = "${S}/openmp"
+
+PACKAGECONFIG ?= "ompt-tools offloading-plugin"
+
+PACKAGECONFIG:remove:arm = "ompt-tools offloading-plugin"
+PACKAGECONFIG:remove:powerpc = "ompt-tools offloading-plugin"
+
+PACKAGECONFIG:append:mipsarcho32 = " no-atomics"
+
+PACKAGECONFIG[ompt-tools] = "-DOPENMP_ENABLE_OMPT_TOOLS=ON,-DOPENMP_ENABLE_OMPT_TOOLS=OFF,"
+PACKAGECONFIG[aliases] = "-DLIBOMP_INSTALL_ALIASES=ON,-DLIBOMP_INSTALL_ALIASES=OFF,"
+PACKAGECONFIG[offloading-plugin] = ",,elfutils libffi,libelf libffi"
+PACKAGECONFIG[no-atomics] = "-DLIBOMP_HAVE_BUILTIN_ATOMIC=OFF -DLIBOMP_LIBFLAGS='-latomic',,"
+
+PACKAGES += "${PN}-libomptarget ${PN}-gdb-plugin"
+FILES_SOLIBSDEV = ""
+FILES:${PN} += "${libdir}/lib*${SOLIBSDEV}"
+FILES:${PN}-libomptarget = "${libdir}/libomptarget-*.bc"
+FILES:${PN}-gdb-plugin = "${datadir}/gdb/python/ompd"
+
+RDEPENDS:${PN}-gdb-plugin += "python3-core"
+
+INSANE_SKIP:${PN} = "dev-so"
+# Currently the static libraries contain buildpaths
+INSANE_SKIP:${PN}-staticdev += "buildpaths"
+
+COMPATIBLE_HOST:mips64 = "null"
+COMPATIBLE_HOST:riscv32 = "null"
+COMPATIBLE_HOST:powerpc = "null"
+
+BBCLASSEXTEND = "native nativesdk"
+
+# This appears to be specific to the Intel distribution before 2022.1
+CVE_CHECK_IGNORE += "CVE-2022-26345"

--- a/recipes-devtools/spirv-llvm-translator/spirv-llvm-translator-llvm15_git.bb
+++ b/recipes-devtools/spirv-llvm-translator/spirv-llvm-translator-llvm15_git.bb
@@ -1,0 +1,50 @@
+LICENSE = "NCSA"
+LIC_FILES_CHKSUM = "file://LICENSE.TXT;md5=47e311aa9caedd1b3abf098bd7814d1d"
+
+BRANCH = "main"
+SRC_URI = "git://github.com/KhronosGroup/SPIRV-LLVM-Translator;protocol=https;branch=${BRANCH} \
+           git://github.com/KhronosGroup/SPIRV-Headers;protocol=https;destsuffix=git/SPIRV-Headers;name=headers;branch=master \
+          "
+
+PV = "15.0.0"
+SRCREV = "1b8a00741caafac50de84f1f860b78e702722585"
+SRCREV_headers = "0bcc624926a25a2a273d07877fd25a6ff5ba1cfb"
+
+SRCREV_FORMAT = "default_headers"
+
+S = "${WORKDIR}/git"
+
+DEPENDS = "spirv-tools clang15"
+
+inherit cmake pkgconfig python3native
+
+OECMAKE_GENERATOR = "Unix Makefiles"
+
+# Specify any options you want to pass to cmake using EXTRA_OECMAKE:
+EXTRA_OECMAKE = "\
+        -DBUILD_SHARED_LIBS=ON \
+        -DLLVM_SPIRV_BUILD_EXTERNAL=YES \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+        -DCMAKE_SKIP_RPATH=ON \
+        -DLLVM_EXTERNAL_LIT=lit \
+        -DLLVM_INCLUDE_TESTS=ON \
+        -Wno-dev \
+        -DCCACHE_ALLOWED=FALSE \
+        -DLLVM_EXTERNAL_SPIRV_HEADERS_SOURCE_DIR=${S}/SPIRV-Headers \
+"
+
+do_compile:append() {
+    oe_runmake llvm-spirv
+}
+
+do_install:append() {
+    install -Dm755 ${B}/tools/llvm-spirv/llvm-spirv ${D}${bindir}/llvm-spirv
+}
+
+PACKAGES =+ "${PN}-bin"
+FILES:${PN}-bin = "${bindir}/*"
+
+BBCLASSEXTEND = "native nativesdk"
+
+EXCLUDE_FROM_WORLD = "1"

--- a/recipes-devtools/spirv-llvm-translator/spirv-llvm-translator-llvm16_git.bb
+++ b/recipes-devtools/spirv-llvm-translator/spirv-llvm-translator-llvm16_git.bb
@@ -1,0 +1,41 @@
+LICENSE = "NCSA"
+LIC_FILES_CHKSUM = "file://LICENSE.TXT;md5=47e311aa9caedd1b3abf098bd7814d1d"
+
+BRANCH = "llvm_release_160"
+SRC_URI = "git://github.com/KhronosGroup/SPIRV-LLVM-Translator;protocol=https;branch=${BRANCH} \
+           git://github.com/KhronosGroup/SPIRV-Headers;protocol=https;destsuffix=git/SPIRV-Headers;name=headers;branch=main \
+          "
+
+PV = "16.0.0+git${SRCPV}"
+SRCREV = "5fdc47b1a94dbf2ad19b3a807736ddde5173e3db"
+SRCREV_headers = "295cf5fb3bfe2454360e82b26bae7fc0de699abe"
+
+SRCREV_FORMAT = "default_headers"
+
+S = "${WORKDIR}/git"
+
+DEPENDS = "spirv-tools clang16"
+
+inherit cmake pkgconfig python3native
+
+# Specify any options you want to pass to cmake using EXTRA_OECMAKE:
+# for CMAKE_SHARED_LIBS=OFF see https://github.com/KhronosGroup/SPIRV-LLVM-Translator/issues/1868
+EXTRA_OECMAKE = "\
+        -DBASE_LLVM_VERSION=${LLVM16VERSION} \
+        -DBUILD_SHARED_LIBS=OFF \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+        -DCMAKE_SKIP_RPATH=ON \
+        -DLLVM_EXTERNAL_LIT=lit \
+        -DLLVM_INCLUDE_TESTS=ON \
+        -Wno-dev \
+        -DCCACHE_ALLOWED=FALSE \
+        -DLLVM_EXTERNAL_SPIRV_HEADERS_SOURCE_DIR=${S}/SPIRV-Headers \
+"
+
+PACKAGES =+ "${PN}-bin"
+FILES:${PN}-bin = "${bindir}/*"
+
+BBCLASSEXTEND = "native nativesdk"
+
+EXCLUDE_FROM_WORLD = "1"


### PR DESCRIPTION
This adds CLANG 15.0.7 in an almost parallel installable way.
Recipes using it must carefully tweak the dependencies to not pull in both clang and clang15

### Contributor checklist
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

This can be easily forward ported to scarthgap and master.

Fixes #869 