### PR TITLE
layer.conf: remove '-mbranch-protection=standard' globally on aarch64

### DIFF
--- a/conf/nonclangable.conf
+++ b/conf/nonclangable.conf
@@ -1,3 +1,6 @@
+# introduced in oe-core 8905639d breaks the handling of runtime exception when build with clang
+TUNE_CCARGS:remove:toolchain-clang = "${@bb.utils.contains('TUNE_FEATURES', 'aarch64', '-mbranch-protection=standard', '', d)}"
+
 # https://github.com/llvm/llvm-project/issues/78337
 TOOLCHAIN:pn-kernel-selftest = "gcc"
 

--- a/recipes-devtools/clang/libcxx_git.bb
+++ b/recipes-devtools/clang/libcxx_git.bb
@@ -41,7 +41,6 @@ BUILD_CXXFLAGS += "-stdlib=libstdc++"
 BUILD_LDFLAGS += "-unwindlib=libgcc -rtlib=libgcc -stdlib=libstdc++"
 BUILD_CPPFLAGS:remove = "-stdlib=libc++"
 BUILD_LDFLAGS:remove = "-stdlib=libc++ -lc++abi"
-TUNE_CCARGS:remove = "-mbranch-protection=standard"
 
 INHIBIT_DEFAULT_DEPS = "1"
 


### PR DESCRIPTION
On aarch64 the handling of runtime exception is broken when build with clang.
There is currently a fix for libcxx on the layer but it is not enough and this same fix needs to be applied globally.

First fix attempt just include libcxx:
https://github.com/kraj/meta-clang/issues/963
https://github.com/kraj/meta-clang/pull/968

Remaining reported issue:
https://github.com/kraj/meta-clang/issues/998

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
