### PR TITLE
qtwebengine: Use clang for native toolchain as well

### DIFF
--- a/dynamic-layers/qt6-layer/recpes-qt/qt6/qtwebengine_%.bbappend
+++ b/dynamic-layers/qt6-layer/recpes-qt/qt6/qtwebengine_%.bbappend
@@ -1,0 +1,1 @@
+inherit clang-native


### PR DESCRIPTION
This makes the chromium build less confused when mixing native compiler for gcc and target compiler for clang this does not sit well with gn build system and it starts to pass clang options to gcc, which does not always work

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
