### PR TITLE
Revert "vte: Use libstdc++ when using clang"

### DIFF
--- a/conf/nonclangable.conf
+++ b/conf/nonclangable.conf
@@ -354,8 +354,6 @@ CFLAGS:pn-pidgin-sipe:append:toolchain-clang = " -Wno-error=cast-function-type-s
 # v8 engine in nodejs moved beyong this commit
 # https://github.com/v8/v8/commit/d15d49b09dc7aef9edcc4cf6a0cb2b77a0db203f
 CXXFLAGS:pn-nodejs:append:toolchain-clang = " -Wno-error=enum-constexpr-conversion"
-# ../vte-0.78.0/src/color-test.cc:167:21: error: constexpr function never produces a constant expression [-Winvalid-constexpr]
-CXXFLAGS:pn-vte:append:toolchain-clang = " -Wno-error=invalid-constexpr"
 
 #| /usr/src/debug/ruby/2.5.1-r0/build/../ruby-2.5.1/process.c:7073: undefined reference to `__mulodi4'
 #| clang-7: error: linker command failed with exit code 1 (use -v to see invocation)
@@ -421,10 +419,6 @@ LIBCPLUSPLUS:pn-poco:toolchain-clang = "-stdlib=libstdc++"
 LIBCPLUSPLUS:pn-netdata:toolchain-clang = "-stdlib=libstdc++"
 LIBCPLUSPLUS:pn-cpp-netlib:toolchain-clang = "-stdlib=libstdc++"
 LIBCPLUSPLUS:pn-cpprest:toolchain-clang = "-stdlib=libstdc++"
-# ../vte-0.78.0/src/termprops.hh:392:31: error: no matching function for call to 'from_chars'
-#  392 |         if (auto [ptr, err] = std::from_chars(std::begin(str),
-#      |                               ^~~~~~~~~~~~~~~
-LIBCPLUSPLUS:pn-vte:toolchain-clang = "-stdlib=libstdc++"
 
 # Uses gcc for native tools, e.g. nsinstall and passes clang options which fails so
 # let same compiler ( gcc or clang) be native/cross compiler


### PR DESCRIPTION
This issue has been resolved upstream:

https://gitlab.gnome.org/GNOME/vte/-/commit/c8838779d5f8c0e03411cef9775cd8f5a10a6204

This reverts commit 70295d739f830a8d2abb2ad961e1c544f01be197.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
