### PR TITLE
u-boot: u-boot is clangable

### DIFF
--- a/conf/nonclangable.conf
+++ b/conf/nonclangable.conf
@@ -153,8 +153,6 @@ TOOLCHAIN:pn-php:mips = "gcc"
 # Workaround oe-core patching problem temporarily
 TOOLCHAIN:pn-rsync = "gcc"
 
-# U-boot does compile with clang but clang-15 crashes compiling it :(
-TOOLCHAIN:pn-u-boot = "gcc"
 TOOLCHAIN:pn-u-boot-at91 = "gcc"
 TOOLCHAIN:pn-u-boot-fslc-mfgtool = "gcc"
 TOOLCHAIN:pn-u-boot-fslc-mxsboot = "gcc"


### PR DESCRIPTION
Since clang is at version 19 now, remove the blocking of building u-boot.  I'm not seeing any issues with building u-boot and running testimage for qemuarm, qemuarm64, and qemumips.
Based on the original comment, this limitation probably should've been only applied to mips.

Leaving the BSP versions of u-boot in nonclangable, as I don't know if those have issues or not, and thought it better to err on the side of caution.