### PR TITLE
libhugetlbfs: Always use BFD linker when using clang toolchain

### DIFF
--- a/conf/nonclangable.conf
+++ b/conf/nonclangable.conf
@@ -658,6 +658,7 @@ LDFLAGS:remove:pn-bluez5:toolchain-clang = "${@bb.utils.contains('DISTRO_FEATURE
 LDFLAGS:append:pn-bluez5:toolchain-clang = "${@bb.utils.contains('DISTRO_FEATURES', 'ld-is-lld', ' -fuse-ld=bfd', '', d)}"
 
 LD:pn-gnu-efi:toolchain-clang = "${@bb.utils.contains('DISTRO_FEATURES', 'ld-is-lld', '${HOST_PREFIX}ld.bfd${TOOLCHAIN_OPTIONS} ${HOST_LD_ARCH}', '${HOST_PREFIX}ld${TOOLCHAIN_OPTIONS} ${HOST_LD_ARCH}', d)}"
+LD:pn-libhugetlbfs:toolchain-clang = "${HOST_PREFIX}ld.bfd${TOOLCHAIN_OPTIONS} ${HOST_LD_ARCH}"
 TOOLCHAIN:pn-perf = "gcc"
 
 # See https://github.com/llvm/llvm-project/issues/108262


### PR DESCRIPTION
it uses its own linker wrapper which calls LD variable in the end and expects it to be traditional GNU linker. Lets provide it what it needs.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
