### PR TITLE
Fix racing on building lib32-llvm-project-source-19.1.0 and llvm-project-source-19.1.0

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -35,5 +35,7 @@ CLANGSDK ??= "0"
 
 LLVMVERSION = "19.1.0"
 
+NON_MULTILIB_RECIPES:append = " llvm-project-source"
+
 require conf/nonclangable.conf
 require conf/nonscanable.conf

--- a/recipes-devtools/clang/llvm-project-source.bb
+++ b/recipes-devtools/clang/llvm-project-source.bb
@@ -7,4 +7,6 @@ HOMEPAGE = "https://github.com/llvm/llvm-project"
 require llvm-project-source.inc
 require clang.inc
 
+BPN = "llvm-project-source"
+
 EXCLUDE_FROM_WORLD = "1"


### PR DESCRIPTION
While enabling multilib, build lib32-llvm-project-source-19.1.0 and llvm-project-source-19.1.0 at the same time:

    $ MACHINE = "qemux86-64"
    $ require conf/multilib.conf
    $ MULTILIBS = "multilib:lib32"
    $ DEFAULTTUNE:virtclass-multilib-lib32 = "x86"
    $ bitbake lib32-llvm-project-source-19.1.0 llvm-project-source-19.1.0
    ...
    $ cat tmp/work-shared/llvm-project-source-19.1.0-r0/temp/log.task_order
    20241012-070604.819630 do_recipe_qa (2728706): log.do_recipe_qa.2728706
    20241012-070604.883194 do_recipe_qa (2728707): log.do_recipe_qa.2728707
    20241012-070605.037448 do_fetch (2728779): log.do_fetch.2728779
    20241012-070605.165280 do_fetch (2728848): log.do_fetch.2728848
    20241012-071030.798104 do_unpack (2733554): log.do_unpack.2733554
    20241012-071030.864536 do_unpack (2733559): log.do_unpack.2733559

There are two tasks for do_fetch, do_unpack and others, so there are race issues.

Both of them have the same hardcode 'llvm-project-source-' prefix in ${WORKDIR} and ${S}, explicitly disable lib32-llvm-project-source-19.1.0 for multilib

Set llvm-project-source as BPN of llvm-project-source-19.1.0

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
