### PR TITLE
ostree: Use libcc for compiler runtime when using glibc for system

### DIFF
--- a/conf/nonclangable.conf
+++ b/conf/nonclangable.conf
@@ -370,7 +370,6 @@ COMPILER_RT:remove:pn-webkitgtk:powerpc = "-rtlib=compiler-rt"
 COMPILER_RT:remove:pn-m4:armeb = "-rtlib=compiler-rt"
 COMPILER_RT:remove:pn-ruby:armeb = "-rtlib=compiler-rt"
 COMPILER_RT:remove:pn-webkitgtk:armeb = "-rtlib=compiler-rt"
-
 # build/lib/libQt5Widgets.so: undefined reference to `__lshrti3'
 # __lshrti3 is missing in libgcc
 COMPILER_RT:pn-qtbase:toolchain-clang:riscv32 = "-rtlib=compiler-rt ${UNWINDLIB}"
@@ -398,6 +397,17 @@ COMPILER_RT:pn-mpich:toolchain-clang:x86-64 = "-rtlib=libgcc --unwindlib=libgcc"
 COMPILER_RT:pn-aufs-util:libc-glibc:toolchain-clang:x86-64 = "-rtlib=libgcc --unwindlib=libgcc"
 COMPILER_RT:pn-libhugetlbfs:libc-glibc:toolchain-clang:x86-64 = "-rtlib=libgcc --unwindlib=libgcc"
 COMPILER_RT:pn-tsocks:libc-glibc:toolchain-clang:x86-64 = "-rtlib=libgcc --unwindlib=libgcc"
+# | tmp-lmp/work/corei7-64-lmp-linux/ostree/2021.6-r0/recipe-sysroot-native/usr/bin/x86_64-lmp-linux/x86_64-lmp-linux-ld: tmp-lmp/work/corei7-64-lmp-linux/ostree/2021.6-r0/recipe-sysroot//usr/lib/libc.a(printf_fp.o): in function `__printf_fp_l':
+# | /usr/src/debug/glibc/2.35-r0/git/stdio-common/printf_fp.c:388: undefined reference to `__unordtf2'
+# | tmp-lmp/work/corei7-64-lmp-linux/ostree/2021.6-r0/recipe-sysroot-native/usr/bin/x86_64-lmp-linux/x86_64-lmp-linux-ld: /usr/src/debug/glibc/2.35-r0/git/stdio-common/printf_fp.c:388: undefined reference to `__unordtf2'
+# | tmp-lmp/work/corei7-64-lmp-linux/ostree/2021.6-r0/recipe-sysroot-native/usr/bin/x86_64-lmp-linux/x86_64-lmp-linux-ld: /usr/src/debug/glibc/2.35-r0/git/stdio-common/printf_fp.c:388: undefined reference to `__letf2'
+# | tmp-lmp/work/corei7-64-lmp-linux/ostree/2021.6-r0/recipe-sysroot-native/usr/bin/x86_64-lmp-linux/x86_64-lmp-linux-ld: tmp-lmp/work/corei7-64-lmp-linux/ostree/2021.6-r0/recipe-sysroot//usr/lib/libc.a(printf_fphex.o): in function `__printf_fphex':
+# | /usr/src/debug/glibc/2.35-r0/git/stdio-common/../stdio-common/printf_fphex.c:206: undefined reference to `__unordtf2'
+# | tmp-lmp/work/corei7-64-lmp-linux/ostree/2021.6-r0/recipe-sysroot-native/usr/bin/x86_64-lmp-linux/x86_64-lmp-linux-ld: /usr/src/debug/glibc/2.35-r0/git/stdio-common/../stdio-common/printf_fphex.c:206: undefined reference to `__unordtf2'
+# | tmp-lmp/work/corei7-64-lmp-linux/ostree/2021.6-r0/recipe-sysroot-native/usr/bin/x86_64-lmp-linux/x86_64-lmp-linux-ld: /usr/src/debug/glibc/2.35-r0/git/stdio-common/../stdio-common/printf_fphex.c:206: undefined reference to `__letf2'
+# | x86_64-lmp-linux-clang -target x86_64-lmp-linux  -m64 -march=nehalem -mtune=generic -mfpmath=sse -msse4.2 -mlittle-endian --dyld-prefix=/usr -Qunused-arguments -fstack-protector-strong  -O2 -D_F
+COMPILER_RT:pn-ostree:libc-glibc:toolchain-clang:x86 = "-rtlib=libgcc --unwindlib=libgcc"
+COMPILER_RT:pn-ostree:libc-glibc:toolchain-clang:x86-64 = "-rtlib=libgcc --unwindlib=libgcc"
 
 #(unwind.o): in function `__pthread_unwind':
 #/usr/src/debug/glibc/2.29-r0/git/nptl/unwind.c:121: undefined reference to `_Unwind_ForcedUnwind'


### PR DESCRIPTION
glibc static library expects builtins from libgcc which may not exist in compiler-rt, therefore use libgcc explicitly.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
