### PR TITLE
tomlplusplus: Pin to use libstdc++ with clang

### DIFF
--- a/conf/nonclangable.conf
+++ b/conf/nonclangable.conf
@@ -417,6 +417,8 @@ LIBCPLUSPLUS:pn-poco:toolchain-clang = "-stdlib=libstdc++"
 LIBCPLUSPLUS:pn-netdata:toolchain-clang = "-stdlib=libstdc++"
 LIBCPLUSPLUS:pn-cpp-netlib:toolchain-clang = "-stdlib=libstdc++"
 LIBCPLUSPLUS:pn-cpprest:toolchain-clang = "-stdlib=libstdc++"
+# See https://lists.openembedded.org/g/openembedded-devel/topic/meta_oe_patch_2_3/108964413
+LIBCPLUSPLUS:pn-tomlplusplus:toolchain-clang = "-stdlib=libstdc++"
 
 # Uses gcc for native tools, e.g. nsinstall and passes clang options which fails so
 # let same compiler ( gcc or clang) be native/cross compiler


### PR DESCRIPTION
libc++ seems to result in test failures, perhaps something to fix in toml++ but it needs to be triaged.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
