### PR TITLE
doxygen: added to LIBCPLUSPLUS

### DIFF
--- a/conf/nonclangable.conf
+++ b/conf/nonclangable.conf
@@ -429,6 +429,7 @@ LIBCPLUSPLUS:pn-cpp-netlib:toolchain-clang = "-stdlib=libstdc++"
 LIBCPLUSPLUS:pn-cpprest:toolchain-clang = "-stdlib=libstdc++"
 # See https://lists.openembedded.org/g/openembedded-devel/topic/meta_oe_patch_2_3/108964413
 LIBCPLUSPLUS:pn-tomlplusplus:toolchain-clang = "-stdlib=libstdc++"
+LIBCPLUSPLUS:pn-doxygen:toolchain-clang = "-stdlib=libstdc++"
 
 # Uses gcc for native tools, e.g. nsinstall and passes clang options which fails so
 # let same compiler ( gcc or clang) be native/cross compiler


### PR DESCRIPTION
Hi Kraj,

I hope this is the requested change to have the new doxygen-native recipe working with clang.

@see: [meta-oe][PATCH] doxygen: version bump 1.9.3 -> 1.12.0

Could you check if it has to be `LIBCPLUSPLUS:pn-doxygen:toolchain-clang` or `pn-doxygen-native`?

I could not tested this with Yoe yet.
