### PR TITLE
openssl: Drop riscv workarounds to add libatomic

### DIFF
--- a/recipes-connectivity/openssl/openssl_%.bbappend
+++ b/recipes-connectivity/openssl/openssl_%.bbappend
@@ -1,11 +1,3 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
-LDLIBS:append:toolchain-clang:riscv64 = " -latomic"
-LDLIBS:append:toolchain-clang:riscv32 = " -latomic"
-
-do_configure:prepend:toolchain-clang:riscv64 () {
-    export LDLIBS="${LDLIBS}"
-}
-do_configure:prepend:toolchain-clang:riscv32 () {
-    export LDLIBS="${LDLIBS}"
-}
+LDFLAGS:append:toolchain-clang:riscv32 = " -Wl,--no-relax"


### PR DESCRIPTION
Additionally disable relaxation on rv32 with lld see [1]

[1] https://github.com/llvm/llvm-project/issues/113838
Signed-off-by: Khem Raj <raj.khem@gmail.com>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
