### PR TITLE
spirv-llvm-translator: update SPIRV-Headers branch from master to main

### DIFF
--- a/recipes-devtools/spirv-llvm-translator/spirv-llvm-translator_git.bb
+++ b/recipes-devtools/spirv-llvm-translator/spirv-llvm-translator_git.bb
@@ -3,7 +3,7 @@ LIC_FILES_CHKSUM = "file://LICENSE.TXT;md5=47e311aa9caedd1b3abf098bd7814d1d"
 
 BRANCH = "llvm_release_140"
 SRC_URI = "git://github.com/KhronosGroup/SPIRV-LLVM-Translator;protocol=https;branch=${BRANCH} \
-           git://github.com/KhronosGroup/SPIRV-Headers;protocol=https;destsuffix=git/SPIRV-Headers;name=headers;branch=master \
+           git://github.com/KhronosGroup/SPIRV-Headers;protocol=https;destsuffix=git/SPIRV-Headers;name=headers;branch=main \
           "
 
 PV = "14.0.0"


### PR DESCRIPTION
* branch was renamed long time ago, nanbield and newer already have this updated since: 
  2d9f57f spirv-llvm-translator: Update to latest 16.0.0 branch
  but kirkstone was still using master
