### PR TITLE
clang: remove PROVIDES:append settings

### DIFF
--- a/recipes-devtools/clang/clang_git.bb
+++ b/recipes-devtools/clang/clang_git.bb
@@ -303,9 +303,6 @@ do_install:append:class-nativesdk () {
     sed -i -e 's,${B},,g' ${D}${libdir}/cmake/llvm/LLVMConfig.cmake
 }
 
-PROVIDES:append:class-native = " llvm-native"
-PROVIDES:append:class-target = " llvm"
-
 PACKAGES =+ "${PN}-libllvm ${PN}-lldb-python ${PN}-libclang-cpp ${PN}-tidy ${PN}-format ${PN}-tools \
              libclang lldb lldb-server liblldb llvm-linker-tools"
 


### PR DESCRIPTION
With these settings, we'll have multiple providers of llvm. This means that with pristine poky master + meta-clang master, we'll have some output like below:

  NOTE: Multiple providers are available for llvm-native (llvm-native, clang-native)
  Consider defining a PREFERRED_PROVIDER entry to match llvm-native

And when running 'bitbake world', we'll get error messages like below:

  ERROR: Multiple .bb files are due to be built which each provide llvm-native:
    virtual:native:/PATH/TO/poky/meta/recipes-devtools/llvm/llvm_19.1.4.bb
    virtual:native:/PATH/TO/Yocto/poky/meta-clang/recipes-devtools/clang/clang_git.bb

As the README.md has already specified how to use this layer, let's remove such settings before sorting things out.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
