### PR TITLE
lttng-ust: Link with libatomic on 32bit x86

### DIFF
--- a/conf/nonclangable.conf
+++ b/conf/nonclangable.conf
@@ -386,6 +386,10 @@ COMPILER_RT:remove:pn-webkitgtk:armeb = "-rtlib=compiler-rt"
 COMPILER_RT:pn-qtbase:toolchain-clang:riscv32 = "-rtlib=compiler-rt ${UNWINDLIB}"
 
 LDFLAGS:append:pn-qtwebengine:toolchain-clang:runtime-gnu:x86 = " -latomic"
+
+# | i686-yoe-linux-ld.lld: error: undefined symbol: __atomic_store
+LDFLAGS:append:pn-lttng-tools:toolchain-clang:x86 = " -latomic"
+
 LDFLAGS:append:pn-qemu:toolchain-clang:x86 = " -latomic"
 # warning: <elfFile> has a LOAD segment with RWX permissions
 LDFLAGS:append:pn-ruby:toolchain-clang:powerpc = "${@bb.utils.contains('DISTRO_FEATURES', 'ld-is-lld', '', ' -Wl,--no-warn-rwx-segment', d)}"


### PR DESCRIPTION
Clang generates _atomic_store calls

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
