### PR TITLE
libslirp,avahi-libnss-mdns: Add --undefined-version to LDFLAGS with LLD

### DIFF
--- a/conf/nonclangable.conf
+++ b/conf/nonclangable.conf
@@ -667,6 +667,10 @@ LDFLAGS:append:pn-util-linux:toolchain-clang = "${@bb.utils.contains('DISTRO_FEA
 LDFLAGS:append:pn-util-linux-libuuid:toolchain-clang = "${@bb.utils.contains('DISTRO_FEATURES', 'ld-is-lld', ' -Wl,--undefined-version', '', d)}"
 # riscv64-yoe-linux-musl-ld.lld: error: version script assignment of 'global' to symbol 'pam_sm_chauthtok' failed: symbol not defined
 LDFLAGS:append:pn-libpam:toolchain-clang = "${@bb.utils.contains('DISTRO_FEATURES', 'ld-is-lld', ' -Wl,--undefined-version', '', d)}"
+# i686-yoe-linux-ld.lld: error: version script assignment of 'SLIRP_4.0' to symbol 'slirp_add_exec' failed: symbol not defined
+LDFLAGS:append:pn-libslirp:toolchain-clang = "${@bb.utils.contains('DISTRO_FEATURES', 'ld-is-lld', ' -Wl,--undefined-version', '', d)}"
+# x86_64-yoe-linux-ld.lld: error: version script assignment of 'NSSMDNS_0' to symbol '_nss_mdns_gethostbyaddr_r' failed: symbol not defined
+LDFLAGS:append:pn-avahi-libnss-mdns:toolchain-clang = "${@bb.utils.contains('DISTRO_FEATURES', 'ld-is-lld', ' -Wl,--undefined-version', '', d)}"
 TUNE_CCARGS:remove:pn-kernel-selftest:toolchain-clang = "-mfpmath=sse"
 
 # Avoid's go linker crash as reported in https://github.com/golang/go/issues/61872


### PR DESCRIPTION
LLD does not understand the linker script versioning scheme as BFD linker does

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
