### PR TITLE
[kirkstone] clang-native: install arm_neon_sve_bridge.h header

### DIFF
--- a/recipes-devtools/clang/clang/0040-Install-arm_neon_sve_bridge.h.patch
+++ b/recipes-devtools/clang/clang/0040-Install-arm_neon_sve_bridge.h.patch
@@ -1,0 +1,44 @@
+From c65c188643e963a857ca0d58a4b53529f8e98651 Mon Sep 17 00:00:00 2001
+From: Gyorgy Sarvari <skandigraun@gmail.com>
+Date: Fri, 7 Feb 2025 20:48:54 +0100
+Subject: [PATCH] [AArch64] Install arm_neon_sve_bridge.h
+
+arm_neon_sve_bridge.h is not generated, so the rules which ensure the
+generated files get copied into the installation prefix don't apply to
+this one.
+
+Add it to the base file set instead, which ensures it ends up
+both in the build directory and the installation directory.
+
+The original upstream patch needed to be adapted to version 14.0.6.
+
+Signed-off-by: Gyorgy Sarvari <skandigraun@gmail.com>
+
+Upstream-Status: Backport [https://github.com/llvm/llvm-project/commit/8cb9e3c3ce1e7e1658921f90420b68ca16bb98fc]
+---
+ clang/lib/Headers/CMakeLists.txt | 5 +----
+ 1 file changed, 1 insertion(+), 4 deletions(-)
+
+diff --git a/clang/lib/Headers/CMakeLists.txt b/clang/lib/Headers/CMakeLists.txt
+index 078988980c52..5fa7310427c6 100644
+--- a/clang/lib/Headers/CMakeLists.txt
++++ b/clang/lib/Headers/CMakeLists.txt
+@@ -7,6 +7,7 @@ set(files
+   arm_cmse.h
+   armintr.h
+   arm64intr.h
++  arm_neon_sve_bridge.h
+   avx2intrin.h
+   avx512bf16intrin.h
+   avx512bwintrin.h
+@@ -219,10 +220,6 @@ if(ARM IN_LIST LLVM_TARGETS_TO_BUILD OR AArch64 IN_LIST LLVM_TARGETS_TO_BUILD)
+   clang_generate_header(-gen-arm-mve-header arm_mve.td arm_mve.h)
+   # Generate arm_cde.h
+   clang_generate_header(-gen-arm-cde-header arm_cde.td arm_cde.h)
+-  # Copy arm_neon_sve_bridge.h
+-  copy_header_to_output_dir(${CMAKE_CURRENT_SOURCE_DIR}
+-    arm_neon_sve_bridge.h
+-  )
+ endif()
+ if(RISCV IN_LIST LLVM_TARGETS_TO_BUILD)
+   # Generate riscv_vector.h

--- a/recipes-devtools/clang/common.inc
+++ b/recipes-devtools/clang/common.inc
@@ -49,6 +49,7 @@ SRC_URI = "\
     file://0037-sanitizer-Remove-include-linux-fs.h-to-resolve-fscon.patch \
     file://0038-lldb-Get-rid-of-__STDC_LIMIT_MACROS-and-__STDC_CONST.patch \
     file://0039-lldb-Fix-error-non-const-lvalue.-caused-by-SWIG-4.1..patch \
+    file://0040-Install-arm_neon_sve_bridge.h.patch \
     "
 # Fallback to no-PIE if not set
 GCCPIE ??= ""


### PR DESCRIPTION
During building clang, arm_neon_sve_bridge.h is not copied to the correct destination folder, failing the compilation of applications using this header.

This has been fixed upstream starting in [clang 16](https://github.com/llvm/llvm-project/commit/8cb9e3c3ce1e7e1658921f90420b68ca16bb98fc). This patch is a backport of the fix, only for Kirkstone branch.

The changes have been tested by building clang-native, and using it to compile Firefox (which failed previously, due to this missing header)

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
