### PR TITLE
libmodulemd,libblockdev,webkitgtk: Disable g-i on x86-64

### DIFF
--- a/conf/nonclangable.conf
+++ b/conf/nonclangable.conf
@@ -708,8 +708,12 @@ SELECTED_OPTIMIZATION:append:pn-libjxl:arm:toolchain-clang = " -Og"
 # see https://patchwork.yoctoproject.org/project/oe-core/patch/20240923234336.3978188-1-raj.khem@gmail.com/
 GI_DATA_ENABLED:pn-vte:toolchain-clang:armv7ve = "False"
 
-# in following 4 recipes g-i fails to parse glibc 2.41 headers with clang
+# in following 4 recipes g-i fails to parse glibc 2.41 headers with clang on x86 arches
 GI_DATA_ENABLED:pn-libmodulemd:toolchain-clang:x86 = "False"
 GI_DATA_ENABLED:pn-libblockdev:toolchain-clang:x86 = "False"
 GI_DATA_ENABLED:pn-webkitgtk3:toolchain-clang:x86 = "False"
 GI_DATA_ENABLED:pn-webkitgtk:toolchain-clang:x86 = "False"
+GI_DATA_ENABLED:pn-libmodulemd:toolchain-clang:x86-64 = "False"
+GI_DATA_ENABLED:pn-libblockdev:toolchain-clang:x86-64 = "False"
+GI_DATA_ENABLED:pn-webkitgtk3:toolchain-clang:x86-64 = "False"
+GI_DATA_ENABLED:pn-webkitgtk:toolchain-clang:x86-64 = "False"


### PR DESCRIPTION
Somehow g-i parser is confused with glibc 2.41 headers on x86-64 as well when using clang, it works ok when using gcc

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
