### PR TITLE
clang: set BPN = "clang" for clang cross,crosssdk,cross-canadian recipes

### DIFF
--- a/recipes-devtools/clang/common.inc
+++ b/recipes-devtools/clang/common.inc
@@ -64,3 +64,5 @@ B ?= "${WORKDIR}/llvm-project-source-${PV}/build.${HOST_SYS}.${TARGET_SYS}"
 # The real WORKDIR location isn't a dependency for the shared workdir.
 src_patches[vardepsexclude] = "WORKDIR"
 should_apply[vardepsexclude] += "PN"
+
+BPN = "clang"

--- a/recipes-devtools/clang/compiler-rt-sanitizers_git.bb
+++ b/recipes-devtools/clang/compiler-rt-sanitizers_git.bb
@@ -10,6 +10,8 @@ SECTION = "base"
 require clang.inc
 require common-source.inc
 
+BPN = "compiler-rt-sanitizers"
+
 inherit cmake pkgconfig python3native
 
 

--- a/recipes-devtools/clang/compiler-rt_git.bb
+++ b/recipes-devtools/clang/compiler-rt_git.bb
@@ -12,6 +12,8 @@ SECTION = "base"
 require clang.inc
 require common-source.inc
 
+BPN = "compiler-rt"
+
 inherit cmake cmake-native pkgconfig python3native
 
 

--- a/recipes-devtools/clang/libclc_git.bb
+++ b/recipes-devtools/clang/libclc_git.bb
@@ -5,6 +5,8 @@ SECTION = "libs"
 require clang.inc
 require common-source.inc
 
+BPN = "libclc"
+
 TOOLCHAIN = "clang"
 
 LIC_FILES_CHKSUM = "file://libclc/LICENSE.TXT;md5=7cc795f6cbb2d801d84336b83c8017db"

--- a/recipes-devtools/clang/libcxx_git.bb
+++ b/recipes-devtools/clang/libcxx_git.bb
@@ -10,6 +10,8 @@ require common-source.inc
 
 inherit cmake cmake-native python3native
 
+BPN = "libcxx"
+
 PACKAGECONFIG ??= "compiler-rt exceptions ${@bb.utils.contains("TC_CXX_RUNTIME", "llvm", "unwind unwind-shared", "", d)}"
 PACKAGECONFIG:append:armv5 = " no-atomics"
 PACKAGECONFIG:remove:class-native = "compiler-rt"

--- a/recipes-devtools/clang/openmp_git.bb
+++ b/recipes-devtools/clang/openmp_git.bb
@@ -8,6 +8,8 @@ SECTION = "libs"
 require clang.inc
 require common-source.inc
 
+BPN = "openmp"
+
 TOOLCHAIN = "clang"
 
 LIC_FILES_CHKSUM = "file://openmp/LICENSE.TXT;md5=d75288d1ce0450b28b8d58a284c09c79"


### PR DESCRIPTION
Similar gcc recipes in oe-core [1], set BPN = "clang" in common.inc for clang cross,crosssdk,cross-canadian recipes, but the recipe compiler-rt-sanitizers, compiler-rt, libclc, libcxx, openmp which shares sources with clang are not affected

Due to commit [2], the BPN of llvm-project-source is not affected by this commit

[1] https://github.com/openembedded/openembedded-core/commit/a2c5509520d5c3e082f55844e6545d0309565f8f
[2] https://github.com/kraj/meta-clang/commit/e7517e1910a7d49abb4782fa0778f0b958f7717d

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
