### PR TITLE
fix: [Issue #1061] - check for existence before trying to process a file

### DIFF
--- a/recipes-devtools/clang/clang_git.bb
+++ b/recipes-devtools/clang/clang_git.bb
@@ -284,7 +284,9 @@ do_install:append:class-native () {
 }
 
 do_install:append:class-nativesdk () {
-    sed -i -e "s|${B}/./bin/||g" ${D}${libdir}/cmake/llvm/LLVMConfig.cmake
+    if [ -e ${D}${libdir}/cmake/llvm/LLVMConfig.cmake ] ; then
+        sed -i -e "s|${B}/./bin/||g" ${D}${libdir}/cmake/llvm/LLVMConfig.cmake
+    fi
     if ${@bb.utils.contains('PACKAGECONFIG', 'clangd', 'true', 'false', d)}; then
         install -Dm 0755 ${B}${BINPATHPREFIX}/bin/clangd-indexer ${D}${bindir}/clangd-indexer
     fi
@@ -300,7 +302,9 @@ do_install:append:class-nativesdk () {
     rm -rf ${D}${datadir}/llvm
 
     #reproducibility
-    sed -i -e 's,${B},,g' ${D}${libdir}/cmake/llvm/LLVMConfig.cmake
+    if [ -e ${D}${libdir}/cmake/llvm/LLVMConfig.cmake ] ; then
+        sed -i -e 's,${B},,g' ${D}${libdir}/cmake/llvm/LLVMConfig.cmake
+    fi
 }
 
 PACKAGES =+ "${PN}-libllvm ${PN}-lldb-python ${PN}-libclang-cpp ${PN}-tidy ${PN}-format ${PN}-tools \


### PR DESCRIPTION
### Abstract
In certain configurations LLVMConfig.cmake does not exist in the build output. If that's the case do_install breaks for the nativesdk-clang recipe.

### Reproduce
To reproduce set the following on a vanilla build:

EXTRA_OECMAKE:append:pn-nativesdk-clang = " -DLLVM_INSTALL_TOOLCHAIN_ONLY=ON"

as suggested here:

https://llvm.org/docs/BuildingADistribution.html

### Remarks
The corresponding issue #1061 blames commit f002eb5a but 716d7efb is also to blame and it is not ruled out that the problem could affect other configurations and other tasks.

**Question**: 716d7efb is from Oct. 2023 - so for a while out in the wild. But nobody seems to have similar problems like we have. If we remove the EXTRA_OECMAKE:append the build works fine. Does noone actually builds clang with the suggestd EXTRA_OECMAKE:append, or why is it that we seem to be the only ones to be affected?

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
