### PR TITLE
clang: Upgrade to 20.1.1

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -33,7 +33,7 @@ INHERIT += "clang"
 # Do not include clang in SDK unless user wants to
 CLANGSDK ??= "0"
 
-LLVMVERSION = "19.1.7"
+LLVMVERSION = "20.1.1"
 
 NON_MULTILIB_RECIPES:append = " llvm-project-source"
 

--- a/recipes-devtools/clang/clang.inc
+++ b/recipes-devtools/clang/clang.inc
@@ -5,7 +5,7 @@ LLVM_HTTP ?= "https://github.com/llvm"
 
 MAJOR_VER = "20"
 MINOR_VER = "1"
-PATCH_VER = "0"
+PATCH_VER = "1"
 # could be 'rcX' or 'git' or empty ( for release )
 VER_SUFFIX = ""
 

--- a/recipes-devtools/clang/common.inc
+++ b/recipes-devtools/clang/common.inc
@@ -15,7 +15,7 @@ LICENSE = "Apache-2.0-with-LLVM-exception"
 RELEASE ?= "${PV}"
 BASEURI ?= "${LLVM_HTTP}/llvm-project/releases/download/llvmorg-${PV}/llvm-project-${PV}.src.tar.xz"
 SOURCEDIR ?= "llvm-project-${PV}.src"
-SRC_URI[sha256sum] = "4579051e3c255fb4bb795d54324f5a7f3ef79bd9181e44293d7ee9a7f62aad9a"
+SRC_URI[sha256sum] = "4d5ebbd40ce1e984a650818a4bb5ae86fc70644dec2e6d54e78b4176db3332e0"
 
 SRC_URI = "\
     ${BASEURI} \


### PR DESCRIPTION
* 424c2d9b7e4d [libcxx] Add a missing include for __bit_iterator (#127015)
* 2cc53628fbe8 [SCEV] Check whether the start is non-zero in `ScalarEvolution::howFarToZero` (#131522)
* 0619bbcbbd86 [BPF] Add default cpu change in ReleaseNotes (#131691)
* 2dc152fb40db fix abi (again)
* 2044b18af046 fix abi
* e3f0ce3ef803 [Clang] Do not emit nodiscard warnings for the base expr of static member access (#131450)
* 0ceb4efefeaa [CUDA][HIP] fix virtual dtor host/device attr (#128926)
* 1058e693f090 [libc++][test] Skip a `is_virtual_base_of` test for apple-clang-17 (#131438)
* 1f9d00524b8c [libc++] Forward-proof some tests for AppleClang 17
* 1515c4ac202d [LAA] Consider accessed addrspace when mapping underlying obj to access. (#129087)
* 1cfbb9f33436 Backport/20.x: [Clang] Fix an incorrect assumption on getTemplatedDecl()
* 0fcfeacd8b99 [BPF] Fix BitCast Assertion with NonZero AddrSpace
* 0b23d98dceaa Reduce memory usage in AST parent map generation by lazily checking if nodes have been seen (#129934)
* 073ae08864b4  AMDGPU: Fix broken broken negative test for gfx950 assembler (#129667) (#129686)
* cb50aaf8a11b [llvm-objcopy] Apply encryptable offset to first segment, not section (#130517)
* 63e63f306128 [Clang] Fix an integer overflow issue in computing CTAD's parameter depth (#128704)
* b09b05b8e7c3 [MemCpyOpt] Fix clobber check in fca2memcpy optimization
* 64ae6413559e [SystemZ]  Move disabling of arg verification to before isFullyInternal(). (#130693)
* 548d057ebcfa [VectorCombine] scalarizeLoadExtract - don't create scalar loads if any extract is waiting to be erased (#129375)
* 7c154dad4d15 [Clang] Fix GPU intrinsic helpers incorrectly sign extending (#129560)
* 946780474f3b [libc++][test] extend XFAIL clauses to cover Amazon Linux too (#129377)
* f09bcfbdc90b [LoongArch] Relax the restrictions of inlineasm operand modifier 'u' and 'w' (#129864)
* f62b50e0e8f1 [ValueTracking] Skip incoming values that are the same as the phi in `isGuaranteedNotToBeUndefOrPoison` (#130111)
* 50343e517992 [HEXAGON] Fix hvx-isel for extract_subvector op (#129672)
* 0412f708c380 [TailDuplicator] Do not restrict the computed gotos (#114990)
* 72c4a3f419f4 [clang][test] Don't require specific alignment in test case (#130589)
* fbb2a7e74d91 [clang] Reject constexpr-unknown values as constant expressions more consistently (#129952)
* 9010db1b84ef [Clang] Treat constexpr-unknown value as invalid in `EvaluateAsInitializer` (#128409)
* 32ce5b043c2b [AArch64] Fix BE popcount casts. (#129879)
* 05be3ca72e39 [AArch64] Add BE test coverage for popcount. NFC
* 0e96713a3b29 [ValueTracking] Bail out on x86_fp80 when computing fpclass with knownbits (#130477)
* 0fda7e633255 [X86][AVX10.2] Fix unexpected larger scope (#130767)
* f7a4e3a4d45d [clang-format] Don't remove parentheses separated from ellipsis by comma (#130471)
* 1d4d84c89be6 [AArch64] Don't try to custom lower fp16 selects with nofp (#129492)
* 0064565bce3f [DAGCombiner] Don't ignore N2's undef elements in `foldVSelectOfConstants` (#129272)
* 54c90e4cdf2f [lldb] Fix manual CURSES_LIBRARIES tinfo finding (#128245)
* 712d3c7f0944 [lldb] Add terminfo dependency for ncurses support (#126810)
* 6525b151fe77 [Hexagon] Handle Call Operand vxi1 in Hexagon Backend (#128027)
* dcc378e862de [libc++] Guard <codecvt> contents on _LIBCPP_HAS_LOCALIZATION (#129112)
* 0f5e7e86e38e [SystemZ] Add header guard macros to vecintrin.h (#129170)
* 5b552d780ae8 [LV][VPlan] Prevent calculate cost for skiped instructions in precomputeCosts(). (#127966)
* 20adce87104c [libc++][ci] Update the Windows toolchains to Clang 19 (#129232)
* 0e537474ea59 Bump version to 20.1.1 (#130806)

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
