### PR TITLE
gimp: Remove -Qunused-arguments from complier cmdline with clang

### DIFF
--- a/conf/nonclangable.conf
+++ b/conf/nonclangable.conf
@@ -340,6 +340,7 @@ TUNE_CCARGS:remove:pn-tesseract:toolchain-clang = "-Qunused-arguments"
 TUNE_CCARGS:remove:pn-pulseaudio:toolchain-clang = "-Qunused-arguments"
 TUNE_CCARGS:remove:pn-btrfs-tools:toolchain-clang = "-Qunused-arguments"
 TUNE_CCARGS:append:pn-btrfs-tools:toolchain-clang = " -Werror=unused-command-line-argument"
+TUNE_CCARGS:remove:pn-gimp:toolchain-clang = "-Qunused-arguments"
 
 # Disable altivec on ppc32
 #/usr/include/eigen3/Eigen/src/Core/arch/AltiVec/PacketMath.h:1345:32: error: use of undeclared identifier 'vec_sqrt'; did you mean 'vec_rsqrt'?


### PR DESCRIPTION
This supresses the -msseX argument diagnostics on non-x86 architectures and meson wrongly decided to enable SSE on these biulds which ends up in

                                   │
│| In file included from ../gimp-3.0.2/app/gegl/gimp-gegl-loops-sse2.c:36:                                                                                                               │
│| /mnt/b/yoe/master/build/tmp/work/riscv64-yoe-linux/gimp/3.0.2/recipe-sysroot-native/usr/lib/clang/20/include/emmintrin.h:14:2: error: "This header is only meant to be used on x86 and│
│ x64 architecture"                                                                                                                                                                      │
│|    14 | #error "This header is only meant to be used on x86 and x64 architecture"                                                                                                     │
│|       |  ^                                                                                                                                                                            │
│| In file included from ../gimp-3.0.2/app/gegl/gimp-gegl-loops-sse2.c:36:

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
