### PR TITLE
layer.conf: disable conflicting LLVM PACKAGECONFIG options

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -30,6 +30,12 @@ PREFERRED_PROVIDER_libgcc-initial = "libgcc-initial"
 PREFERRED_PROVIDER_libunwind = "${@bb.utils.contains_any("TC_CXX_RUNTIME", "llvm android", "libcxx", "libunwind", d)}"
 INHERIT += "clang"
 
+# libclc and SPIRV-LLVM-Trasnaltor from OE-Core/llvm conflict with Clang from
+# meta-clang
+PACKAGECONFIG:remove:pn-llvm = "libclc spirv-llvm-translator"
+PACKAGECONFIG:remove:pn-llvm-native = "libclc spirv-llvm-translator"
+PACKAGECONFIG:remove:pn-nativesdk-llvm = "libclc spirv-llvm-translator"
+
 # Do not include clang in SDK unless user wants to
 CLANGSDK ??= "0"
 


### PR DESCRIPTION
The LLVM package in OE-Core got optional support for building libclc and SPIRV-LLVM-Translator. However this also means that llvm-native also install clang binaries into the sysroot. In order to remove a conflict with the clang recipe from meta-clang forcibly disable PACKAGECONFIG options causing conflict.

---
### Contributor checklist
- [X] Changes have been tested
- [X] `Signed-off-by` is present
- [X] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
