### PR TITLE
More fixes for meta-clang vs OE-Core

### DIFF
--- a/recipes-devtools/clang/clang/0033-llvm-Add-libunwind.pc.in-and-llvm-config-scripts.patch
+++ b/recipes-devtools/clang/clang/0033-llvm-Add-libunwind.pc.in-and-llvm-config-scripts.patch
@@ -35,7 +35,7 @@ new file mode 100644
 index 000000000000..6a0dd54b8eab
 --- /dev/null
 +++ b/llvm/tools/llvm-config/llvm-config
-@@ -0,0 +1,52 @@
+@@ -0,0 +1,55 @@
 +#!/bin/bash
 +#
 +# Wrapper script for llvm-config. Supplies the right environment variables
@@ -67,6 +67,9 @@ index 000000000000..6a0dd54b8eab
 +      ;;
 +    --cxxflags)
 +      output="${output} ${CXXFLAGS}"
++      ;;
++    --libdir)
++      output="${output} ${libdir}"
 +      ;;
 +    --ldflags)
 +      output="${output} ${LDFLAGS}"

--- a/recipes-devtools/clang/clang_git.bb
+++ b/recipes-devtools/clang/clang_git.bb
@@ -289,6 +289,20 @@ do_install:append:class-native () {
     ln -sf clang-tblgen ${D}${bindir}/clang-tblgen${PV}
     ln -sf llvm-tblgen ${D}${bindir}/llvm-tblgen${PV}
     ln -sf llvm-config ${D}${bindir}/llvm-config${PV}
+
+    if ${@ 'false' if 'llvm' in d.getVar('PROVIDES') or '' else 'true' } ; then
+        for f in bugpoint dsymutil llc lli opt reduce-chunk-list sancov sanstats verify-uselistorder ; do
+            rm -f ${D}${bindir}/$f
+        done
+        rm -f ${D}${bindir}/llvm-*
+
+        rm -rf ${D}${includedir}/llvm
+        rm -rf ${D}${includedir}/llvm-c
+        rm -rf ${D}${libdir}/cmake/llvm
+        rm -rf ${D}${libdir}/libLLVM*
+        rm -rf ${D}${libdir}/libLTO*
+        rm -rf ${D}${libdir}/libRemarks*
+    fi
 }
 
 do_install:append:class-nativesdk () {

--- a/recipes-devtools/clang/clang_git.bb
+++ b/recipes-devtools/clang/clang_git.bb
@@ -126,7 +126,7 @@ LLVM_BUILD_TOOLS;LLVM_USE_HOST_TOOLS;LLVM_CONFIG_PATH;\
 # Gennerally setting LLVM_TARGETS_TO_BUILD = "" in local.conf is ok in most simple situations
 # where only one target architecture is needed along with just one build arch (usually X86)
 #
-LLVM_TARGETS_TO_BUILD ?= "AMDGPU;AArch64;ARM;BPF;Mips;PowerPC;RISCV;X86;LoongArch"
+LLVM_TARGETS_TO_BUILD ?= "AMDGPU;AArch64;ARM;BPF;Mips;PowerPC;RISCV;X86;LoongArch;NVPTX;SPIRV"
 
 LLVM_EXPERIMENTAL_TARGETS_TO_BUILD ?= ""
 

--- a/recipes-devtools/spirv-llvm-translator/spirv-llvm-translator_git.bb
+++ b/recipes-devtools/spirv-llvm-translator/spirv-llvm-translator_git.bb
@@ -14,7 +14,7 @@ SRCREV_FORMAT = "default_headers"
 
 S = "${WORKDIR}/git"
 
-DEPENDS = "spirv-tools clang"
+DEPENDS = "spirv-tools clang llvm"
 
 inherit cmake pkgconfig python3native
 


### PR DESCRIPTION
Several more patches for meta-clang, resolving sysroot-native conflict when building Mesa with libclc

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [X] Changes have been tested
- [X] `Signed-off-by` is present
- [X] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
