### PR TITLE
clang: Upgrade to 20.1.2 release

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -39,7 +39,7 @@ PACKAGECONFIG:remove:pn-nativesdk-llvm = "libclc spirv-llvm-translator"
 # Do not include clang in SDK unless user wants to
 CLANGSDK ??= "0"
 
-LLVMVERSION = "20.1.1"
+LLVMVERSION = "20.1.2"
 
 NON_MULTILIB_RECIPES:append = " llvm-project-source"
 

--- a/recipes-devtools/clang/clang.inc
+++ b/recipes-devtools/clang/clang.inc
@@ -5,7 +5,7 @@ LLVM_HTTP ?= "https://github.com/llvm"
 
 MAJOR_VER = "20"
 MINOR_VER = "1"
-PATCH_VER = "1"
+PATCH_VER = "2"
 # could be 'rcX' or 'git' or empty ( for release )
 VER_SUFFIX = ""
 

--- a/recipes-devtools/clang/common.inc
+++ b/recipes-devtools/clang/common.inc
@@ -15,7 +15,7 @@ LICENSE = "Apache-2.0-with-LLVM-exception"
 RELEASE ?= "${PV}"
 BASEURI ?= "${LLVM_HTTP}/llvm-project/releases/download/llvmorg-${PV}/llvm-project-${PV}.src.tar.xz"
 SOURCEDIR ?= "llvm-project-${PV}.src"
-SRC_URI[sha256sum] = "4d5ebbd40ce1e984a650818a4bb5ae86fc70644dec2e6d54e78b4176db3332e0"
+SRC_URI[sha256sum] = "f0a4a240aabc9b056142d14d5478bb6d962aeac549cbd75b809f5499240a8b38"
 
 SRC_URI = "\
     ${BASEURI} \


### PR DESCRIPTION
* 58df0ef89dd6 Define LLVM_ABI and CLANG_ABI for __EMSCRIPTEN__ builds (#131578)
* e256eda15377 [LoongArch][MC] Add relocation support for fld fst [x]vld [x]vst
* ba00d9f641e9 [LoongArch] Pre-commit test for #133225
* f07f96873aa8 Backport/20.x: [LoongArch] Fix the type of tls-le symbols
* e7406753caf3 [PATCH] [clang][modules] Fix serialization and de-serialization of PCH module file refs  (#105994) (#132802)
* 2f6c5807ca7e [workflows] Add missing -y option to apt-get for abi tests (#133337)
* bc65196c0919 update test due to https://github.com/llvm/llvm-project/pull/126880 not being backported
* d6d1dbf22181 [ARM] Speedups for CombineBaseUpdate. (#129725)
* 5ba194972878 [MC,COFF] .safeseh: avoid changeSection (#132624)
* 943b43250b55 release/20.x: [clang][docs] Move -Wnontrivial-memcall to added flags. (#132367)
* 44a6f6abbdb6 [libcxx] [test] Fix restoring LLVM_DIR and Clang_DIR (#132838)
* c1c4d7191d70 [clang-format] Allow `Language: Cpp` for C files (#133033)
* 2406e0d4467a Revert "[MC] Explicitly mark MCSymbol for MO_ExternalSymbol" (#133291)
* 3d5f5ef6b784 workflows: Add missing apt-get update to abi tests (#133264)
* d1f5a9f66ee2 [hexagon] Bump the default version to v68 (#132304)
* 90cc9ca8bcb2 [Hexagon] Set the default compilation target to V68 (#125239)
* 3e2801eb634e [PowerPC] Support conversion between f16 and f128 (#130158)
* d60baf3d4786 [HEXAGON] Fix semantics of ordered FP compares (#131089)
* 1a76c29a9ba8 [hexagon] Enable --eh-frame-hdr (#130225)
* ecde8c235e5e [clang] fix matching of nested template template parameters
* c86df914dee1 release/20.x: [Clang] Fix various bugs in alias CTAD transform
* f7b6f23c6bb7 [llvm-dlltool] Add a missing dependency
* a311bc81d957 [llvm-dlltool] Implement the --identify option (#127465)
* 6034661369c4 [LoongArch] Pre-commit test for fixing tls-le symbol type
* 95763651e25c [HEXAGON] Add support to lower "FREEZE a half(f16)" instruction on Hexagon and fix the isel-buildvector-v2f16.ll assertion (#130977)
* e0e8071815c7 [hexagon] Prevent alignment search beyond a label (#130631)
* 2198410a8a8a [compiler-rt][Darwin][x86] Fix instrprof-darwin-exports test (#131425)
* 0383020b6c1a [llvm] Fix crash when complex deinterleaving operates on an unrolled loop (#129735)
* dc7b743515d3 [AArch64] Fix SVE scalar fcopysign lowering without neon. (#129787)
* fcd0ad23f668 [AArch64] Add test for scalar copysign. NFC
* 66825a89b8e0 [LLD] [COFF] Add a few more mingw libs to skip autoexports for (#132289)
* 9710e9963455 [X86][AVX10.2] Include changes for COMX and VGETEXP from rev. 2 (#132824)
* 3f957cc67cff Bump version to 20.1.2 (#132293)

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
