### PR TITLE
bcc: fix CVE-2024-2314

### DIFF
--- a/dynamic-layers/meta-python/recipes-devtools/bcc/bcc/CVE-2024-2314.patch
+++ b/dynamic-layers/meta-python/recipes-devtools/bcc/bcc/CVE-2024-2314.patch
@@ -1,0 +1,72 @@
+From 008ea09e891194c072f2a9305a3c872a241dc342 Mon Sep 17 00:00:00 2001
+From: Brendan Gregg <brendan@intel.com>
+Date: Thu, 7 Mar 2024 05:27:14 +1100
+Subject: [PATCH] clang: check header ownership (#4928)
+
+Example testing with a brendan-owned /tmp/kheaders file (note the "ERROR:" message):
+
+~/bcc/build$ sudo /usr/share/bcc/tools/biosnoop
+ERROR: header file ownership unexpected: /tmp/kheaders-5.15.47-internal
+<built-in>:1:10: fatal error: './include/linux/kconfig.h' file not found
+         ^~~~~~~~~~~~~~~~~~~~~~~~~~~
+1 error generated.
+Traceback (most recent call last):
+  File "/usr/share/bcc/tools/biosnoop", line 335, in <module>
+    b = BPF(text=bpf_text)
+  File "/usr/lib/python3/dist-packages/bcc-0.1.5+6cd27218-py3.10.egg/bcc/__init__.py", line 479, in __init__
+Exception: Failed to compile BPF module <text>
+~/bcc/build$ ls -lhd /tmp/kheaders-5.15.47-internal
+drwxrwxr-x 2 brendan dev 4.0K Mar  6 02:50 /tmp/kheaders-5.15.47-internal
+
+No error when chown'd back to root.
+
+CVE: CVE-2024-2314
+
+Upstream-Status: Backport [https://github.com/iovisor/bcc/commit/008ea09e891194c072f2a9305a3c872a241dc342]
+
+Signed-off-by: Divya Chellam <divya.chellam@windriver.com>
+---
+ src/cc/frontends/clang/kbuild_helper.cc | 15 +++++++++++----
+ 1 file changed, 11 insertions(+), 4 deletions(-)
+
+diff --git a/src/cc/frontends/clang/kbuild_helper.cc b/src/cc/frontends/clang/kbuild_helper.cc
+index 50e2da9a..d4b9d3e6 100644
+--- a/src/cc/frontends/clang/kbuild_helper.cc
++++ b/src/cc/frontends/clang/kbuild_helper.cc
+@@ -140,15 +140,22 @@ int KBuildHelper::get_flags(const char *uname_machine, vector<string> *cflags) {
+   return 0;
+ }
+
+-static inline int file_exists(const char *f)
++static inline int file_exists_and_ownedby(const char *f, uid_t uid)
+ {
+   struct stat buffer;
+-  return (stat(f, &buffer) == 0);
++  int ret;
++  if ((ret = stat(f, &buffer)) == 0) {
++    if (buffer.st_uid != uid) {
++      std::cout << "ERROR: header file ownership unexpected: " << std::string(f) << "\n";
++      return -1;
++    }
++  }
++  return ret;
+ }
+
+ static inline int proc_kheaders_exists(void)
+ {
+-  return file_exists(PROC_KHEADERS_PATH);
++  return file_exists_and_ownedby(PROC_KHEADERS_PATH, 0);
+ }
+
+ static inline const char *get_tmp_dir() {
+@@ -224,7 +231,7 @@ int get_proc_kheaders(std::string &dirpath)
+            uname_data.release);
+   dirpath = std::string(dirpath_tmp);
+
+-  if (file_exists(dirpath_tmp))
++  if (file_exists_and_ownedby(dirpath_tmp, 0))
+     return 0;
+
+   // First time so extract it
+--
+2.40.0

--- a/dynamic-layers/meta-python/recipes-devtools/bcc/bcc_0.29.1.bb
+++ b/dynamic-layers/meta-python/recipes-devtools/bcc/bcc_0.29.1.bb
@@ -25,6 +25,7 @@ SRC_URI = "gitsm://github.com/iovisor/bcc;branch=master;protocol=https \
            file://0001-CMakeLists.txt-don-t-modify-.gitconfig-on-build-host.patch \
            file://run-ptest \
            file://ptest_wrapper.sh \
+           file://CVE-2024-2314.patch \
            "
 
 SRCREV = "eb8ede2d70b17350757f2570ef76ea4c2e1dbff8"


### PR DESCRIPTION
If kernel headers need to be extracted, bcc will attempt to load them from a temporary directory. An unprivileged attacker could use this to force bcc to load compromised linux headers. Linux distributions which provide kernel headers by default are not affected by default.

Reference:
https://nvd.nist.gov/vuln/detail/CVE-2024-2314

Upstream-patch:
https://github.com/iovisor/bcc/commit/008ea09e891194c072f2a9305a3c872a241dc342

Signed-off-by: Divya Chellam <divya.chellam@windriver.com>
---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
