### PR TITLE
bpftrace: add systemd PACKAGECONFIG option

### DIFF
--- a/dynamic-layers/meta-python/recipes-devtools/bpftrace/bpftrace_0.23.0.bb
+++ b/dynamic-layers/meta-python/recipes-devtools/bpftrace/bpftrace_0.23.0.bb
@@ -26,11 +26,15 @@ SRCREV = "339a2f571505616832379ca216627aceb0e5d0bb"
 
 S = "${WORKDIR}/git"
 
-inherit bash-completion cmake ptest
+inherit bash-completion cmake ptest pkgconfig
 
-PACKAGECONFIG ?= "${@bb.utils.contains('PTEST_ENABLED', '1', 'tests', '', d)}"
+PACKAGECONFIG ?= " \
+        ${@bb.utils.contains('PTEST_ENABLED', '1', 'tests', '', d)} \
+        ${@bb.utils.contains("DISTRO_FEATURES", "systemd", "systemd", "", d)} \
+        "
 
 PACKAGECONFIG[tests] = "-DBUILD_TESTING=ON,-DBUILD_TESTING=OFF,gtest xxd-native"
+PACKAGECONFIG[systemd] = "-DENABLE_SYSTEMD=ON,-DENABLE_SYSTEMD=OFF,systemd"
 
 do_install_ptest() {
     if [ -e ${B}/tests/bpftrace_test ]; then


### PR DESCRIPTION
This option mostly enables sd_notify support and is useful when running bpftrace as part of a systemd service [1].

Defaulting to the systemd DISTRO_FEATURES seems like a reasonable choice. The official builds also now enable this by default [2].

[1] https://bpftrace.org/docs/latest#_systemd_support
[2] https://github.com/bpftrace/bpftrace/pull/3969

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
