### PR TITLE
bpftrace: update SRCREV to tag 0.23.0

### DIFF
--- a/dynamic-layers/meta-python/recipes-devtools/bpftrace/bpftrace_0.23.0.bb
+++ b/dynamic-layers/meta-python/recipes-devtools/bpftrace/bpftrace_0.23.0.bb
@@ -22,7 +22,7 @@ SRC_URI = "git://github.com/iovisor/bpftrace;branch=release/0.23.x;protocol=http
            file://run-ptest \
            file://0002-CMakeLists.txt-allow-to-set-BISON_FLAGS-like-l.patch \
 "
-SRCREV = "339a2f571505616832379ca216627aceb0e5d0bb"
+SRCREV = "01e806d24c61f996f1809e1e991646311499db4f"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Update SRCREV to tag 0.23.0, refer [1]

[1] https://github.com/bpftrace/bpftrace/releases/tag/v0.23.0

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
