### PR TITLE
clang: Update dependencies for cross-compilation support

### DIFF
--- a/recipes-devtools/clang/clang-cross-canadian_git.bb
+++ b/recipes-devtools/clang/clang-cross-canadian_git.bb
@@ -12,7 +12,7 @@ require clang.inc
 require common-source.inc
 inherit cross-canadian
 
-DEPENDS += "nativesdk-clang binutils-cross-canadian-${TRANSLATED_TARGET_ARCH} virtual/nativesdk-cross-binutils virtual/nativesdk-libc"
+DEPENDS += "nativesdk-clang binutils-cross-canadian-${TRANSLATED_TARGET_ARCH} ${@bb.utils.contains_any('LAYERSERIES_CORENAMES', 'scarthgap styhead', 'virtual/${HOST_PREFIX}binutils', 'virtual/nativesdk-cross-binutils', d)} virtual/nativesdk-libc"
 # We have to point gcc at a sysroot but we don't need to rebuild if this changes
 # e.g. we switch between different machines with different tunes.
 EXTRA_OECONF_PATHS[vardepsexclude] = "TUNE_PKGARCH"

--- a/recipes-devtools/clang/clang-crosssdk_git.bb
+++ b/recipes-devtools/clang/clang-crosssdk_git.bb
@@ -11,7 +11,7 @@ PN = "clang-crosssdk-${SDK_SYS}"
 require clang.inc
 require common-source.inc
 inherit crosssdk
-DEPENDS += "clang-native nativesdk-clang-glue virtual/nativesdk-cross-binutils virtual/nativesdk-libc"
+DEPENDS += "clang-native nativesdk-clang-glue ${@bb.utils.contains_any('LAYERSERIES_CORENAMES', 'scarthgap styhead', 'virtual/${TARGET_PREFIX}binutils', 'virtual/nativesdk-cross-binutils', d)} virtual/nativesdk-libc"
 
 do_install() {
         install -d ${D}${bindir}

--- a/recipes-devtools/clang/clang_git.bb
+++ b/recipes-devtools/clang/clang_git.bb
@@ -214,7 +214,7 @@ EXTRA_OECMAKE:append:class-target = "\
 "
 
 DEPENDS = "binutils zlib zstd libffi libxml2 libxml2-native ninja-native swig-native"
-DEPENDS:append:class-nativesdk = " clang-crosssdk-${SDK_SYS} virtual/nativesdk-cross-binutils nativesdk-python3"
+DEPENDS:append:class-nativesdk = " clang-crosssdk-${SDK_SYS} ${@bb.utils.contains_any('LAYERSERIES_CORENAMES', 'scarthgap styhead', 'virtual/${HOST_PREFIX}binutils', 'virtual/nativesdk-cross-binutils', d)} nativesdk-python3"
 DEPENDS:append:class-target = " clang-cross-${TARGET_ARCH} python3 compiler-rt libcxx"
 
 RRECOMMENDS:${PN} = "binutils"


### PR DESCRIPTION
Modify `clang_git.bb`, `clang-cross-canadian_git.bb` and `clang-crosssdk_git.bb` to conditionally depend on `virtual/${HOST_PREFIX}binutils` or `virtual/${TARGET_PREFIX}binutils` for `scarthgap` and `styhead` layers.

This prevents `Nothing PROVIDES 'virtual/nativesdk-cross-binutils'` in old but still compatible layers as `scarthgap` and `styhead`.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
