### PR TITLE
bcc: export BCC_KERNEL_SOURCE in run-ptest

### DIFF
--- a/dynamic-layers/meta-python/recipes-devtools/bcc/bcc/run-ptest
+++ b/dynamic-layers/meta-python/recipes-devtools/bcc/bcc/run-ptest
@@ -17,6 +17,29 @@ print_test_result() {
     fi
 }
 
+ARCH=$(uname -m)
+
+case "$ARCH" in
+  x86_64)
+    KDIR="x86"
+    ;;
+  riscv64)
+    KDIR="riscv"
+    ;;
+  aarch64)
+    KDIR="arm64"
+    ;;
+  powerpc64le | ppc64le)
+    KDIR="powerpc"
+    ;;
+  *)
+    echo "Architecture not present, Add the architecture in run-ptest: $ARCH"
+    exit 1
+    ;;
+esac
+
+export BCC_KERNEL_SOURCE="/usr/src/kernel/arch/$KDIR"
+
 # Run CC tests, set IFS as test names have spaces
 IFS=$(printf '\n\t')
 for test_name in $(./cc/test_libbcc_no_libbpf --list-test-names-only); do


### PR DESCRIPTION
when running ptest for bcc we need to
export BCC_KERNEL_SOURCE to resolve test errors.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
