### PR TITLE
Revert "Drop crosssdk suffix from virtual binutils provides to match oe-core"

### DIFF
--- a/recipes-devtools/clang/clang-cross-canadian_git.bb
+++ b/recipes-devtools/clang/clang-cross-canadian_git.bb
@@ -12,7 +12,7 @@ require clang.inc
 require common-source.inc
 inherit cross-canadian
 
-DEPENDS += "nativesdk-clang binutils-cross-canadian-${TRANSLATED_TARGET_ARCH} virtual/${HOST_PREFIX}binutils virtual/nativesdk-libc"
+DEPENDS += "nativesdk-clang binutils-cross-canadian-${TRANSLATED_TARGET_ARCH} virtual/${HOST_PREFIX}binutils-crosssdk virtual/nativesdk-libc"
 # We have to point gcc at a sysroot but we don't need to rebuild if this changes
 # e.g. we switch between different machines with different tunes.
 EXTRA_OECONF_PATHS[vardepsexclude] = "TUNE_PKGARCH"

--- a/recipes-devtools/clang/clang-crosssdk_git.bb
+++ b/recipes-devtools/clang/clang-crosssdk_git.bb
@@ -11,7 +11,7 @@ PN = "clang-crosssdk-${TARGET_ARCH}"
 require clang.inc
 require common-source.inc
 inherit crosssdk
-DEPENDS += "clang-native nativesdk-clang-glue virtual/${TARGET_PREFIX}binutils virtual/nativesdk-libc"
+DEPENDS += "clang-native nativesdk-clang-glue virtual/${TARGET_PREFIX}binutils-crosssdk virtual/nativesdk-libc"
 
 do_install() {
         install -d ${D}${bindir}

--- a/recipes-devtools/clang/clang_git.bb
+++ b/recipes-devtools/clang/clang_git.bb
@@ -202,7 +202,7 @@ EXTRA_OECMAKE:append:class-target = "\
 "
 
 DEPENDS = "binutils zlib zstd libffi libxml2 libxml2-native ninja-native swig-native"
-DEPENDS:append:class-nativesdk = " clang-crosssdk-${SDK_ARCH} virtual/${TARGET_PREFIX}binutils nativesdk-python3"
+DEPENDS:append:class-nativesdk = " clang-crosssdk-${SDK_ARCH} virtual/${TARGET_PREFIX}binutils-crosssdk nativesdk-python3"
 DEPENDS:append:class-target = " clang-cross-${TARGET_ARCH} python3 compiler-rt libcxx"
 
 RRECOMMENDS:${PN} = "binutils"


### PR DESCRIPTION
This reverts commit e7b3acb82f4c4422e57884ad9427fba6bd020e8b.

This change was originally made in scarthgap and later backported to kirkstone-clang18. However, oe-core kirkstone still uses 'virtual/${TARGET_PREFIX}binutils-crosssdk'.

Reverting to maintain compatibility with oe-core kirkstone.

Signed-off-by: Soumya Sambu <soumya.sambu@windriver.com>
---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
