### PR TITLE
bcc: Backport fix tests to support finish_task_switch.isra.* suffix

### DIFF
--- a/dynamic-layers/meta-python/recipes-devtools/bcc/bcc/support_finish_task_switch_isra_0.patch
+++ b/dynamic-layers/meta-python/recipes-devtools/bcc/bcc/support_finish_task_switch_isra_0.patch
@@ -1,0 +1,49 @@
+Upstream-Status: Backport [https://github.com/iovisor/bcc/pull/5302/commits/b24519e1ba7b87c9676ae3a7f70772215cd5819d]
+Signed-off-by: Harish Sadineni <Harish.Sadineni@windriver.com>
+
+diff --git a/tests/python/test_histogram.py b/tests/python/test_histogram.py
+--- a/tests/python/test_histogram.py
++++ b/tests/python/test_histogram.py
+@@ -64,7 +64,7 @@
+ #include <linux/version.h>
+ typedef struct { char name[TASK_COMM_LEN]; u64 slot; } Key;
+ BPF_HISTOGRAM(hist1, Key, 1024);
+-int kprobe__finish_task_switch(struct pt_regs *ctx, struct task_struct *prev) {
++int count_prev_task_start_time(struct pt_regs *ctx, struct task_struct *prev) {
+ #if LINUX_VERSION_CODE < KERNEL_VERSION(5,5,0)
+     Key k = {.slot = bpf_log2l(prev->real_start_time)};
+ #else
+@@ -77,6 +77,10 @@
+     return 0;
+ }
+ """)
++        b.attach_kprobe(
++            event_re=r'^finish_task_switch$|^finish_task_switch\.isra\.\d$',
++            fn_name=b"count_prev_task_start_time"
++        )
+         for i in range(0, 100): time.sleep(0.01)
+         b[b"hist1"].print_log2_hist()
+         b.cleanup()
+diff --git a/tests/python/test_clang.py b/tests/python/test_clang.py
+--- a/tests/python/test_clang.py
++++ b/tests/python/test_clang.py
+@@ -399,7 +399,7 @@
+   u32 curr_pid;
+ };
+ BPF_HASH(stats, struct key_t, u64, 1024);
+-int kprobe__finish_task_switch(struct pt_regs *ctx, struct task_struct *prev) {
++int count_sched(struct pt_regs *ctx, struct task_struct *prev) {
+   struct key_t key = {};
+   u64 zero = 0, *val;
+   key.curr_pid = bpf_get_current_pid_tgid();
+@@ -412,6 +412,10 @@
+   return 0;
+ }
+ """)
++        b.attach_kprobe(
++            event_re=r'^finish_task_switch$|^finish_task_switch\.isra\.\d$',
++            fn_name=b"count_sched"
++        )
+ 
+     def test_probe_simple_assign(self):
+         b = BPF(text=b"""

--- a/dynamic-layers/meta-python/recipes-devtools/bcc/bcc_0.33.0.bb
+++ b/dynamic-layers/meta-python/recipes-devtools/bcc/bcc_0.33.0.bb
@@ -25,6 +25,7 @@ SRC_URI = "gitsm://github.com/iovisor/bcc;branch=master;protocol=https \
            file://run-ptest \
            file://ptest_wrapper.sh \
            file://bpf_stack_id.patch \
+           file://support_finish_task_switch_isra_0.patch \
            "
 
 SRCREV = "92e32ff8a06616779f3a3191b75da6881d59fd17"


### PR DESCRIPTION
When running on kernels compiled with GCC 11.4, the py_test_clang and
 py_test_histogram tests fail because the finish_task_switch function
changed to finish_task_switch.isra.0.

Upstream-Status: Backport [https://github.com/iovisor/bcc/pull/5302/commits/b24519e1ba7b87c9676ae3a7f70772215cd5819d]

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
