### PR TITLE
castxml/include-what-you-use: remove incorrect S settings

### DIFF
--- a/recipes-devtools/castxml/castxml_0.6.11.bb
+++ b/recipes-devtools/castxml/castxml_0.6.11.bb
@@ -6,8 +6,6 @@ SRC_URI = "git://github.com/CastXML/CastXML;protocol=https;branch=master"
 
 SRCREV = "f38c024b395187814f14f77974d8f5240bb2e71f"
 
-S = "${WORKDIR}/git"
-
 DEPENDS = "clang"
 inherit cmake pkgconfig python3native
 

--- a/recipes-devtools/include-what-you-use/include-what-you-use_0.23.bb
+++ b/recipes-devtools/include-what-you-use/include-what-you-use_0.23.bb
@@ -15,8 +15,6 @@ SRCREV = "fa1094c0b3848f82244778bc6153cc84f8a890f6"
 
 PV .= "+git"
 
-S = "${WORKDIR}/git"
-
 inherit cmake python3native
 
 EXTRA_OECMAKE = "-DIWYU_RESOURCE_RELATIVE_TO=iwyu"


### PR DESCRIPTION
Due to recent UNPACKDIR/S change in oe-core, the S settings in these two recipes are no longer valid and are causing errors. Remove them.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
