### PR TITLE
Revert "clang.bbclass: remove mcpu option with qualifiers for the octeontx2 core"

### DIFF
--- a/classes/clang.bbclass
+++ b/classes/clang.bbclass
@@ -56,7 +56,7 @@ TUNE_CCARGS:append:toolchain-clang = "${@bb.utils.contains_any("TUNE_FEATURES", 
 TUNE_CCARGS_MARCH_OPTS:append:toolchain-clang = "${@bb.utils.contains_any("DEFAULTTUNE", "cortexa72 cortexa53", "+nocrypto", "", d)}"
 
 # Clang does not support octeontx2 processor
-TUNE_CCARGS:remove:toolchain-clang = "-mcpu=octeontx2${TUNE_CCARGS_MARCH_OPTS}"
+TUNE_CCARGS:remove:toolchain-clang = "-mcpu=octeontx2"
 
 # Reconcile some ppc anamolies
 TUNE_CCARGS:remove:toolchain-clang:powerpc = "-mhard-float -mno-spe"


### PR DESCRIPTION
This reverts commit 4e0da29d9bca9ab7091abcbb59dd439c09319ca8.

This commit was backported from scarthgap to kirkstone-clang18 and is incompatible with oe-core kirkstone tune configuration. Reverting to align with oe-core.

Signed-off-by: Soumya Sambu <soumya.sambu@windriver.com>
---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
