### PR TITLE
Revert "clang: Do not provide llvm-native implicitly"

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,20 +57,6 @@ TOOLCHAIN = "clang"
 also look at `conf/nonclangable.conf` for list of recipes which do not yet fully
 build with clang.
 
-# Providing LLVM
-
-clang recipes can provide llvm and related packages too, it might be worth using single
-provider for llvm and clang to save some compile time and space, select the knobs
-to point to clang, default is to use the version provided by core layer.
-
-```shell
-PREFERRED_PROVIDER_llvm = "clang"
-PREFERRED_PROVIDER_llvm-native = "clang-native"
-PREFERRED_PROVIDER_nativesdk-llvm = "nativesdk-clang"
-PROVIDES:pn-clang = "llvm"
-PROVIDES:pn-clang-native = "llvm-native"
-PROVIDES:pn-nativesdk-clang = "nativesdk-llvm"
-```
 # Default Compiler Runtime
 
 Default is to use GNU runtime `TC_CXX_RUNTIME = "gnu"` which consists of libgcc, libstdc++ to provide C/C++

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -27,6 +27,9 @@ BBFILES_DYNAMIC += " \
 
 PREFERRED_PROVIDER_libgcc-initial = "libgcc-initial"
 #PREFERRED_PROVIDER_virtual/${TARGET_PREFIX}compilerlibs_forcevariable = "libcxx"
+PREFERRED_PROVIDER_llvm = "clang"
+PREFERRED_PROVIDER_llvm-native = "clang-native"
+PREFERRED_PROVIDER_nativesdk-llvm = "nativesdk-clang"
 PREFERRED_PROVIDER_libunwind = "${@bb.utils.contains_any("TC_CXX_RUNTIME", "llvm android", "libcxx", "libunwind", d)}"
 INHERIT += "clang"
 

--- a/recipes-devtools/clang/clang_git.bb
+++ b/recipes-devtools/clang/clang_git.bb
@@ -287,6 +287,9 @@ do_install:append:class-nativesdk () {
 PACKAGES =+ "${PN}-libllvm ${PN}-lldb-python ${PN}-libclang-cpp ${PN}-tidy ${PN}-format ${PN}-tools \
              libclang lldb lldb-server liblldb llvm-linker-tools"
 
+PROVIDES += "llvm llvm${PV}"
+PROVIDES:append:class-native = " llvm-native"
+
 BBCLASSEXTEND = "native nativesdk"
 
 RDEPENDS:lldb += "${PN}-lldb-python lldb-server"


### PR DESCRIPTION
This reverts commit 384e8d169a2c408e2cef03ea2deb88fb82058011.

The original commit removed the implicit PROVIDES declarations for llvm, llvm-native, and nativesdk-llvm from the clang recipe.

However, this change breaks builds in kirkstone-clang18 environments, where mesa and lib32-llvm expect these to be provided by clang:

- Mesa fails due to missing providers for llvm18.1.6 and nativesdk-llvm18.1.6.
- lib32-llvm 13.0.1 fails on ARM BSPs with the following error, falling back to the core layer's outdated LLVM:

    error: 'RegVT' was not declared in this scope

This commit was backported from scarthgap, but it is incompatible with oe-core expectations in the kirkstone branch. Reverting it restores compatibility.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
