### PR TITLE
compiler-rt-sanitizers: disable builtins library

### DIFF
--- a/recipes-devtools/clang/compiler-rt-sanitizers_git.bb
+++ b/recipes-devtools/clang/compiler-rt-sanitizers_git.bb
@@ -50,6 +50,10 @@ EXTRA_OECMAKE += "-DCMAKE_BUILD_TYPE=RelWithDebInfo \
                   -DLLVM_LIBDIR_SUFFIX=${LLVM_LIBDIR_SUFFIX} \
 "
 
+EXTRA_OECMAKE:append:class-native = "\
+               -DCOMPILER_RT_USE_BUILTINS_LIBRARY=OFF \
+"
+
 EXTRA_OECMAKE:append:class-nativesdk = "\
                -DCMAKE_RANLIB=${STAGING_BINDIR_TOOLCHAIN}/${TARGET_PREFIX}llvm-ranlib \
                -DCMAKE_AR=${STAGING_BINDIR_TOOLCHAIN}/${TARGET_PREFIX}llvm-ar \


### PR DESCRIPTION
Currently compiler-rt-sanitizers fails to build as native recipe. Configuration log shows:
-- Compiler-RT supported architectures: x86_64
-- Failed to find compiler-rt builtins library for x86_64-linux

The reasons is that calling
`clang --rtlib=compiler-rt -print-libgcc-file-name`
returns (tested in devshell and via additional cmake logs)
`/usr/lib/clang/18.1.6/lib/linux/libclang_rt.builtins-x86_64.a`
which is missing the recipe-sysroot-native prefix.

COMPILER_RT_USE_BUILTINS_LIBRARY=OFF is implemented in kirkstone and also in master (in core). Note that when moving clang from meta-clang to core, I didn't find explanation why this was changed back, but I assume that it was because of issues like this.

When running
`clang --rtlib=compiler-rt -print-libgcc-file-name`
on master, it correctly returns the sysroot prefix. However re-enabling builtins still results in a failure because on my system it also detects i386 multilib which then fails.

Alternative which works (at least in Debian 11) is following:
```
EXTRA_OECMAKE:append:class-native = "\
    -DCOMPILER_RT_LIBRARY_builtins_${BUILD_SYS}=${STAGING_LIBDIR_NATIVE}/clang/${PV}/lib/linux/libclang_rt.builtins-${BUILD_ARCH}.a \
    -DCOMPILER_RT_LIBRARY_builtins_=${STAGING_LIBDIR_NATIVE}/clang/${PV}/lib/linux/libclang_rt.builtins-${BUILD_ARCH}.a \
"
```
However seeing failures on master, it's uncertain if it fixes all corner cases.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
