### PR TITLE
python3-pyside6: Remove due to being missing from meta-qt6 dev

### DIFF
--- a/dynamic-layers/qt6-layer/recipes-qt/qt6/python3-pyside6_%.bbappend
+++ b/dynamic-layers/qt6-layer/recipes-qt/qt6/python3-pyside6_%.bbappend
@@ -1,1 +1,0 @@
-EXCLUDE_FROM_WORLD = "1"


### PR DESCRIPTION
The recipe being bbappended is not supported in meta-qt6 until later in a stable versions life cycle.  This has the effect that in the most recent version branches (6.10 as of this commit) does not have the required recipe to bbappend, and dev will never have the recipe.  This causes a parsing error when using these more up to date branches:

ERROR: No recipes in default available for:
  .../meta-clang/dynamic-layers/qt6-layer/recipes-qt/qt6/python3-pyside6_%.bbappend

Given this, we should drop this bbappend and try to address the build failure in world another way.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
