### PR TITLE
bcc: Fix for test tools_memleak.py

### DIFF
--- a/dynamic-layers/meta-python/recipes-devtools/bcc/bcc/fix_for_memleak.patch
+++ b/dynamic-layers/meta-python/recipes-devtools/bcc/bcc/fix_for_memleak.patch
@@ -1,0 +1,16 @@
+Upstream-Status: Submitted [https://github.com/iovisor/bcc/pull/5355]
+Signed-off-by: Harish Sadineni <Harish.Sadineni@windriver.com>
+
+diff --git a/tests/python/test_tools_memleak.py b/tests/python/test_tools_memleak.py
+--- a/tests/python/test_tools_memleak.py       
++++ b/tests/python/test_tools_memleak.py   
+@@ -26,7 +26,7 @@
+     # Build the memory leaking application.
+     c_src = 'test_tools_memleak_leaker_app.c'
+     tmp_dir = tempfile.mkdtemp(prefix='bcc-test-memleak-')
+-    c_src_full = os.path.dirname(sys.argv[0]) + os.path.sep + c_src
++    c_src_full = os.path.abspath(os.path.dirname(sys.argv[0])) + os.path.sep + c_src
+     exec_dst = tmp_dir + os.path.sep + 'leaker_app'
+
+     if subprocess.call(['gcc', '-g', '-O0', '-o', exec_dst, c_src_full]) != 0:
+

--- a/dynamic-layers/meta-python/recipes-devtools/bcc/bcc_0.33.0.bb
+++ b/dynamic-layers/meta-python/recipes-devtools/bcc/bcc_0.33.0.bb
@@ -16,7 +16,7 @@ DEPENDS += "bison-native \
             "
 
 RDEPENDS:${PN} += "bash python3 python3-core python3-setuptools xz"
-RDEPENDS:${PN}-ptest = "kernel-devsrc packagegroup-core-buildessential cmake python3 python3-netaddr python3-pyroute2"
+RDEPENDS:${PN}-ptest = "kernel-devsrc packagegroup-core-buildessential cmake bash python3 python3-netaddr python3-pyroute2"
 
 SRC_URI = "gitsm://github.com/iovisor/bcc;branch=master;protocol=https \
            file://0001-CMakeLists.txt-override-the-PY_CMD_ESCAPED.patch \
@@ -26,6 +26,7 @@ SRC_URI = "gitsm://github.com/iovisor/bcc;branch=master;protocol=https \
            file://ptest_wrapper.sh \
            file://bpf_stack_id.patch \
            file://support_finish_task_switch_isra_0.patch \
+           file://fix_for_memleak.patch \
            "
 
 SRCREV = "92e32ff8a06616779f3a3191b75da6881d59fd17"
@@ -71,10 +72,16 @@ do_install_ptest() {
     cp -rf ${S}/tests/python ${D}${PTEST_PATH}/tests/python
     install ${UNPACKDIR}/ptest_wrapper.sh ${D}${PTEST_PATH}/tests
     install ${S}/examples/networking/simulation.py ${D}${PTEST_PATH}/tests/python
+    find ${B}/../sources/bcc-0.33.0+git/tools/ -type f -name "*.py" -exec \
+    sed -i \
+    -e 's@^#! */usr/bin/env python$@#!/usr/bin/env python3@' \
+    -e 's@^#! */usr/bin/python.*@#!/usr/bin/env python3@' {} +
+    cp -rf ${B}/../sources/bcc-0.33.0+git/tools/ ${D}${PTEST_PATH}/../../tools/
 }
 
 FILES:${PN} += "${PYTHON_SITEPACKAGES_DIR}"
 FILES:${PN} += "${B}/tests/cc"
+FILES:${PN}-ptest += "${libdir}/tools/"
 FILES:${PN}-ptest += "/opt/"
 FILES:${PN}-doc += "${datadir}/${PN}/man"
 


### PR DESCRIPTION
Fixes tools_memleak.py which is getting failed due to "c_src_full = os.path.dirname(sys.argv[0]) + os.path.sep + c_src" is giving "/'test_tools_memleak_leaker_app.c".

memleak.py and other test cases requires bcc tools so copying the tools to image.

Upstream-Status: Submitted [https://github.com/iovisor/bcc/pull/5355]

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
