### PR TITLE
bcc: include libbcc.so in ptest package

### DIFF
--- a/dynamic-layers/meta-python/recipes-devtools/bcc/bcc_0.35.0.bb
+++ b/dynamic-layers/meta-python/recipes-devtools/bcc/bcc_0.35.0.bb
@@ -76,6 +76,7 @@ do_install_ptest() {
 
 FILES:${PN} += "${PYTHON_SITEPACKAGES_DIR}"
 FILES:${PN} += "${B}/tests/cc"
+FILES:${PN}-ptest += "${libdir}/libbcc.so"
 FILES:${PN}-ptest += "${libdir}/tools/"
 FILES:${PN}-ptest += "/opt/"
 FILES:${PN}-doc += "${datadir}/${PN}/man"


### PR DESCRIPTION
Added ${libdir}/libbcc.so to FILES:${PN}-ptest to ensure it is included during ptest execution. This is necessary for the test "resolve symbol addresses for a given PID", which requires libbcc.so to be available in the runtime environment.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
