### PR TITLE
Backport bcc patches from master to walnascar to fix bcc ptest failures

### DIFF
--- a/dynamic-layers/meta-python/recipes-devtools/bcc/bcc/bpf_stack_id.patch
+++ b/dynamic-layers/meta-python/recipes-devtools/bcc/bcc/bpf_stack_id.patch
@@ -1,0 +1,13 @@
+Upstream-Status: Backport [https://github.com/iovisor/bcc/pull/5292/commits/d23df413a1959e9dcb1446ec5a583b5a22307b70]
+Signed-off-by: Harish Sadineni <Harish.Sadineni@windriver.com>
+
+--- a/tests/cc/test_bpf_table.cc
++++ b/tests/cc/test_bpf_table.cc
+@@ -260,6 +260,7 @@
+   /* libc locations on different distributions are added below*/
+   bpf.add_module("/lib/x86_64-linux-gnu/libc.so.6"); //Location of libc in ubuntu
+   bpf.add_module("/lib64/libc.so.6"); //Location of libc fedora machine
++  bpf.add_module("/lib/libc.so.6");//location of libc in image
+
+   int stack_id = id[0];
+   REQUIRE(stack_id >= 0);

--- a/dynamic-layers/meta-python/recipes-devtools/bcc/bcc/fix_for_memleak.patch
+++ b/dynamic-layers/meta-python/recipes-devtools/bcc/bcc/fix_for_memleak.patch
@@ -1,0 +1,16 @@
+Upstream-Status: Backport [https://github.com/iovisor/bcc/pull/5355/commits/a36d733592f28ea3e46ba59c2b7a50903d57dd8c]
+Signed-off-by: Harish Sadineni <Harish.Sadineni@windriver.com>
+
+diff --git a/tests/python/test_tools_memleak.py b/tests/python/test_tools_memleak.py
+--- a/tests/python/test_tools_memleak.py       
++++ b/tests/python/test_tools_memleak.py   
+@@ -26,7 +26,7 @@
+     # Build the memory leaking application.
+     c_src = 'test_tools_memleak_leaker_app.c'
+     tmp_dir = tempfile.mkdtemp(prefix='bcc-test-memleak-')
+-    c_src_full = os.path.dirname(sys.argv[0]) + os.path.sep + c_src
++    c_src_full = os.path.abspath(os.path.dirname(sys.argv[0])) + os.path.sep + c_src
+     exec_dst = tmp_dir + os.path.sep + 'leaker_app'
+
+     if subprocess.call(['gcc', '-g', '-O0', '-o', exec_dst, c_src_full]) != 0:
+

--- a/dynamic-layers/meta-python/recipes-devtools/bcc/bcc/run-ptest
+++ b/dynamic-layers/meta-python/recipes-devtools/bcc/bcc/run-ptest
@@ -17,6 +17,29 @@ print_test_result() {
     fi
 }
 
+ARCH=$(uname -m)
+
+case "$ARCH" in
+  x86_64)
+    KDIR="x86"
+    ;;
+  riscv64)
+    KDIR="riscv"
+    ;;
+  aarch64)
+    KDIR="arm64"
+    ;;
+  powerpc64le | ppc64le)
+    KDIR="powerpc"
+    ;;
+  *)
+    echo "Architecture not present, Add the architecture in run-ptest: $ARCH"
+    exit 1
+    ;;
+esac
+
+export BCC_KERNEL_SOURCE="/usr/src/kernel/arch/$KDIR"
+
 # Run CC tests, set IFS as test names have spaces
 IFS=$(printf '\n\t')
 for test_name in $(./cc/test_libbcc_no_libbpf --list-test-names-only); do

--- a/dynamic-layers/meta-python/recipes-devtools/bcc/bcc/support_finish_task_switch_isra_0.patch
+++ b/dynamic-layers/meta-python/recipes-devtools/bcc/bcc/support_finish_task_switch_isra_0.patch
@@ -1,0 +1,49 @@
+Upstream-Status: Backport [https://github.com/iovisor/bcc/pull/5302/commits/b24519e1ba7b87c9676ae3a7f70772215cd5819d]
+Signed-off-by: Harish Sadineni <Harish.Sadineni@windriver.com>
+
+diff --git a/tests/python/test_histogram.py b/tests/python/test_histogram.py
+--- a/tests/python/test_histogram.py
++++ b/tests/python/test_histogram.py
+@@ -64,7 +64,7 @@
+ #include <linux/version.h>
+ typedef struct { char name[TASK_COMM_LEN]; u64 slot; } Key;
+ BPF_HISTOGRAM(hist1, Key, 1024);
+-int kprobe__finish_task_switch(struct pt_regs *ctx, struct task_struct *prev) {
++int count_prev_task_start_time(struct pt_regs *ctx, struct task_struct *prev) {
+ #if LINUX_VERSION_CODE < KERNEL_VERSION(5,5,0)
+     Key k = {.slot = bpf_log2l(prev->real_start_time)};
+ #else
+@@ -77,6 +77,10 @@
+     return 0;
+ }
+ """)
++        b.attach_kprobe(
++            event_re=r'^finish_task_switch$|^finish_task_switch\.isra\.\d$',
++            fn_name=b"count_prev_task_start_time"
++        )
+         for i in range(0, 100): time.sleep(0.01)
+         b[b"hist1"].print_log2_hist()
+         b.cleanup()
+diff --git a/tests/python/test_clang.py b/tests/python/test_clang.py
+--- a/tests/python/test_clang.py
++++ b/tests/python/test_clang.py
+@@ -399,7 +399,7 @@
+   u32 curr_pid;
+ };
+ BPF_HASH(stats, struct key_t, u64, 1024);
+-int kprobe__finish_task_switch(struct pt_regs *ctx, struct task_struct *prev) {
++int count_sched(struct pt_regs *ctx, struct task_struct *prev) {
+   struct key_t key = {};
+   u64 zero = 0, *val;
+   key.curr_pid = bpf_get_current_pid_tgid();
+@@ -412,6 +412,10 @@
+   return 0;
+ }
+ """)
++        b.attach_kprobe(
++            event_re=r'^finish_task_switch$|^finish_task_switch\.isra\.\d$',
++            fn_name=b"count_sched"
++        )
+ 
+     def test_probe_simple_assign(self):
+         b = BPF(text=b"""

--- a/dynamic-layers/meta-python/recipes-devtools/bcc/bcc_0.33.0.bb
+++ b/dynamic-layers/meta-python/recipes-devtools/bcc/bcc_0.33.0.bb
@@ -24,6 +24,7 @@ SRC_URI = "gitsm://github.com/iovisor/bcc;branch=master;protocol=https \
            file://0001-CMakeLists.txt-don-t-modify-.gitconfig-on-build-host.patch \
            file://run-ptest \
            file://ptest_wrapper.sh \
+           file://bpf_stack_id.patch \
            "
 
 SRCREV = "92e32ff8a06616779f3a3191b75da6881d59fd17"

--- a/dynamic-layers/meta-python/recipes-devtools/bcc/bcc_0.33.0.bb
+++ b/dynamic-layers/meta-python/recipes-devtools/bcc/bcc_0.33.0.bb
@@ -16,7 +16,7 @@ DEPENDS += "bison-native \
             "
 
 RDEPENDS:${PN} += "bash python3 python3-core python3-setuptools xz"
-RDEPENDS:${PN}-ptest = "kernel-devsrc packagegroup-core-buildessential cmake python3 python3-netaddr python3-pyroute2"
+RDEPENDS:${PN}-ptest = "kernel-devsrc packagegroup-core-buildessential cmake bash python3 python3-netaddr python3-pyroute2"
 
 SRC_URI = "gitsm://github.com/iovisor/bcc;branch=master;protocol=https \
            file://0001-CMakeLists.txt-override-the-PY_CMD_ESCAPED.patch \
@@ -26,6 +26,7 @@ SRC_URI = "gitsm://github.com/iovisor/bcc;branch=master;protocol=https \
            file://ptest_wrapper.sh \
            file://bpf_stack_id.patch \
            file://support_finish_task_switch_isra_0.patch \
+           file://fix_for_memleak.patch \
            "
 
 SRCREV = "92e32ff8a06616779f3a3191b75da6881d59fd17"
@@ -73,10 +74,16 @@ do_install_ptest() {
     cp -rf ${S}/tests/python ${D}${PTEST_PATH}/tests/python
     install ${UNPACKDIR}/ptest_wrapper.sh ${D}${PTEST_PATH}/tests
     install ${S}/examples/networking/simulation.py ${D}${PTEST_PATH}/tests/python
+    find ${S}/tools/ -type f -name "*.py" -exec \
+    sed -i \
+    -e 's@^#! */usr/bin/env python$@#!/usr/bin/env python3@' \
+    -e 's@^#! */usr/bin/python.*@#!/usr/bin/env python3@' {} +
+    cp -rf ${S}/tools/ ${D}${PTEST_PATH}/../../tools/
 }
 
 FILES:${PN} += "${PYTHON_SITEPACKAGES_DIR}"
 FILES:${PN} += "${B}/tests/cc"
+FILES:${PN}-ptest += "${libdir}/tools/"
 FILES:${PN}-ptest += "/opt/"
 FILES:${PN}-doc += "${datadir}/${PN}/man"
 

--- a/dynamic-layers/meta-python/recipes-devtools/bcc/bcc_0.33.0.bb
+++ b/dynamic-layers/meta-python/recipes-devtools/bcc/bcc_0.33.0.bb
@@ -25,6 +25,7 @@ SRC_URI = "gitsm://github.com/iovisor/bcc;branch=master;protocol=https \
            file://run-ptest \
            file://ptest_wrapper.sh \
            file://bpf_stack_id.patch \
+           file://support_finish_task_switch_isra_0.patch \
            "
 
 SRCREV = "92e32ff8a06616779f3a3191b75da6881d59fd17"

--- a/dynamic-layers/meta-python/recipes-devtools/bcc/bcc_0.33.0.bb
+++ b/dynamic-layers/meta-python/recipes-devtools/bcc/bcc_0.33.0.bb
@@ -67,6 +67,7 @@ do_install_ptest() {
     # Hence, these files are copied to the image to fix these tests.
     install -d ${D}${B}/tests/cc
     install ${B}/tests/cc/archive.zip ${B}/tests/cc/libdebuginfo_test_lib.so ${B}/tests/cc/with_gnu_debuglink.so ${B}/tests/cc/with_gnu_debugdata.so ${B}/tests/cc/debuginfo.so ${D}${B}/tests/cc
+    install -d ${D}/opt
     install ${B}/tests/cc/test_libbcc_no_libbpf ${B}/tests/cc/libusdt_test_lib.so ${D}${PTEST_PATH}/tests/cc
     cp -rf ${S}/tests/python ${D}${PTEST_PATH}/tests/python
     install ${UNPACKDIR}/ptest_wrapper.sh ${D}${PTEST_PATH}/tests
@@ -75,6 +76,7 @@ do_install_ptest() {
 
 FILES:${PN} += "${PYTHON_SITEPACKAGES_DIR}"
 FILES:${PN} += "${B}/tests/cc"
+FILES:${PN}-ptest += "/opt/"
 FILES:${PN}-doc += "${datadir}/${PN}/man"
 
 COMPATIBLE_HOST = "(x86_64.*|aarch64.*|powerpc64.*|riscv64.*)-linux"

--- a/dynamic-layers/meta-python/recipes-devtools/bcc/bcc_0.33.0.bb
+++ b/dynamic-layers/meta-python/recipes-devtools/bcc/bcc_0.33.0.bb
@@ -83,6 +83,7 @@ do_install_ptest() {
 
 FILES:${PN} += "${PYTHON_SITEPACKAGES_DIR}"
 FILES:${PN} += "${B}/tests/cc"
+FILES:${PN}-ptest += "${libdir}/libbcc.so"
 FILES:${PN}-ptest += "${libdir}/tools/"
 FILES:${PN}-ptest += "/opt/"
 FILES:${PN}-doc += "${datadir}/${PN}/man"


### PR DESCRIPTION
Backporting bcc-patches from master to walnascar to fix most of the bcc-ptest failures.
---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
