### PR TITLE
Revert "recipes: Update to match OE-Core virtual/cross-* changes"

### DIFF
--- a/classes/clang.bbclass
+++ b/classes/clang.bbclass
@@ -133,7 +133,7 @@ def clang_base_deps(d):
             elif (d.getVar('LIBCPLUSPLUS').find('-stdlib=libc++') != -1):
                 ret += " libcxx "
             else:
-                ret += " virtual/${MLPREFIX}compilerlibs "
+                ret += " virtual/${TARGET_PREFIX}compilerlibs "
             return ret
     return ""
 

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -26,7 +26,7 @@ BBFILES_DYNAMIC += " \
 "
 
 PREFERRED_PROVIDER_libgcc-initial = "libgcc-initial"
-#PREFERRED_PROVIDER_virtual/${MLPREFIX}compilerlibs:forcevariable = "libcxx"
+#PREFERRED_PROVIDER_virtual/${TARGET_PREFIX}compilerlibs_forcevariable = "libcxx"
 PREFERRED_PROVIDER_libunwind = "${@bb.utils.contains_any("TC_CXX_RUNTIME", "llvm android", "libcxx", "libunwind", d)}"
 INHERIT += "clang"
 

--- a/recipes-core/musl/musl_%.bbappend
+++ b/recipes-core/musl/musl_%.bbappend
@@ -1,5 +1,5 @@
 DEPENDS:append:toolchain-clang = " clang-cross-${TARGET_ARCH}"
-DEPENDS:remove:toolchain-clang = "virtual/cross-cc"
+DEPENDS:remove:toolchain-clang = "virtual/${TARGET_PREFIX}gcc"
 TOOLCHAIN:x86-x32 = "gcc"
 
 # crashes seen in malloc@plt

--- a/recipes-devtools/clang/clang-cross-canadian_git.bb
+++ b/recipes-devtools/clang/clang-cross-canadian_git.bb
@@ -12,7 +12,7 @@ require clang.inc
 require common-source.inc
 inherit cross-canadian
 
-DEPENDS += "nativesdk-clang binutils-cross-canadian-${TRANSLATED_TARGET_ARCH} virtual/nativesdk-cross-binutils virtual/nativesdk-libc"
+DEPENDS += "nativesdk-clang binutils-cross-canadian-${TRANSLATED_TARGET_ARCH} virtual/${HOST_PREFIX}binutils virtual/nativesdk-libc"
 # We have to point gcc at a sysroot but we don't need to rebuild if this changes
 # e.g. we switch between different machines with different tunes.
 EXTRA_OECONF_PATHS[vardepsexclude] = "TUNE_PKGARCH"

--- a/recipes-devtools/clang/clang-cross_git.bb
+++ b/recipes-devtools/clang/clang-cross_git.bb
@@ -11,7 +11,7 @@ PN = "clang-cross-${TARGET_ARCH}"
 require clang.inc
 require common-source.inc
 inherit cross
-DEPENDS += "clang-native virtual/cross-binutils"
+DEPENDS += "clang-native virtual/${TARGET_PREFIX}binutils"
 
 #INHIBIT_PACKAGE_STRIP = "1"
 INHIBIT_SYSROOT_STRIP = "1"

--- a/recipes-devtools/clang/clang-crosssdk_git.bb
+++ b/recipes-devtools/clang/clang-crosssdk_git.bb
@@ -11,7 +11,7 @@ PN = "clang-crosssdk-${SDK_SYS}"
 require clang.inc
 require common-source.inc
 inherit crosssdk
-DEPENDS += "clang-native nativesdk-clang-glue virtual/nativesdk-cross-binutils virtual/nativesdk-libc"
+DEPENDS += "clang-native nativesdk-clang-glue virtual/${TARGET_PREFIX}binutils virtual/nativesdk-libc"
 
 do_install() {
         install -d ${D}${bindir}

--- a/recipes-devtools/clang/clang_git.bb
+++ b/recipes-devtools/clang/clang_git.bb
@@ -208,7 +208,7 @@ EXTRA_OECMAKE:append:class-target = "\
 "
 
 DEPENDS = "binutils zlib zstd libffi libxml2 libxml2-native ninja-native swig-native"
-DEPENDS:append:class-nativesdk = " clang-crosssdk-${SDK_SYS} virtual/nativesdk-cross-binutils nativesdk-python3"
+DEPENDS:append:class-nativesdk = " clang-crosssdk-${SDK_SYS} virtual/${TARGET_PREFIX}binutils nativesdk-python3"
 DEPENDS:append:class-target = " clang-cross-${TARGET_ARCH} python3 compiler-rt libcxx"
 
 RRECOMMENDS:${PN} = "binutils"

--- a/recipes-devtools/clang/compiler-rt-sanitizers_git.bb
+++ b/recipes-devtools/clang/compiler-rt-sanitizers_git.bb
@@ -107,7 +107,7 @@ INSANE_SKIP:${PN} = "dev-so libdir"
 INSANE_SKIP:${PN}-dbg = "libdir"
 
 #PROVIDES:append:class-target = "\
-#        virtual/${MLPREFIX}compilerlibs \
+#        virtual/${TARGET_PREFIX}compilerlibs \
 #        libgcc \
 #        libgcc-initial \
 #        libgcc-dev \

--- a/recipes-devtools/clang/compiler-rt_git.bb
+++ b/recipes-devtools/clang/compiler-rt_git.bb
@@ -114,7 +114,7 @@ INSANE_SKIP:${PN} = "dev-so libdir"
 INSANE_SKIP:${PN}-dbg = "libdir"
 
 #PROVIDES:append:class-target = "\
-#        virtual/${MLPREFIX}compilerlibs \
+#        virtual/${TARGET_PREFIX}compilerlibs \
 #        libgcc \
 #        libgcc-initial \
 #        libgcc-dev \

--- a/recipes-devtools/clang/libcxx_git.bb
+++ b/recipes-devtools/clang/libcxx_git.bb
@@ -22,7 +22,7 @@ PACKAGECONFIG[compiler-rt] = "-DLIBCXX_USE_COMPILER_RT=ON -DLIBCXXABI_USE_COMPIL
 PACKAGECONFIG[unwind-shared] = "-DLIBUNWIND_ENABLE_SHARED=ON,-DLIBUNWIND_ENABLE_SHARED=OFF,,"
 
 DEPENDS += "ninja-native"
-DEPENDS:append:class-target = " clang-cross-${TARGET_ARCH} virtual/${MLPREFIX}libc virtual/${MLPREFIX}compilerlibs"
+DEPENDS:append:class-target = " clang-cross-${TARGET_ARCH} virtual/${MLPREFIX}libc virtual/${TARGET_PREFIX}compilerlibs"
 DEPENDS:append:class-nativesdk = " clang-crosssdk-${SDK_SYS} nativesdk-compiler-rt"
 DEPENDS:append:class-native = " clang-native compiler-rt-native"
 


### PR DESCRIPTION
This reverts commit 0ea2df0462edc0c01e787b6ee6c0e20cd6a42fc7.
Required backport to match the OE-Core machanism in scarthgap
