### PR TITLE
perf: Use gcc as default compiler

### DIFF
--- a/conf/nonclangable.conf
+++ b/conf/nonclangable.conf
@@ -640,3 +640,4 @@ LDFLAGS:append:pn-lastlog2:toolchain-clang = "${@bb.utils.contains('DISTRO_FEATU
 LDFLAGS:remove:pn-lastlog2:toolchain-clang = "${@bb.utils.contains('DISTRO_FEATURES', 'ld-is-lld', '-fuse-ld=lld', '', d)}"
 
 LD:pn-gnu-efi:toolchain-clang = "${@bb.utils.contains('DISTRO_FEATURES', 'ld-is-lld', '${HOST_PREFIX}ld.bfd${TOOLCHAIN_OPTIONS} ${HOST_LD_ARCH}', '${HOST_PREFIX}ld${TOOLCHAIN_OPTIONS} ${HOST_LD_ARCH}', d)}"
+TOOLCHAIN:pn-perf = "gcc"


### PR DESCRIPTION
Since its being build from kernel sources which are procecced with gcc by default KERNEL_CC is gcc, its a constant battle to keep this compiling with clang, so unless clang is also used to compile kernel this is a fruitless excercise to use clang just for perf.


(cherry picked from commit 9fadcead4fd4336783ef270a4019e105a270daf4)

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
