### PR TITLE
bpftool: Use gcc instead of clang compiler

### DIFF
--- a/conf/nonclangable.conf
+++ b/conf/nonclangable.conf
@@ -201,6 +201,9 @@ TOOLCHAIN:pn-gcc-for-nvcc-runtime:tegra = "gcc"
 #|       | ^
 TOOLCHAIN:pn-optee-os:imx-nxp-bsp = "gcc"
 
+# Does not compile with clang 18
+TOOLCHAIN:pn-bpftool = "gcc"
+
 CFLAGS:append:pn-liboil:toolchain-clang:x86-64 = " -fheinous-gnu-extensions "
 
 # TOPDIR/build/tmp/work/core2-32-yoe-linux/gnu-efi/3.0.17-r0/gnu-efi-3.0.17//lib/ctors.S:11:41: error: expected the entry size


### PR DESCRIPTION
While compiling bpftool with clang, it fails with below error: | error: no member named 'id' in 'struct bpf_link'
|           return BPF_CORE_READ((struct bpf_link *)ent, id);

bpftool is kernel tool to inspect and manipulate eBPF programs and maps. And kernel is built using GCC by default. Maintaining compatibility with Clang is an ongoing challenge, and using Clang solely for building bpftool is ineffective unless the entire kernel is compiled with Clang.

Hence, updated TOOLCHAIN of bpftool to gcc.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
