### PR TITLE
android-tools: Remove use of nobranch

### DIFF
--- a/dynamic-layers/selinux/android-tools/android-tools_10.0.0.r36.bb
+++ b/dynamic-layers/selinux/android-tools/android-tools_10.0.0.r36.bb
@@ -20,12 +20,12 @@ SRCREV_build = "28768b3120f751583a2743101b892f210d4715cf"
 SRCREV_libunwind = "03a963ecf6ea836b38b3537cbcda0ecfd7a77393"
 
 SRC_URI = " \
-    git://salsa.debian.org/android-tools-team/android-platform-external-boringssl;name=boringssl;protocol=https;nobranch=1;destsuffix=git/external/boringssl \
-    git://salsa.debian.org/android-tools-team/android-platform-system-core;name=core;protocol=https;nobranch=1;destsuffix=git/system/core \
-    git://salsa.debian.org/android-tools-team/android-platform-system-extras;name=extras;protocol=https;nobranch=1;destsuffix=git/system/extras \
-    git://${ANDROID_MIRROR}/platform/hardware/libhardware;name=libhardware;protocol=https;nobranch=1;destsuffix=git/hardware/libhardware \
-    git://salsa.debian.org/android-tools-team/android-platform-build.git;name=build;protocol=https;nobranch=1;destsuffix=git/build \
-    git://salsa.debian.org/android-tools-team/android-platform-external-libunwind.git;protocol=https;name=libunwind;nobranch=1;destsuffix=git/external/libunwind \
+    git://salsa.debian.org/android-tools-team/android-platform-external-boringssl;name=boringssl;protocol=https;destsuffix=git/external/boringssl \
+    git://salsa.debian.org/android-tools-team/android-platform-system-core;name=core;protocol=https;destsuffix=git/system/core \
+    git://salsa.debian.org/android-tools-team/android-platform-system-extras;name=extras;protocol=https;destsuffix=git/system/extras \
+    git://${ANDROID_MIRROR}/platform/hardware/libhardware;name=libhardware;protocol=https;branch=android10-qpr2-release;destsuffix=git/hardware/libhardware \
+    git://salsa.debian.org/android-tools-team/android-platform-build.git;name=build;protocol=https;destsuffix=git/build \
+    git://salsa.debian.org/android-tools-team/android-platform-external-libunwind.git;protocol=https;name=libunwind;destsuffix=git/external/libunwind \
 "
 
 # Patches copied from android-platform-system-core/debian/patches


### PR DESCRIPTION
remove use of nobranch=1 so that source
can be pick up from master branch

For libhardware SRCREV not present in
master branch so mentioned the branch
android10-qpr2-release

Signed-off-by: Nitin Wankhade <nitin.wankhade333@gmail.com>
---
