### PR TITLE
opensbi: Do not enforce objcopy from binutils for clang

### DIFF
--- a/conf/nonclangable.conf
+++ b/conf/nonclangable.conf
@@ -378,7 +378,6 @@ OBJCOPY:pn-linux-linaro-qcomlt:toolchain-clang = "${HOST_PREFIX}objcopy"
 OBJCOPY:pn-linux-intel:toolchain-clang = "${HOST_PREFIX}objcopy"
 
 # see https://github.com/llvm/llvm-project/issues/53948
-OBJCOPY:pn-opensbi:toolchain-clang = "${HOST_PREFIX}objcopy"
 OBJCOPY:pn-libc-bench:toolchain-clang = "${HOST_PREFIX}objcopy"
 STRIP:pn-libc-bench:toolchain-clang = "${HOST_PREFIX}strip"
 OBJCOPY:pn-aufs-util:toolchain-clang = "${HOST_PREFIX}objcopy"


### PR DESCRIPTION
This has adverse effect now with clang-21 on riscv64 qemu where opensbi ends up not being found during boot and qemu getting stuck in early boot.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
