### PR TITLE
llvm,clang: update to 18.1.8

### DIFF
--- a/recipes-devtools/clang/clang.inc
+++ b/recipes-devtools/clang/clang.inc
@@ -5,7 +5,7 @@ LLVM_HTTP ?= "https://github.com/llvm"
 
 MAJOR_VER = "18"
 MINOR_VER = "1"
-PATCH_VER = "6"
+PATCH_VER = "8"
 # could be 'rcX' or 'git' or empty ( for release )
 VER_SUFFIX = ""
 

--- a/recipes-devtools/clang/common.inc
+++ b/recipes-devtools/clang/common.inc
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://llvm/LICENSE.TXT;md5=${LLVMMD5SUM} \
 LICENSE = "Apache-2.0-with-LLVM-exception"
 
 BASEURI = "${LLVM_HTTP}/llvm-project/releases/download/llvmorg-${PV}/llvm-project-${PV}.src.tar.xz"
-SRC_URI[sha256sum] = "bd4b4cb6374bcd5fc5a3ba60cb80425d29da34f316b8821abc12c0db225cf6b4"
+SRC_URI[sha256sum] = "0b58557a6d32ceee97c8d533a59b9212d87e0fc4d2833924eb6c611247db2f2a"
 
 SRC_URI = "\
     ${BASEURI} \


### PR DESCRIPTION
This is probably the last 18.1.x release, so let's get it in.

3b5b5c1ec4a3 (tag: llvmorg-18.1.8, origin/release/18.x) [libcxx] Align `__recommend() + 1`  by __endian_factor (#90292) 72c9425a79fd [libc++][NFC] Rewrite function call on two lines for clarity (#79141) 443e23eed24d Bump version to 18.1.8 (#95458)
768118d1ad38 (tag: llvmorg-18.1.7) [clang-format] Fix a bug in formatting goto labels in macros (#92494) 8c0fe0d65ed8 release/18.x: [clang-format] Don't always break before << between str… (#94091) 7e6ece9b4f2d [PPCMergeStringPool] Only replace constant once (#92996) 1ce2d26cd2e9 Bump version to 18.1.7 (#93723)

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
- [x] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
