### PR TITLE
swupdate: Pin to use gcc

### DIFF
--- a/conf/nonclangable.conf
+++ b/conf/nonclangable.conf
@@ -584,7 +584,7 @@ LDFLAGS:append:pn-libfaketime:toolchain-clang = "${@bb.utils.contains('DISTRO_FE
 LDFLAGS:remove:pn-libfaketime:toolchain-clang = "${@bb.utils.contains('DISTRO_FEATURES', 'ld-is-lld', '-fuse-ld=lld', '', d)}"
 # arm-yoe-linux-gnueabi-ld.lld: error: version script assignment of 'global' to symbol 'readdir' failed: symbol not defined
 #| arm-yoe-linux-gnueabi-ld.lld: error: version script assignment of 'global' to symbol 'readdir_r' failed: symbol not defined
-#| arm-yoe-linux-gnueabi-clang: error: linker command failed with exit code 1 (use -v to see invocation) 
+#| arm-yoe-linux-gnueabi-clang: error: linker command failed with exit code 1 (use -v to see invocation)
 LDFLAGS:append:pn-aufs-util:toolchain-clang = "${@bb.utils.contains('DISTRO_FEATURES', 'ld-is-lld', ' -fuse-ld=bfd', '', d)}"
 LDFLAGS:remove:pn-aufs-util:toolchain-clang = "${@bb.utils.contains('DISTRO_FEATURES', 'ld-is-lld', '-fuse-ld=lld', '', d)}"
 # | arm-yoe-linux-gnueabi-ld.lld: error: version script assignment of 'global' to symbol 'pam_sm_chauthtok' failed: symbol not defined
@@ -597,6 +597,10 @@ LDFLAGS:append:pn-bluez5:toolchain-clang = "${@bb.utils.contains('DISTRO_FEATURE
 LD:pn-gnu-efi:toolchain-clang = "${@bb.utils.contains('DISTRO_FEATURES', 'ld-is-lld', '${HOST_PREFIX}ld.bfd${TOOLCHAIN_OPTIONS} ${HOST_LD_ARCH}', '${HOST_PREFIX}ld${TOOLCHAIN_OPTIONS} ${HOST_LD_ARCH}', d)}"
 LD:pn-libhugetlbfs:toolchain-clang = "${HOST_PREFIX}ld.bfd${TOOLCHAIN_OPTIONS} ${HOST_LD_ARCH}"
 LD:pn-libunix-statgrab:toolchain-clang = "${CC}"
+
+# swupdate-2025.12/core/swupdate.c:1018: more undefined references to `no symbol' follow
+#| aarch64-yoe-linux-clang: error: linker command failed with exit code 1 (use -v to see invocation)
+TOOLCHAIN:pn-swupdate = "gcc"
 
 TOOLCHAIN:pn-perf = "gcc"
 


### PR DESCRIPTION
2025.12 does not compile with clang sadly

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
