### PR TITLE
compiler-rt-sanitizers: fix directory name on do_install when removing liborc_rt

### DIFF
--- a/recipes-devtools/clang/compiler-rt-sanitizers_git.bb
+++ b/recipes-devtools/clang/compiler-rt-sanitizers_git.bb
@@ -89,7 +89,7 @@ do_install:append () {
         mv ${D}${libdir}/linux ${D}${libdir}/clang/${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}/lib
     fi
     # Already shipped with compile-rt Orc support
-    rm -rf ${D}${nonarch_libdir}/clang/${MAJOR_VER}/lib/linux/liborc_rt-*.a
+    rm -rf ${D}${nonarch_libdir}/clang/${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}/lib/linux/liborc_rt-*.a
     rm -rf ${D}${nonarch_libdir}/clang/${MAJOR_VER}/include/orc/
 }
 


### PR DESCRIPTION
on `do_install()` the directory containing the .a files is renamed from `${MAJOR_VER}` to `${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}` but the rm command below fails to account for that rename and tries to delete the file on a non-existing directory after the rename.

This causes later a conflict when creating the rootfs or populating the SDK:
```
     - do_populate_sdk failed with exit code '1'
       Error: Transaction test error:
         file /usr/lib/clang/20.1.1/lib/linux/liborc_rt-aarch64.a from install of
         compiler-rt-sanitizers-staticdev-20.1.1-r0.cortexa72 conflicts with file
         from package compiler-rt-staticdev-20.1.1-r0.cortexa72
```
---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [X] Changes have been tested
- [X] `Signed-off-by` is present
- [X] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
