### PR TITLE
clang: Add status of CVE-2024-7883

### DIFF
--- a/recipes-devtools/clang/clang_git.bb
+++ b/recipes-devtools/clang/clang_git.bb
@@ -466,3 +466,5 @@ clang_sysroot_preprocess() {
 		install -m 755 ${D}${bindir}/$f ${SYSROOT_DESTDIR}${bindir}/
 	done
 }
+
+CVE_STATUS[CVE-2024-7883] = "fixed-version: Fixed via CVE-2024-7883.patch included here. Patch applied via llvm-project-source do_patch (CVE-2024-7883.patch)"


### PR DESCRIPTION
The patch (CVE-2024-7883.patch) is correctly applied via llvm-project-source's do_patch task. However, because common-source.inc sets SRC_URI = "" in the clang recipe (shared-source architecture), cve_check finds no patches in the clang recipe and reports the CVE as Unpatched.

Add an explicit CVE_STATUS declaration to mark the CVE as fixed and document that the patch is applied via llvm-project-source, without altering the shared-source build flow.

CVE: CVE-2024-7883

Signed-off-by: Divyanshu Rathore <Divyanshu.DR.Rathore@bti.bmwgroup.com>