### PR TITLE
conf/layer.conf: remove unused BBFILES_DYNAMIC entries

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -11,16 +11,8 @@ LAYERSERIES_COMPAT_clang-layer = "wrynose"
 LAYERDEPENDS_clang-layer = "core"
 
 BBFILES_DYNAMIC += " \
-    browser-layer:${LAYERDIR}/dynamic-layers/browser-layer/*/*.bb \
-    browser-layer:${LAYERDIR}/dynamic-layers/browser-layer/*/*.bbappend \
     openembedded-layer:${LAYERDIR}/dynamic-layers/openembedded-layer/*/*/*.bb \
     openembedded-layer:${LAYERDIR}/dynamic-layers/openembedded-layer/*/*/*.bbappend \
-    networking-layer:${LAYERDIR}/dynamic-layers/networking-layer/*/*/*.bb \
-    networking-layer:${LAYERDIR}/dynamic-layers/networking-layer/*/*/*.bbappend \
-    meta-python:${LAYERDIR}/dynamic-layers/meta-python/*/*/*.bb \
-    meta-python:${LAYERDIR}/dynamic-layers/meta-python/*/*/*.bbappend \
-    qt5-layer:${LAYERDIR}/dynamic-layers/qt5-layer/*/*/*.bb \
-    qt5-layer:${LAYERDIR}/dynamic-layers/qt5-layer/*/*/*.bbappend \
     qt6-layer:${LAYERDIR}/dynamic-layers/qt6-layer/*/*/*.bb \
     qt6-layer:${LAYERDIR}/dynamic-layers/qt6-layer/*/*/*.bbappend \
 "


### PR DESCRIPTION
Remove stale dynamic layer references (browser-layer, networking-layer, meta-python, qt5-layer) from BBFILES_DYNAMIC in layer.conf.

These directories no longer exist under dynamic-layers/, so the patterns are dead code and have no effect.

(cherry picked from commit 0baedd06e78d26d3b927471cfd91960b7229a178)
